### PR TITLE
Improve selection of planner and support EXPLAIN from CLI

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -156,6 +156,7 @@ import herddb.sql.expressions.JdbcParameterExpression;
 import herddb.sql.expressions.SQLExpressionCompiler;
 import herddb.sql.expressions.TypedJdbcParameterExpression;
 import herddb.utils.SystemProperties;
+import java.util.regex.Pattern;
 import net.sf.jsqlparser.statement.Statement;
 
 /**
@@ -169,6 +170,8 @@ public class CalcitePlanner implements AbstractSQLPlanner {
      * Time to wait for the requested tablespace to be up
      */
     private static final long WAIT_FOR_SCHEMA_UP_TIMEOUT = SystemProperties.getLongSystemProperty("herddb.planner.waitfortablespacetimeout", 60000);
+    
+    private static final Pattern USE_DDL_PARSER = Pattern.compile("^[\\s]*(EXECUTE|CREATE|DROP|ALTER|TRUNCATE|BEGIN|COMMIT|ROLLBACK).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private final DBManager manager;
     private final AbstractSQLPlanner fallback;
@@ -209,13 +212,18 @@ public class CalcitePlanner implements AbstractSQLPlanner {
     public ExecutionPlan plan(String defaultTableSpace, Statement stmt, boolean scan, boolean returnValues, int maxRows) {
         return fallback.plan(defaultTableSpace, stmt, scan, returnValues, maxRows);
     }
-
+    
+    static final boolean isDDL(String query) {
+        return USE_DDL_PARSER.matcher(query).matches();
+    }
+        
     @Override
-    public TranslatedQuery translate(String defaultTableSpace, String query, List<Object> parameters, boolean scan, boolean allowCache, boolean returnValues, int maxRows) throws StatementExecutionException {
-        query = SQLPlanner.rewriteExecuteSyntax(query);
-        if (query.matches("(?i)(EXECUTE|CREATE|DROP|ALTER|TRUNCATE).*")) {        
+    public TranslatedQuery translate(String defaultTableSpace, String query, List<Object> parameters, boolean scan, boolean allowCache, boolean returnValues, int maxRows) throws StatementExecutionException {        
+        if (isDDL(query)) {        
+            query = SQLPlanner.rewriteExecuteSyntax(query);
             return fallback.translate(defaultTableSpace, query, parameters, scan, allowCache, returnValues, maxRows);
         }
+        System.out.println("NOT DDL:'"+query+"'");
         if (parameters == null) {
             parameters = Collections.emptyList();
         }

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -223,7 +223,6 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             query = SQLPlanner.rewriteExecuteSyntax(query);
             return fallback.translate(defaultTableSpace, query, parameters, scan, allowCache, returnValues, maxRows);
         }
-        System.out.println("NOT DDL:'"+query+"'");
         if (parameters == null) {
             parameters = Collections.emptyList();
         }

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -97,7 +97,7 @@ public class CalcitePlannerTest {
             assertInstanceOf(plan(manager, "update tblspace1.tsql set n1=? where k1=?"), SimpleUpdateOp.class);
             assertInstanceOf(plan(manager, "update tblspace1.tsql set n1=? where k1=? and n1=?"), SimpleUpdateOp.class);
             assertInstanceOf(plan(manager, "update tblspace1.tsql set n1=?"
-                + " where n1 in (select b.n1*2 from tblspace1.tsql b)"), UpdateOp.class);
+                    + " where n1 in (select b.n1*2 from tblspace1.tsql b)"), UpdateOp.class);
             assertInstanceOf(plan(manager, "delete from tblspace1.tsql where k1=?"), SimpleDeleteOp.class);
             assertInstanceOf(plan(manager, "delete from tblspace1.tsql where k1=? and n1=?"), SimpleDeleteOp.class);
             assertInstanceOf(plan(manager, "delete from tblspace1.tsql where n1 in (select b.n1*2 from tblspace1.tsql b)"), DeleteOp.class);
@@ -203,7 +203,7 @@ public class CalcitePlannerTest {
             assertInstanceOf(plan(manager, "-- comment\nupdate tblspace1.tsql set n1=? where k1=?"), SimpleUpdateOp.class);
             assertInstanceOf(plan(manager, "/* multiline\ncomment */\nupdate tblspace1.tsql set n1=? where k1=? and n1=?"), SimpleUpdateOp.class);
             assertInstanceOf(plan(manager, "update tblspace1.tsql set n1=?"
-                + " where n1 in (select b.n1*2 from tblspace1.tsql b)"), UpdateOp.class);
+                    + " where n1 in (select b.n1*2 from tblspace1.tsql b)"), UpdateOp.class);
             assertInstanceOf(plan(manager, "-- comment\ndelete from tblspace1.tsql where k1=?"), SimpleDeleteOp.class);
             assertInstanceOf(plan(manager, "/* multiline\ncomment */\ndelete from tblspace1.tsql where k1=? and n1=?"), SimpleDeleteOp.class);
             assertInstanceOf(plan(manager, "\n\ndelete from tblspace1.tsql where n1 in (select b.n1*2 from tblspace1.tsql b)"), DeleteOp.class);
@@ -237,9 +237,9 @@ public class CalcitePlannerTest {
             execute(manager, "INSERT INTO tblspace1.tsql2 (k2,n2) values(?,?)", Arrays.asList("mykey2", 1234), TransactionContext.NO_TRANSACTION);
             {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2,n1 "
-                    + "  from tblspace1.tsql2 join tblspace1.tsql on k2<>k1 "
-                    + "  where n2 > 1 "
-                    + " ", Collections.emptyList()).consume();
+                        + "  from tblspace1.tsql2 join tblspace1.tsql on k2<>k1 "
+                        + "  where n2 > 1 "
+                        + " ", Collections.emptyList()).consume();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(3, t.getFieldNames().length);
@@ -250,18 +250,18 @@ public class CalcitePlannerTest {
                 assertEquals(1, tuples.size());
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey2", "n2", 1234, "n1", 1234
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey2", "n2", 1234, "n1", 1234
                 ))));
 
             }
             {
                 // theta join
                 List<DataAccessor> tuples = scan(manager, "select k2,n2,n1 "
-                    + "  from tblspace1.tsql2"
-                    + "  left join tblspace1.tsql on n2 < n1-1000"
-                    + "  "
-                    + " ", Collections.emptyList()).consume();
+                        + "  from tblspace1.tsql2"
+                        + "  left join tblspace1.tsql on n2 < n1-1000"
+                        + "  "
+                        + " ", Collections.emptyList()).consume();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(3, t.getFieldNames().length);
@@ -272,22 +272,22 @@ public class CalcitePlannerTest {
                 assertEquals(2, tuples.size());
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey2", "n2", 1234, "n1", null
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey2", "n2", 1234, "n1", null
                 ))));
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey", "n2", 1234, "n1", null
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey", "n2", 1234, "n1", null
                 ))));
 
             }
             {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2,round(n1/2) as halfn1"
-                    + "  from tblspace1.tsql2"
-                    + "  left join tblspace1.tsql on n2 < n1-?"
-                    + "  "
-                    + " ", Arrays.asList(-1000)).consume();
+                        + "  from tblspace1.tsql2"
+                        + "  left join tblspace1.tsql on n2 < n1-?"
+                        + "  "
+                        + " ", Arrays.asList(-1000)).consume();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(3, t.getFieldNames().length);
@@ -298,20 +298,20 @@ public class CalcitePlannerTest {
                 assertEquals(2, tuples.size());
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey2", "n2", 1234, "halfn1", 617.0
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey2", "n2", 1234, "halfn1", 617.0
                 ))));
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey", "n2", 1234, "halfn1", 617.0
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey", "n2", 1234, "halfn1", 617.0
                 ))));
 
             }
             {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
-                    + "                     where k2 not in (select k1 from tblspace1.tsql)"
-                    + " ", Collections.emptyList()).consume();
+                        + "                     where k2 not in (select k1 from tblspace1.tsql)"
+                        + " ", Collections.emptyList()).consume();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -321,16 +321,16 @@ public class CalcitePlannerTest {
                 assertEquals(1, tuples.size());
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey2", "n2", 1234
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey2", "n2", 1234
                 ))));
 
             }
             {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
-                    + "                     where n2 in (select n1 from tblspace1.tsql"
-                    + "                                    )"
-                    + " ", Collections.emptyList()).consume();
+                        + "                     where n2 in (select n1 from tblspace1.tsql"
+                        + "                                    )"
+                        + " ", Collections.emptyList()).consume();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -340,21 +340,21 @@ public class CalcitePlannerTest {
                 assertEquals(2, tuples.size());
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey2", "n2", 1234
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey2", "n2", 1234
                 ))));
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey", "n2", 1234
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey", "n2", 1234
                 ))));
 
             }
 
             {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
-                    + "                     where exists (select * from tblspace1.tsql"
-                    + "                                     where n1=n2)"
-                    + " ", Collections.emptyList()).consume();
+                        + "                     where exists (select * from tblspace1.tsql"
+                        + "                                     where n1=n2)"
+                        + " ", Collections.emptyList()).consume();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -364,12 +364,12 @@ public class CalcitePlannerTest {
                 assertEquals(2, tuples.size());
 
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey2", "n2", 1234
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey2", "n2", 1234
                 ))));
                 assertTrue(
-                    tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
-                    "k2", "mykey", "n2", 1234
+                        tuples.stream().anyMatch(t -> t.toMap().equals(MapUtils.map(
+                        "k2", "mykey", "n2", 1234
                 ))));
 
             }
