### PR TITLE
Fix/blink node map release

### DIFF
--- a/herddb-core/src/main/java/herddb/mem/MemoryLocalNodeIdManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryLocalNodeIdManager.java
@@ -1,0 +1,24 @@
+package herddb.mem;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import herddb.server.LocalNodeIdManager;
+
+/**
+ * In memory LocalNodeIdManager, for tests
+ *
+ * @author diego.salvi
+ */
+public class MemoryLocalNodeIdManager extends LocalNodeIdManager {
+
+    public MemoryLocalNodeIdManager(Path dataPath) {
+        super(dataPath);
+    }
+
+    @Override
+    public void persistLocalNodeId(String nodeId) throws IOException {
+        /* NOP */
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -45,6 +45,7 @@ import herddb.file.FileMetadataStorageManager;
 import herddb.log.CommitLogManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryLocalNodeIdManager;
 import herddb.mem.MemoryMetadataStorageManager;
 import herddb.metadata.MetadataStorageManager;
 import herddb.metadata.MetadataStorageManagerException;
@@ -188,7 +189,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 realData);
 
         if (nodeId.isEmpty()) {
-            LocalNodeIdManager localNodeIdManager = new LocalNodeIdManager(dataDirectory);
+            LocalNodeIdManager localNodeIdManager = buildLocalNodeIdManager();
             try {
                 nodeId = localNodeIdManager.readLocalNodeId();
                 if (nodeId == null) {
@@ -337,6 +338,20 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 throw new RuntimeException();
         }
     }
+
+    private LocalNodeIdManager buildLocalNodeIdManager() {
+        switch (mode) {
+            case ServerConfiguration.PROPERTY_MODE_LOCAL:
+                return new MemoryLocalNodeIdManager(dataDirectory);
+            case ServerConfiguration.PROPERTY_MODE_STANDALONE:
+                return new LocalNodeIdManager(dataDirectory);
+            case ServerConfiguration.PROPERTY_MODE_CLUSTER:
+                return new LocalNodeIdManager(dataDirectory);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
 
     public void start() throws Exception {
         boolean startBookie = configuration.getBoolean(ServerConfiguration.PROPERTY_BOOKKEEPER_START,


### PR DESCRIPTION
In many memory dumps ConcurrentSkipListMaps in Blink nodes still reatain memory after clear(). This commit dereference the node internal map too after clear.

