### PR TITLE
Feature/brin preallocate head block

### DIFF
--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -80,7 +80,10 @@ public class BRINIndexManager extends AbstractIndexManager {
 
     public BRINIndexManager(Index index, MemoryManager memoryManager, AbstractTableManager tableManager, CommitLog log, DataStorageManager dataStorageManager, TableSpaceManager tableSpaceManager, String tableSpaceUUID, long transaction) {
         super(index, tableManager, dataStorageManager, tableSpaceManager.getTableSpaceUUID(), log, transaction);
-        this.data = new BlockRangeIndex<>(memoryManager.getMaxLogicalPageSize(), memoryManager.getDataPageReplacementPolicy(), storageLayer);
+        this.data = new BlockRangeIndex<>(
+                memoryManager.getMaxLogicalPageSize(),
+                memoryManager.getDataPageReplacementPolicy(),
+                storageLayer);
     }
 
     private static final class PageContents {
@@ -281,7 +284,7 @@ public class BRINIndexManager extends AbstractIndexManager {
     public void rebuild() throws DataStorageManagerException {
         long _start = System.currentTimeMillis();
         LOGGER.log(Level.SEVERE, "rebuilding index {0}", index.name);
-        data.clear();
+        data.reset();
         Table table = tableManager.getTable();
         tableManager.scanForIndexRebuild(r -> {
             DataAccessor values = r.getDataAccessor(table);
@@ -332,12 +335,8 @@ public class BRINIndexManager extends AbstractIndexManager {
             SecondaryIndexSeek sis = (SecondaryIndexSeek) operation;
             SQLRecordKeyFunction value = sis.value;
             byte[] refvalue = value.computeNewValue(null, context, tableContext);
-            List<Bytes> result = data.search(Bytes.from_array(refvalue));
-            if (result != null) {
-                return result.stream();
-            } else {
-                return Stream.empty();
-            }
+            return data.query(Bytes.from_array(refvalue));
+
         } else if (operation instanceof SecondaryIndexPrefixScan) {
             SecondaryIndexPrefixScan sis = (SecondaryIndexPrefixScan) operation;
             SQLRecordKeyFunction value = sis.value;
@@ -433,7 +432,7 @@ public class BRINIndexManager extends AbstractIndexManager {
 
     @Override
     public void truncate() throws DataStorageManagerException {
-        this.data.clear();
+        this.data.reset();
         dropIndexData();
     }
 

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -249,7 +248,7 @@ public class BRINIndexManager extends AbstractIndexManager {
 
         if (LogSequenceNumber.START_OF_TIME.equals(sequenceNumber)) {
             /* Empty index (booting from the start) */
-            this.data.boot(new BlockRangeIndexMetadata<>(Collections.emptyList()));
+            this.data.boot(BlockRangeIndexMetadata.empty());
             LOGGER.log(Level.SEVERE, "loaded empty index {0}", new Object[]{index.name});
 
             return true;

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -232,6 +232,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
         private final BRINPage<KEY,VAL> page;
 
+        /** Constructor for restore operations */
         public Block(BlockRangeIndex<KEY,VAL> index, long blockId, KEY firstKey, long size, long pageId, Block<KEY,VAL> next) {
             this.index = index;
             this.key = BlockStartKey.valueOf(firstKey, blockId);
@@ -247,6 +248,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             page = new BRINPage<>(this, blockId);
         }
 
+        /** Constructor for head block */
         @SuppressWarnings("unchecked")
         public Block(BlockRangeIndex<KEY,VAL> index) {
             this.index = index;
@@ -254,26 +256,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
             this.values = new TreeMap<>();
             this.size = 0;
-
-            this.loaded = true;
-            this.dirty = true;
-            this.pageId = IndexDataStorage.NEW_PAGE;
-
-            /* Immutable Block ID */
-            page = new BRINPage<>(this, key.blockId);
-        }
-
-        @Deprecated
-        public Block(BlockRangeIndex<KEY,VAL> index, KEY firstKey, VAL firstValue) {
-            this.index = index;
-            this.key = (BlockStartKey<KEY>) BlockStartKey.HEAD_KEY;
-
-            /* TODO: estimate a better sizing for array list */
-            List<VAL> firstKeyValues = new ArrayList<>();
-            firstKeyValues.add(firstValue);
-            values = new TreeMap<>();
-            values.put(firstKey, firstKeyValues);
-            this.size = index.evaluateEntrySize(firstKey, firstValue);
 
             this.loaded = true;
             this.dirty = true;

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.TreeMap;
@@ -35,7 +34,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import herddb.core.Page;
@@ -191,6 +189,14 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
         return size;
     }
 
+    private static final class PutState <KEY extends Comparable<KEY> & SizeAwareObject, VAL extends SizeAwareObject> {
+        Block<KEY,VAL> next;
+
+        public PutState() {
+            super();
+        }
+    }
+
     private static final class DeleteState <KEY extends Comparable<KEY> & SizeAwareObject, VAL extends SizeAwareObject> {
         Block<KEY,VAL> next;
 
@@ -239,6 +245,22 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
             /* Immutable Block ID */
             page = new BRINPage<>(this, blockId);
+        }
+
+        @SuppressWarnings("unchecked")
+        public Block(BlockRangeIndex<KEY,VAL> index) {
+            this.index = index;
+            this.key = (BlockStartKey<KEY>) BlockStartKey.HEAD_KEY;
+
+            this.values = new TreeMap<>();
+            this.size = 0;
+
+            this.loaded = true;
+            this.dirty = true;
+            this.pageId = IndexDataStorage.NEW_PAGE;
+
+            /* Immutable Block ID */
+            page = new BRINPage<>(this, key.blockId);
         }
 
         @Deprecated
@@ -299,14 +321,15 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             valuesForKey.add(value);
         }
 
-        Block<KEY,VAL> addValue(KEY key, VAL value) {
+        void addValue(KEY key, VAL value, PutState<KEY, VAL> state) {
 
             /* Eventual new block from split. It must added to PageReplacementPolicy only after lock release */
             Block<KEY,VAL> newblock = null;
             lock.lock();
             try {
-                Block<KEY,VAL> next = this.next;
-                if (next != null && next.key.compareMinKey(key) <= 0) {
+
+                Block<KEY,VAL> currentNext = this.next;
+                if (currentNext != null && currentNext.key.compareMinKey(key) <= 0) {
                     // unfortunately this occours during split
                     // put #1 -> causes split
                     // put #2 -> designates this block for put, but the split is taking place
@@ -314,8 +337,10 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                     // put #2 needs to addValue to the 'next' (split result) block not to this
 
                     /* Add to next */
-                    return next;
+                    state.next = currentNext;
+                    return;
                 }
+
                 ensureBlockLoaded();
 
                 mergeAddValue(key, value, values);
@@ -337,7 +362,9 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             }
 
             /* Added */
-            return null;
+            /* No more next */
+            state.next = null;
+            return;
         }
 
 
@@ -654,12 +681,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
         return blocks.size();
     }
 
-    public void put(K key, V value) {
-        BlockStartKey<K> lookUp = BlockStartKey.valueOf(key, Long.MAX_VALUE);
-        while (!tryPut(key, value, lookUp)) {
-        }
-    }
-
     public BlockRangeIndexMetadata<K> checkpoint() throws IOException {
         final boolean fineEnabled = LOG.isLoggable(Level.FINE);
 
@@ -741,118 +762,131 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
         return new BlockRangeIndexMetadata<>(blocksMetadata);
     }
 
+    public void put(K key, V value) {
 
-    private boolean tryPut(K key, V value, BlockStartKey<K> lookUp) {
-        Map.Entry<BlockStartKey<K>, Block<K,V>> segmentEntry = blocks.floorEntry(lookUp);
-        if (segmentEntry == null) {
+        /* Lookup from the last possible block where we could insert the value */
+        final BlockStartKey<K> lookUp = BlockStartKey.valueOf(key, Long.MAX_VALUE);
 
-            final Block<K,V> headBlock = new Block<>(this, key, value);
-            headBlock.lock.lock();
+        final PutState<K,V> state = new PutState<>();
 
-            try {
-                boolean added = blocks.putIfAbsent((BlockStartKey<K>) BlockStartKey.HEAD_KEY, headBlock) == null;
-
-                /* Set the block as "loaded" only if has been really added */
-                if (added) {
-                    final Metadata unload = pageReplacementPolicy.add(headBlock.page);
-                    if (unload != null) {
-                        unload.owner.unload(unload.pageId);
-                    }
-                }
-
-                return added;
-            } finally {
-                headBlock.lock.unlock();
-            }
-        }
-
-
-        Block<K,V> block = segmentEntry.getValue();
-
+        /* There is always at least the head block! */
+        state.next = blocks.floorEntry(lookUp).getValue();
         do {
-            block = block.addValue(key, value);
-        } while(block != null);
-
-        return true;
+            state.next.addValue(key, value, state);
+        } while (state.next != null);
 
     }
 
     public void delete(K key, V value) {
 
-        final Entry<BlockStartKey<K>,Block<K,V>> entry = blocks.floorEntry(BlockStartKey.valueOf(key, -1L));
+        /* Lookup from the first possible block that could contain the value*/
+        final BlockStartKey<K> lookUp = BlockStartKey.valueOf(key, -1L);
 
         final DeleteState<K,V> state = new DeleteState<>();
-        state.next = entry.getValue();
+
+        /* There is always at least the head block! */
+        state.next = blocks.floorEntry(lookUp).getValue();
         do {
             state.next.delete(key, value, state);
         } while (state.next != null);
     }
 
-    public Stream<V> query(K firstKey, K lastKey) {
-
-        final Entry<BlockStartKey<K>,Block<K,V>> entry;
-        if (firstKey != null ) {
-            entry = blocks.floorEntry(BlockStartKey.valueOf(firstKey, -1L));
-        } else {
-            /* Use first entry and not HEAD block lookup just because has better performances */
-            entry = blocks.firstEntry();
-        }
+    public List<V> search(K firstKey, K lastKey) {
 
         final LookupState<K, V> state = new LookupState<>();
-        state.next = entry.getValue();
+
+        if (firstKey != null ) {
+            /* Lookup from the first possible block that could contain the first lookup key*/
+            final BlockStartKey<K> lookUp = BlockStartKey.valueOf(firstKey, -1L);
+
+            /* There is always at least the head block! */
+            state.next = blocks.floorEntry(lookUp).getValue();
+        } else {
+            /* Use first entry and not HEAD block lookup just because has better performances */
+            state.next = blocks.firstEntry().getValue();
+        }
+
         do {
             state.next.lookUpRange(firstKey, lastKey, state);
         } while (state.next != null);
 
-        return state.found.stream();
+        return state.found;
     }
-
-    public List<V> lookUpRange(K firstKey, K lastKey) {
-        return query(firstKey, lastKey).collect(Collectors.toList());
-    }
-
 
     public List<V> search(K key) {
-        return lookUpRange(key, key);
+        return search(key, key);
+    }
+
+    public Stream<V> query(K firstKey, K lastKey) {
+        return search(firstKey, lastKey).stream();
+    }
+
+    public Stream<V> query(K key) {
+        return query(key, key);
     }
 
     public boolean containsKey(K key) {
-        return !lookUpRange(key, key).isEmpty();
+        return !search(key, key).isEmpty();
     }
 
     public void boot(BlockRangeIndexMetadata<K> metadata) throws DataStorageManagerException {
         LOG.severe("boot index, with " + metadata.getBlocksMetadata().size() + " blocks");
 
+        if (metadata.getBlocksMetadata().size() == 0) {
+
+            reset();
+
+        } else {
+
+            clear();
+
+            /* Metadata are saved/recovered in reverse order so "next" block has been already created */
+            Block<K,V> next = null;
+            for (BlockRangeIndexMetadata.BlockMetadata<K> blockData : metadata.getBlocksMetadata()) {
+                /*
+                 * TODO: if the system is restart with a different (smaller) page size old blocks will remain
+                 * bigger until a split occurs.
+                 */
+
+                /* Medatada safety check (do not trust blindly ordering) */
+                if (blockData.nextBlockId != null) {
+                    if (next == null || next.key.blockId != blockData.nextBlockId.longValue()) {
+                        throw new DataStorageManagerException("Wron next block, expected " + next.key.blockId + " but "
+                                + blockData.nextBlockId + " found");
+                    }
+                } else {
+                    if (next != null) {
+                        throw new DataStorageManagerException("Wron next block, expected notingh but "
+                                + blockData.nextBlockId + " found");
+                    }
+                }
+
+                next = new Block<>(this, blockData.blockId, blockData.firstKey, blockData.size, blockData.pageId, next);
+                blocks.put(next.key, next);
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.fine("boot block at " + next.key + " " + next.key.minKey);
+                }
+                currentBlockId.accumulateAndGet(next.key.blockId, EnsureLongIncrementAccumulator.INSTANCE);
+            }
+        }
+
+    }
+
+    @SuppressWarnings("unchecked")
+    void reset() {
+
         clear();
 
-        /* Metadata are saved/recovered in reverse order so "next" block has been already created */
-        Block<K,V> next = null;
-        for (BlockRangeIndexMetadata.BlockMetadata<K> blockData : metadata.getBlocksMetadata()) {
-            /*
-             * TODO: if the system is restart with a different (smaller) page size old blocks will remain
-             * bigger until a split occurs.
-             */
+        /* Create the head block */
+        final Block<K,V> headBlock = new Block<>(this);
+        blocks.put((BlockStartKey<K>) BlockStartKey.HEAD_KEY, headBlock);
 
-            /* Medatada safety check (do not trust blindly ordering) */
-            if (blockData.nextBlockId != null) {
-                if (next == null || next.key.blockId != blockData.nextBlockId.longValue()) {
-                    throw new DataStorageManagerException("Wron next block, expected " + next.key.blockId + " but "
-                            + blockData.nextBlockId + " found");
-                }
-            } else {
-                if (next != null) {
-                    throw new DataStorageManagerException("Wron next block, expected notingh but "
-                            + blockData.nextBlockId + " found");
-                }
-            }
-
-            next = new Block<>(this, blockData.blockId, blockData.firstKey, blockData.size, blockData.pageId, next);
-            blocks.put(next.key, next);
-            if (LOG.isLoggable(Level.FINE)) {
-                LOG.fine("boot block at " + next.key + " " + next.key.minKey);
-            }
-            currentBlockId.accumulateAndGet(next.key.blockId, EnsureLongIncrementAccumulator.INSTANCE);
+        final Metadata unload = pageReplacementPolicy.add(headBlock.page);
+        if (unload != null) {
+            unload.owner.unload(unload.pageId);
         }
+
+        currentBlockId.set(0);
     }
 
     void clear() {

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
@@ -19,6 +19,7 @@
  */
 package herddb.index.brin;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -27,6 +28,15 @@ import java.util.List;
  * @author enrico.olivelli
  */
 public class BlockRangeIndexMetadata<K extends Comparable<K>> {
+
+    @SuppressWarnings("rawtypes")
+    private static final BlockRangeIndexMetadata EMPTY_METADATA =
+            new BlockRangeIndexMetadata<>(Collections.emptyList());
+
+    @SuppressWarnings("unchecked")
+    public static final <X extends Comparable<X>> BlockRangeIndexMetadata<X> empty() {
+        return EMPTY_METADATA;
+    }
 
     private List<BlockMetadata<K>> blocksMetadata;
 
@@ -49,15 +59,6 @@ public class BlockRangeIndexMetadata<K extends Comparable<K>> {
         final long size;
         final long pageId;
         Long nextBlockId;
-
-//        public BlockMetadata(long blockId, long size, long pageId, Long nextBlockId) {
-//            this.headBlock = true;
-//            this.firstKey = null;
-//            this.blockId = blockId;
-//            this.size = size;
-//            this.pageId = pageId;
-//            this.nextBlockId = nextBlockId;
-//        }
 
         public BlockMetadata(K firstKey, long blockId, long size, long pageId, Long nextBlockId) {
 

--- a/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexBench.java
+++ b/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexBench.java
@@ -36,25 +36,67 @@ public class BlockRangeIndexBench {
     @Test
     public void testHuge() {
         final int testSize = 1_000_000;
-//        final int testSize = 100_000;
+
+        final int tenPerc = testSize/10;
 
         long _start = System.currentTimeMillis();
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(10000, new RandomPageReplacementPolicy(10000));
+        index.boot(BlockRangeIndexMetadata.empty());
         for (int i = 0; i < testSize; i++) {
             index.put(Sized.valueOf(i), Sized.valueOf("test_" + i));
+            if (i % tenPerc == 0) System.out.println("insert : " + (1 + i / tenPerc) * 10 + "%: " + i);
         }
         long _stop = System.currentTimeMillis();
         System.out.println("time w: " + (_stop - _start));
         System.out.println("num segments: " + index.getNumBlocks());
         for (int i = 0; i < testSize; i++) {
-
-            if (i % 10000 == 0) System.out.println("search : " + i);
-
             List<Sized<String>> s = index.search(Sized.valueOf(i));
             Assert.assertEquals(1, s.size());
             Assert.assertEquals("test_" + i, s.get(0).dummy);
-//            index.lookUpRange(i, i + 1000);
+
+            if (i % tenPerc == 0) System.out.println("search : " + (1 + i / tenPerc) * 10 + "%: " + i);
+        }
+        _start = _stop;
+        _stop = System.currentTimeMillis();
+        System.out.println("time r: " + (_stop - _start));
+        index.clear();
+    }
+
+    /**
+     * Test with multivalued keys
+     * @author diego.salvi
+     */
+    @Test
+    public void testHugeMultivalued() {
+        final int testSize = 1_000_000;
+        final int valuesPerKey = 10;
+
+        final int tenPerc = testSize/10;
+
+        long _start = System.currentTimeMillis();
+        BlockRangeIndex<Sized<Integer>, Sized<String>> index =
+                new BlockRangeIndex<>(10000, new RandomPageReplacementPolicy(10000));
+        index.boot(BlockRangeIndexMetadata.empty());
+        for (int i = 0; i < testSize; i++) {
+            for(int j = 0; j < valuesPerKey; j++) {
+                index.put(Sized.valueOf(i), Sized.valueOf("test_" + i + "_" + j));
+            }
+
+            if (i % tenPerc == 0) System.out.println("insert : " + (1 + i / tenPerc) * 10 + "%: " + i);
+        }
+        long _stop = System.currentTimeMillis();
+        System.out.println("time w: " + (_stop - _start));
+        System.out.println("num segments: " + index.getNumBlocks());
+        for (int i = 0; i < testSize; i++) {
+            List<Sized<String>> s = index.search(Sized.valueOf(i));
+            Assert.assertEquals(valuesPerKey, s.size());
+
+            for(int j = 0; j < valuesPerKey; ++j) {
+                Assert.assertEquals("test_" + i + "_" + j, s.get(j).dummy);
+            }
+
+            if (i % tenPerc == 0) System.out.println("search : " + (1 + i / tenPerc) * 10 + "%: " + i);
         }
         _start = _stop;
         _stop = System.currentTimeMillis();

--- a/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexConcurrentTest.java
+++ b/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexConcurrentTest.java
@@ -53,6 +53,7 @@ public class BlockRangeIndexConcurrentTest {
         int parallelism = 10;
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(3));
+        index.boot(BlockRangeIndexMetadata.empty());
 
         try {
 
@@ -82,7 +83,7 @@ public class BlockRangeIndexConcurrentTest {
             dumpIndex(index);
             verifyIndex(index);
 
-            List<Sized<String>> result = index.lookUpRange(Sized.valueOf(0), Sized.valueOf(testSize + 1));
+            List<Sized<String>> result = index.search(Sized.valueOf(0), Sized.valueOf(testSize + 1));
             for (Sized<String> res : result) {
                 System.out.println("res " + res.dummy);
             }
@@ -105,6 +106,7 @@ public class BlockRangeIndexConcurrentTest {
         int parallelism = 10;
         BlockRangeIndex<Sized<Integer>, Sized<String>> index = new BlockRangeIndex<>(1024,
                 new RandomPageReplacementPolicy(3));
+        index.boot(BlockRangeIndexMetadata.empty());
         ExecutorService threadpool = Executors.newFixedThreadPool(parallelism);
 
         try {
@@ -142,7 +144,7 @@ public class BlockRangeIndexConcurrentTest {
 
             dumpIndex(index);
             verifyIndex(index);
-            List<Sized<String>> result = index.lookUpRange(Sized.valueOf(0), Sized.valueOf(testSize + 1));
+            List<Sized<String>> result = index.search(Sized.valueOf(0), Sized.valueOf(testSize + 1));
             for (Sized<String> res : result) {
                 System.out.println("res " + res.dummy);
             }
@@ -166,6 +168,7 @@ public class BlockRangeIndexConcurrentTest {
         int parallelism = 10;
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(3));
+        index.boot(BlockRangeIndexMetadata.empty());
 
         try {
 
@@ -213,7 +216,7 @@ public class BlockRangeIndexConcurrentTest {
             dumpIndex(index);
 
             verifyIndex(index);
-            List<Sized<String>> lookupAfterDeletion = index.lookUpRange(Sized.valueOf(0), Sized.valueOf(testSize + 1));
+            List<Sized<String>> lookupAfterDeletion = index.search(Sized.valueOf(0), Sized.valueOf(testSize + 1));
             assertTrue(lookupAfterDeletion.isEmpty());
 
             for (int i = 0; i < testSize; i++) {

--- a/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexStorageTest.java
+++ b/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexStorageTest.java
@@ -49,6 +49,7 @@ public class BlockRangeIndexStorageTest {
         IndexDataStorage<Sized<Integer>, Sized<String>> storage = new MemoryIndexDataStorage<>();
 
         BlockRangeIndex<Sized<Integer>, Sized<String>> index = new BlockRangeIndex<>(400, policy, storage);
+        index.boot(BlockRangeIndexMetadata.empty());
 
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
         index.put(Sized.valueOf(2), Sized.valueOf("b"));
@@ -75,6 +76,7 @@ public class BlockRangeIndexStorageTest {
         IndexDataStorage<Sized<Integer>, Sized<Integer>> storage = new MemoryIndexDataStorage<>();
 
         BlockRangeIndex<Sized<Integer>, Sized<Integer>> index = new BlockRangeIndex<>(400, policy, storage);
+        index.boot(BlockRangeIndexMetadata.empty());
 
         int i = 0;
         do {
@@ -137,6 +139,7 @@ public class BlockRangeIndexStorageTest {
         IndexDataStorage<Sized<Integer>, Sized<String>> storage = new MemoryIndexDataStorage<>();
 
         BlockRangeIndex<Sized<Integer>, Sized<String>> index = new BlockRangeIndex<>(1024, policy, storage);
+        index.boot(BlockRangeIndexMetadata.empty());
         for (int i = 0; i < 100; i++) {
             index.put(Sized.valueOf(i), Sized.valueOf("a"));
         }

--- a/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexTest.java
@@ -45,6 +45,7 @@ public class BlockRangeIndexTest {
 
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(400, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
         index.put(Sized.valueOf(2), Sized.valueOf("b"));
         index.put(Sized.valueOf(3), Sized.valueOf("c"));
@@ -60,6 +61,7 @@ public class BlockRangeIndexTest {
 
         BlockRangeIndex<Sized<Integer>, Sized<Integer>> index =
                 new BlockRangeIndex<>(400, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
 
         int i = 0;
         do {
@@ -83,6 +85,8 @@ public class BlockRangeIndexTest {
     public void testRemoveHead() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
+        index.boot(BlockRangeIndexMetadata.empty());
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
         index.delete(Sized.valueOf(1), Sized.valueOf("a"));
         List<Sized<String>> searchResult = index.search(Sized.valueOf(1));
@@ -93,6 +97,7 @@ public class BlockRangeIndexTest {
     public void testSimpleSplitSameKey() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(400, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
         index.put(Sized.valueOf(1), Sized.valueOf("b"));
         index.put(Sized.valueOf(1), Sized.valueOf("c"));
@@ -110,11 +115,12 @@ public class BlockRangeIndexTest {
     public void testUnboundedSearch() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
         index.put(Sized.valueOf(2), Sized.valueOf("b"));
         index.put(Sized.valueOf(3), Sized.valueOf("c"));
-        assertEquals(3, index.lookUpRange(Sized.valueOf(1), null).size());
-        assertEquals(2, index.lookUpRange(null, Sized.valueOf(2)).size());
+        assertEquals(3, index.search(Sized.valueOf(1), null).size());
+        assertEquals(2, index.search(null, Sized.valueOf(2)).size());
 
     }
 
@@ -122,6 +128,8 @@ public class BlockRangeIndexTest {
     public void lookupVeryFirstEntry() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
+
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
         index.put(Sized.valueOf(2), Sized.valueOf("b"));
         index.put(Sized.valueOf(3), Sized.valueOf("c"));
@@ -133,7 +141,7 @@ public class BlockRangeIndexTest {
         System.out.println("searchResult:" + searchResult);
         assertEquals(1, searchResult.size());
 
-        List<Sized<String>> searchResult2 = index.lookUpRange(Sized.valueOf(1), Sized.valueOf(4));
+        List<Sized<String>> searchResult2 = index.search(Sized.valueOf(1), Sized.valueOf(4));
         System.out.println("searchResult:" + searchResult2);
         assertEquals(4, searchResult2.size());
         assertEquals(Sized.valueOf("a"), searchResult2.get(0));
@@ -146,6 +154,7 @@ public class BlockRangeIndexTest {
     public void testSimpleSplitInverse() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(400, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
         index.put(Sized.valueOf(3), Sized.valueOf("c"));
         index.put(Sized.valueOf(2), Sized.valueOf("b"));
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
@@ -161,6 +170,7 @@ public class BlockRangeIndexTest {
     public void testDelete() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
         index.put(Sized.valueOf(3), Sized.valueOf("c"));
         index.put(Sized.valueOf(2), Sized.valueOf("b"));
         index.put(Sized.valueOf(1), Sized.valueOf("a"));
@@ -191,6 +201,7 @@ public class BlockRangeIndexTest {
 
         final BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(400, policy, storage);
+        index.boot(BlockRangeIndexMetadata.empty());
 
         /* Add values until block split */
         int elements;
@@ -236,6 +247,7 @@ public class BlockRangeIndexTest {
 
         final BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(400, policy, storage);
+        index.boot(BlockRangeIndexMetadata.empty());
 
         /* Add values until block split */
         int elements;
@@ -290,6 +302,7 @@ public class BlockRangeIndexTest {
     public void testMultiple() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
         for (int i = 0; i < 10; i++) {
             index.put(Sized.valueOf(i), Sized.valueOf("test_" + i));
         }
@@ -312,7 +325,7 @@ public class BlockRangeIndexTest {
             assertEquals(Sized.valueOf("test_" + i), result.get(0));
             assertEquals(Sized.valueOf("test_" + i), result.get(1));
         }
-        List<Sized<String>> range = index.lookUpRange(Sized.valueOf(3), Sized.valueOf(5));
+        List<Sized<String>> range = index.search(Sized.valueOf(3), Sized.valueOf(5));
         assertEquals(6, range.size());
 
         for (int i = 0; i < 10; i++) {
@@ -329,10 +342,11 @@ public class BlockRangeIndexTest {
     public void testManySegments() {
         BlockRangeIndex<Sized<Integer>, Sized<String>> index =
                 new BlockRangeIndex<>(1024, new RandomPageReplacementPolicy(10));
+        index.boot(BlockRangeIndexMetadata.empty());
         for (int i = 0; i < 20; i++) {
             index.put(Sized.valueOf(i), Sized.valueOf("test_" + i));
         }
-        List<Sized<String>> result = index.lookUpRange(Sized.valueOf(2), Sized.valueOf(10));
+        List<Sized<String>> result = index.search(Sized.valueOf(2), Sized.valueOf(10));
         System.out.println("result_" + result);
         for (int i = 2; i <= 10; i++) {
             assertTrue(result.contains(Sized.valueOf("test_" + i)));


### PR DESCRIPTION
* Head block preallocation during index boot() operation (the index shouldn't be used before boot)
* Removed head block insertion attempt during put / try put
* BRIN query interface cleanup