### PR TITLE
ALTER TABLE do not autostart transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,13 +10,15 @@
 **/.settings/
 **/bin/
 
-# Gui Dev
-**/src/main/webapp/collectors/
-**/src/main/webapp/console.history.*.txt
-**/src/main/webapp/events/
-**/src/main/webapp/feedbackwal/
-**/src/main/webapp/indexes/
-**/src/main/webapp/notification.groups.xml
-**/src/main/webapp/resultsets/
-**/src/main/webapp/ssh.ser
-**/src/main/webapp/store/
+# NetBeans
+/herddb-core/nbproject/ 
+
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,22 @@
-target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
-/herddb-core/nbproject/
+# Maven
+**/target/
+
+# Surefire
+**/.surefire-*
+
+# Eclipse
+**/.classpath
+**/.project
+**/.settings/
+**/bin/
+
+# Gui Dev
+**/src/main/webapp/collectors/
+**/src/main/webapp/console.history.*.txt
+**/src/main/webapp/events/
+**/src/main/webapp/feedbackwal/
+**/src/main/webapp/indexes/
+**/src/main/webapp/notification.groups.xml
+**/src/main/webapp/resultsets/
+**/src/main/webapp/ssh.ser
+**/src/main/webapp/store/

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -824,7 +824,9 @@ public class TableSpaceManager {
             throw new StatementExecutionException("executeStatement not available on virtual tablespaces");
         }
         boolean rollbackOnError = false;
-        if (transactionContext.transactionId == TransactionContext.AUTOTRANSACTION_ID) {
+        
+        /* Do not autostart transaction on alter table statements */
+        if (transactionContext.transactionId == TransactionContext.AUTOTRANSACTION_ID && !(statement instanceof AlterTableStatement)) {
             StatementExecutionResult newTransaction = beginTransaction();
             transactionContext = new TransactionContext(newTransaction.transactionId);
             rollbackOnError = true;

--- a/herddb-core/src/main/java/herddb/sql/SQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLPlanner.java
@@ -1291,7 +1291,7 @@ public class SQLPlanner {
         }
         List<Column> addColumns = new ArrayList<>();
         List<String> dropColumns = new ArrayList<>();
-        String tableName = alter.getTable().getName();
+        String tableName = alter.getTable().getName().toLowerCase();
         if (alter.getAlterExpressions() == null || alter.getAlterExpressions().size() != 1) {
             throw new StatementExecutionException("supported multi-alter operation '" + alter + "'");
         }

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
@@ -125,14 +125,11 @@ public class HerdDBConnection implements java.sql.Connection {
     @Override
     public void commit() throws SQLException {
         if (autocommit) {
-            throw new SQLException("connection is not in autocommit mode");
+            throw new SQLException("connection is in autocommit mode");
         }
-        if (transactionId == 0) {
+        if (transactionId == 0 || transactionId == -1) {
             // no transaction actually started, nothing to commit
             return;
-        }
-        if (transactionId < 0) {
-            throw new SQLException("current transactionId cannot be negative");
         }
         try {
             connection.commitTransaction(tableSpace, transactionId);


### PR DESCRIPTION
Isuing ALTER TABLE wasn't possible through JDBC cause it required the absence of a transaction but a transaction was autocreated.