### PR TITLE
Issue-230 'Select *' does not work on Heap tables using JDBC

### DIFF
--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -65,7 +65,7 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
     private Table(String uuid, String name, Column[] columns, String[] primaryKey, String tablespace, boolean auto_increment, int maxSerialPosition) {
         this.uuid = uuid;
         this.name = name;
-        this.columns = columns;
+        this.columns = reorderColumnsPrimaryKeyFirst(columns, primaryKey);
         this.maxSerialPosition = maxSerialPosition;
         this.primaryKey = primaryKey;
         this.tablespace = tablespace;
@@ -88,6 +88,35 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
         }
         this.primaryKeyColumns = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(primaryKey)));
 
+    }
+
+    private static Column[] reorderColumnsPrimaryKeyFirst(Column[] columns, String[] primaryKey) throws IllegalStateException, IllegalArgumentException {
+        Column[] _columns = new Column[columns.length];
+        int pos = 0;
+        Set<String> pkCols = new HashSet<>();
+        for (String pkCol : primaryKey) {
+            pkCols.add(pkCol.toLowerCase());
+            boolean found = false;
+            for (Column column : columns) {
+                if (column.name.equalsIgnoreCase(pkCol)) {
+                    _columns[pos++] = column;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new IllegalArgumentException("pk col " + pkCol + " not found in columns definition " + Arrays.toString(columns));
+            }
+        }
+        for (Column column : columns) {
+            if (!pkCols.contains(column.name.toLowerCase())) {
+                _columns[pos++] = column;
+            }
+        }
+        if (pos != columns.length) {
+            throw new IllegalStateException();
+        }
+        return _columns;
     }
 
     public boolean isPrimaryKeyColumn(String column) {

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -75,7 +75,7 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
         this.columnNames = new String[columns.length];
         int i = 0;
         this.primaryKeyProjection = new int[columns.length];
-        for (Column c : columns) {
+        for (Column c : this.columns) {
             String cname = c.name.toLowerCase();
             columnsByName.put(cname, c);
             if (c.serialPosition < 0) {
@@ -90,7 +90,7 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
 
     }
 
-    private static Column[] reorderColumnsPrimaryKeyFirst(Column[] columns, String[] primaryKey) throws IllegalStateException, IllegalArgumentException {
+    private static Column[] reorderColumnsPrimaryKeyFirst(Column[] columns, String[] primaryKey) throws IllegalStateException, IllegalArgumentException {        
         Column[] _columns = new Column[columns.length];
         int pos = 0;
         Set<String> pkCols = new HashSet<>();
@@ -116,6 +116,8 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
         if (pos != columns.length) {
             throw new IllegalStateException();
         }
+        System.out.println("BEFORE: "+Arrays.toString(columns));
+        System.out.println("AFTER: "+Arrays.toString(_columns));
         return _columns;
     }
 

--- a/herddb-core/src/test/java/herddb/core/SystemTablesTest.java
+++ b/herddb-core/src/test/java/herddb/core/SystemTablesTest.java
@@ -189,12 +189,13 @@ public class SystemTablesTest {
                     Collections.emptyList());) {
                 List<DataAccessor> records = scan.consume();
                 for (DataAccessor da : records) {
-                    System.out.println("rec: " + da.toMap());
+                    System.out.println("rec2: " + da.toMap());
                 }                
                 assertTrue(records
                         .stream()
                         .map(d -> d.toMap())
                         .filter(d -> {
+                            System.out.println("filter: " + d);
                             return d.get("table_name").equals("tsql")
                                     && d.get("index_type").equals("pk")
                                     && d.get("column_name").equals("k1")

--- a/herddb-core/src/test/java/herddb/server/LedgerManagementTest.java
+++ b/herddb-core/src/test/java/herddb/server/LedgerManagementTest.java
@@ -126,7 +126,7 @@ public class LedgerManagementTest {
             LedgersInfo actualLedgersList = log.getActualLedgersList();
             System.out.println("actualLedgersList:" + actualLedgersList + " lastLedgerId " + log.getLastLedgerId());
             assertEquals(2, log.getLastLedgerId());
-            assertEquals(2, actualLedgersList.getActiveLedgers().size());
+            assertEquals(3, actualLedgersList.getActiveLedgers().size());
             assertTrue(actualLedgersList.getActiveLedgers().contains(0L));
             // ledger id 1 dropped at restart
             assertTrue(actualLedgersList.getActiveLedgers().contains(2L));

--- a/herddb-net/src/main/java/herddb/network/Message.java
+++ b/herddb-net/src/main/java/herddb/network/Message.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -58,7 +59,7 @@ public final class Message {
     }
 
     public static Message CLIENT_SHUTDOWN() {
-        return new Message( TYPE_CLIENT_SHUTDOWN, new HashMap<>());
+        return new Message(TYPE_CLIENT_SHUTDOWN, new HashMap<>());
     }
 
     public static Message EXECUTE_STATEMENT(String tableSpace, String query, long tx,
@@ -231,14 +232,14 @@ public final class Message {
         HashMap<String, Object> data = new HashMap<>();
         data.put("tableSpace", tableSpace);
         data.put("data", chunk);
-        return new Message( TYPE_PUSH_TXLOGCHUNK, data);
+        return new Message(TYPE_PUSH_TXLOGCHUNK, data);
     }
 
     public static Message PUSH_TRANSACTIONSBLOCK(String tableSpace, List<byte[]> chunk) {
         HashMap<String, Object> data = new HashMap<>();
         data.put("tableSpace", tableSpace);
         data.put("data", chunk);
-        return new Message( TYPE_PUSH_TRANSACTIONSBLOCK, data);
+        return new Message(TYPE_PUSH_TRANSACTIONSBLOCK, data);
     }
 
     public final int type;
@@ -326,7 +327,7 @@ public final class Message {
         }
     }
 
-    public Message(int type, Map<String, Object> parameters) {        
+    public Message(int type, Map<String, Object> parameters) {
         this.type = type;
         this.parameters = parameters;
     }
@@ -359,4 +360,39 @@ public final class Message {
         this.parameters.put(key, value);
         return this;
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 89 * hash + (int) (this.messageId ^ (this.messageId >>> 32));
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Message other = (Message) obj;
+        if (this.type != other.type) {
+            return false;
+        }
+        if (this.messageId != other.messageId) {
+            return false;
+        }
+        if (this.replyMessageId != other.replyMessageId) {
+            return false;
+        }
+        if (!Objects.equals(this.parameters, other.parameters)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/herddb-net/src/main/java/herddb/network/netty/MessageUtils.java
+++ b/herddb-net/src/main/java/herddb/network/netty/MessageUtils.java
@@ -37,7 +37,6 @@ import herddb.utils.MapDataAccessor;
 import herddb.utils.RawString;
 import herddb.utils.TuplesList;
 import io.netty.buffer.ByteBuf;
-import java.util.function.BiConsumer;
 
 /**
  *
@@ -73,28 +72,26 @@ public class MessageUtils {
     private static final byte OPCODE_TUPLELIST_VALUE = 25;
 
     /**
-     * When writing int <b>greater than this</b> value are better written
-     * directly as int because in vint encoding will use at least 4 bytes
+     * When writing int <b>greater than this</b> value are better written directly as int because in vint encoding will
+     * use at least 4 bytes
      */
     private static final int WRITE_MAX_V_INT_LIMIT = -1 >>> 11;
 
     /**
-     * When writing negative int <b>smaller than this</b> value are better
-     * written directly as int because in zint encoding will use at least 8
-     * bytes
+     * When writing negative int <b>smaller than this</b> value are better written directly as int because in zint
+     * encoding will use at least 8 bytes
      */
     private static final int WRITE_MIN_Z_INT_LIMIT = -1 << 20;
 
     /**
-     * When writing long <b>greater than this</b> value are better written
-     * directly as long because in vint encoding will use at least 4 bytes
+     * When writing long <b>greater than this</b> value are better written directly as long because in vint encoding
+     * will use at least 4 bytes
      */
     private static final long WRITE_MAX_V_LONG_LIMIT = -1L >>> 15;
 
     /**
-     * When writing negative long <b>smaller than this</b> value are better
-     * written directly as long because in zlong encoding will use at least 8
-     * bytes
+     * When writing negative long <b>smaller than this</b> value are better written directly as long because in zlong
+     * encoding will use at least 8 bytes
      */
     private static final long WRITE_MIN_Z_LONG_LIMIT = -1L << 48;
 
@@ -126,7 +123,7 @@ public class MessageUtils {
         int type = ByteBufUtils.readVInt(encoded);
         long messageId = ByteBufUtils.readVLong(encoded);
         long replyMessageId = -1;
-      
+
         Map<String, Object> params = new HashMap<>();
         while (encoded.isReadable()) {
             byte opcode = encoded.readByte();


### PR DESCRIPTION
this is the fix for #230.
Just put primary key columns as first columns in the Schema we are providing to Calcite.
This way DataAccessForFullRecord can leverage natural sort of data in memory