### PR TITLE
Fix BLink lock excalation from read to write - condition not rechecked after upgrading lock

### DIFF
--- a/herddb-utils/nb-configuration.xml
+++ b/herddb-utils/nb-configuration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <netbeans.compile.on.save>none</netbeans.compile.on.save>
+    </properties>
+</project-shared-configuration>

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -1137,8 +1137,10 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
         } else {
             unlock_anchor(READ_LOCK);
             lock_anchor(WRITE_LOCK);
-            anchor.fastheight = h;
-            anchor.fast = n;
+            if (anchor.fastheight != h) {                
+                anchor.fastheight = h;
+                anchor.fast = n;
+            }
             unlock_anchor(WRITE_LOCK);
         }
     }


### PR DESCRIPTION
This PR add a fix for BLink lock excalation.
There are additional tests and a NetBeans configuration file