### PR TITLE
 Fix corner case of follower with snapshot at (X,-1) 

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1342,10 +1342,10 @@ public class TableSpaceManager {
             logSequenceNumber = log.getLastSequenceNumber();
 
             if (logSequenceNumber.isStartOfTime()) {
-                LOGGER.log(Level.INFO, nodeId + " checkpoint " + tableSpaceName + " at " + logSequenceNumber + ". skipped (no write ever issued to log)");
+                LOGGER.log(Level.INFO, "{0} checkpoint {1} at {2}. skipped (no write ever issued to log)", new Object[]{nodeId, tableSpaceName, logSequenceNumber});
                 return new TableSpaceCheckpoint(logSequenceNumber, checkpointsTableNameSequenceNumber);
             }
-            LOGGER.log(Level.INFO, nodeId + " checkpoint start " + tableSpaceName + " at " + logSequenceNumber);
+            LOGGER.log(Level.INFO, "{0} checkpoint start {1} at {2}", new Object[]{nodeId, tableSpaceName, logSequenceNumber});
             if (actualLogSequenceNumber == null) {
                 throw new DataStorageManagerException("actualLogSequenceNumber cannot be null");
             }

--- a/herddb-services/src/main/resources/bin/java-utils.sh
+++ b/herddb-services/src/main/resources/bin/java-utils.sh
@@ -71,7 +71,7 @@ shift
 
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
   CONSOLE_OUTPUT_FILE=$SERVICE.service.log  
-  nohup $JAVA -cp $CLASSPATH $JAVA_OPTS "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
+  nohup $JAVA -cp $CLASSPATH $JAVA_OPTS "$@" >> "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
   RETVAL=$?
 else    
   exec $JAVA -cp $CLASSPATH $JAVA_OPTS "$@"


### PR DESCRIPTION
It happened in a test environment that a follower made a valid checkpoint at position (X,-1).
We should not issues reads to BK with entryId = -1, it will result in a  BKIncorrectParameterException