### PR TITLE
fix ZookeeperClientSideMetadataProvider.java:[22,29] package com.sun.webkit.plugin does not exist

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ZookeeperClientSideMetadataProvider.java
+++ b/herddb-core/src/main/java/herddb/client/ZookeeperClientSideMetadataProvider.java
@@ -19,7 +19,6 @@
  */
 package herddb.client;
 
-import com.sun.webkit.plugin.Plugin;
 import herddb.model.NodeMetadata;
 import herddb.model.TableSpace;
 import herddb.network.ServerHostData;


### PR DESCRIPTION
Removed an unused package import which prevented maven to compile on a clean environment