@@ -387,10 +387,10 @@ public class CalcitePlannerTest {
             manager.waitForTablespace("tblspace1", 10000);
 
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,"
-                + "s1 string)", Collections.emptyList());
+                    + "s1 string)", Collections.emptyList());
 
             execute(manager, "INSERT INTO tblspace1.tsql (k1 ,"
-                + "s1) values('testk1','tests1')", Collections.emptyList());
+                    + "s1) values('testk1','tests1')", Collections.emptyList());
 
             try (DataScanner scan = scan(manager, "EXPLAIN SELECT k1 FROM tblspace1.tsql", Collections.emptyList());) {
                 List<DataAccessor> consume = scan.consume();
@@ -422,10 +422,10 @@ public class CalcitePlannerTest {
             manager.waitForTablespace("tblspace1", 10000);
 
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,"
-                + "s1 string)", Collections.emptyList());
+                    + "s1 string)", Collections.emptyList());
 
             execute(manager, "INSERT INTO tblspace1.tsql (k1 ,"
-                + "s1) values('testk1','tests1')", Collections.emptyList());
+                    + "s1) values('testk1','tests1')", Collections.emptyList());
 
             try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList());) {
                 List<DataAccessor> consume = scan.consume();
@@ -489,9 +489,9 @@ public class CalcitePlannerTest {
 
     private static PlannerOp plan(final DBManager manager, String query) throws StatementExecutionException {
         TranslatedQuery translate = manager.getPlanner().translate(TableSpace.DEFAULT,
-            query,
-            Collections.emptyList(),
-            true, true, true, -1);
+                query,
+                Collections.emptyList(),
+                true, true, true, -1);
 
         return translate.plan.mainStatement.unwrap(SQLPlannedOperationStatement.class
         ).getRootOp();
@@ -500,8 +500,33 @@ public class CalcitePlannerTest {
     @SuppressWarnings("unchecked")
     private static <T> T assertInstanceOf(PlannerOp plan, Class<T> aClass) {
         Assert.assertTrue("expecting " + aClass + " but found " + plan.getClass(),
-            plan.getClass().equals(aClass));
+                plan.getClass().equals(aClass));
         return (T) plan;
+    }
+
+    @Test
+    public void testIsDdl() {
+        assertTrue(CalcitePlanner.isDDL("CREATE TABLE"));
+        assertTrue(CalcitePlanner.isDDL("   CREATE TABLE `sm_machine`"));
+          assertTrue(CalcitePlanner.isDDL("CREATE TABLE `sm_machine` (\n"
+                + "  `ip` varchar(20) NOT NULL DEFAULT '',"));
+        assertTrue(CalcitePlanner.isDDL("CREATE TABLE `sm_machine` (\n"
+                + "  `ip` varchar(20) NOT NULL DEFAULT '',\n"
+                + "  `firefox_version` int(50) DEFAULT NULL,\n"
+                + "  `chrome_version` int(50) DEFAULT NULL,\n"
+                + "  `ie_version` int(50) DEFAULT NULL,\n"
+                + "  `log` varchar(2000) DEFAULT NULL,\n"
+                + "  `offset` int(50) DEFAULT NULL,\n"
+                + "  PRIMARY KEY (`ip`)\n"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8;"));
+        assertTrue(CalcitePlanner.isDDL("creaTe TABLE"));
+        assertTrue(CalcitePlanner.isDDL("alter table"));
+        assertTrue(CalcitePlanner.isDDL("coMMIT transaction"));
+        assertTrue(CalcitePlanner.isDDL("rollBACK transaction"));
+        assertTrue(CalcitePlanner.isDDL("begin transaction"));
+        assertTrue(CalcitePlanner.isDDL("drop table"));
+        assertFalse(CalcitePlanner.isDDL("select * from"));
+        assertFalse(CalcitePlanner.isDDL("explain select * from"));
     }
 
 }

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
@@ -200,7 +200,7 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
     @Override
     @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
     public boolean execute() throws SQLException {
-        if (sql.toLowerCase().startsWith("select")) {
+        if (EXPECTS_RESULTSET.matcher(sql).matches()) {
             executeQuery();
             moreResults = true;
             return true;

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBStatement.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBStatement.java
@@ -34,6 +34,7 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.Collections;
+import java.util.regex.Pattern;
 
 /**
  * SQL Statement
@@ -41,6 +42,8 @@ import java.util.Collections;
  * @author enrico.olivelli
  */
 public class HerdDBStatement implements java.sql.Statement {
+
+    protected static final Pattern EXPECTS_RESULTSET = Pattern.compile("[\\s]*(SELECT|EXPLAIN).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     protected final HerdDBConnection parent;
     protected int maxRows;
@@ -134,7 +137,7 @@ public class HerdDBStatement implements java.sql.Statement {
     @Override
     @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
     public boolean execute(String sql) throws SQLException {
-        if (sql.toLowerCase().startsWith("select")) {
+        if (EXPECTS_RESULTSET.matcher(sql).matches()) {
             executeQuery(sql);
             moreResults = true;
             return true;
@@ -152,12 +155,12 @@ public class HerdDBStatement implements java.sql.Statement {
     }
 
     @Override
-    public int getUpdateCount() throws SQLException {        
+    public int getUpdateCount() throws SQLException {
         return (int) lastUpdateCount;
     }
 
     @Override
-    public boolean getMoreResults() throws SQLException {        
+    public boolean getMoreResults() throws SQLException {
         lastUpdateCount = -1;
         return moreResults;
     }


### PR DESCRIPTION
Summary of changes:
- improve selection of planner (DDL vs DML/Query)
- in JDBC improve selection of the type of query (DML vs Query) and support EXPLAIN in JDBC (and so in CLI)

