### PR TITLE
Added a way to signal rebuild needed by indexes, fixes #201

### DIFF
--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -71,13 +71,14 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
     LogSequenceNumber bootSequenceNumber;
 
     @Override
-    public void start(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+    protected boolean doStart(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
         LOGGER.log(Level.SEVERE, "loading in memory all the keys for mem index {0}", new Object[]{index.name});
         bootSequenceNumber = sequenceNumber;
 
         if (LogSequenceNumber.START_OF_TIME.equals(sequenceNumber)) {
             /* Empty index (booting from the start) */
             LOGGER.log(Level.SEVERE, "loaded empty index {0}", new Object[]{index.name});
+            return true;
         } else {
 
             IndexStatus status;
@@ -85,8 +86,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
                 status = dataStorageManager.getIndexStatus(tableSpaceUUID, index.uuid, sequenceNumber);
             } catch (DataStorageManagerException e) {
                 LOGGER.log(Level.SEVERE, "cannot load index {0} due to {1}, it will be rebuilt", new Object[] {index.name, e});
-                rebuild();
-                return;
+                return false;
             }
 
             for (long pageId : status.activePages) {
@@ -120,6 +120,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
 
             newPageId.set(status.newPageId);
             LOGGER.log(Level.SEVERE, "loaded {0} keys for index {1}", new Object[]{data.size(), index.name});
+            return true;
         }
     }
 

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
@@ -40,12 +40,23 @@ public class BlockRangeIndexMetadata<K extends Comparable<K>> {
 
     public static class BlockMetadata<K extends Comparable<K>> {
 
+        final boolean headBlock;
         final K firstKey;
         final int blockId;
         final long size;
         final long pageId;
 
+        public BlockMetadata(int blockId, long size, long pageId) {
+            this.headBlock = true;
+            this.firstKey = null;
+            this.blockId = blockId;
+            this.size = size;
+            this.pageId = pageId;
+        }
+
         public BlockMetadata(K firstKey, int blockId, long size, long pageId) {
+
+            this.headBlock = false;
             this.firstKey = firstKey;
             this.blockId = blockId;
             this.size = size;
@@ -62,6 +73,10 @@ public class BlockRangeIndexMetadata<K extends Comparable<K>> {
 
         public K getFirstKey() {
             return firstKey;
+        }
+
+        public boolean isHeadBlock() {
+            return headBlock;
         }
 
         public int getBlockId() {

--- a/herddb-utils/src/main/java/herddb/core/HerdDBInternalException.java
+++ b/herddb-utils/src/main/java/herddb/core/HerdDBInternalException.java
@@ -26,6 +26,9 @@ package herddb.core;
  */
 public class HerdDBInternalException extends RuntimeException {
 
+    /** Default Serial Version UID */
+    private static final long serialVersionUID = 1L;
+
     public HerdDBInternalException() {
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
                             <reuseForks>false</reuseForks>
                             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                             <argLine> -Xmx2G -XX:+UseG1GC -Djava.io.tmpdir=${project.build.directory}</argLine>
-                            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                            <!--<redirectTestOutputToFile>false</redirectTestOutputToFile>-->
                             <trimStackTrace>false</trimStackTrace>
                         </configuration>
                     </plugin>            


### PR DESCRIPTION
On startup indexes can now signal that a full rebuild is needed instead.
Added index rebuild request when BRIN find an index metadata with version smaller than 2
Increased current BRIN index metadata version to 2