### PR TITLE
Use Arrays#compare(byte[],byte[]) when running on JDK9

### DIFF
--- a/herddb-utils/pom.xml
+++ b/herddb-utils/pom.xml
@@ -23,4 +23,57 @@
             <artifactId>lz4</artifactId>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>jdk9</id>
+                                    <goals>
+                                        <goal>compile</goal>
+                                    </goals>
+                                    <configuration>
+                                        <release>9</release>
+                                        <compileSourceRoots>
+                                            <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                                        </compileSourceRoots>
+                                        <outputDirectory>${project.build.outputDirectory}/META-INF/versions/9</outputDirectory>
+                                        <compilerArgs>
+                                            <arg>--patch-module</arg>
+                                            <arg>example.mrjar=${project.build.outputDirectory}</arg>
+                                        </compilerArgs>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-jar-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-jar</id>
+                                    <configuration>
+                                        <archive>
+                                            <manifestEntries>
+                                                <Multi-Release>true</Multi-Release>
+                                            </manifestEntries>
+                                        </archive>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -36,7 +36,7 @@ import java.nio.ByteOrder;
 public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public static final Bytes POSITIVE_INFINITY = new Bytes(new byte[0]);
-    
+
     private static final boolean UNALIGNED = PlatformDependent.isUnaligned();
     private static final boolean HAS_UNSAFE = PlatformDependent.hasUnsafe();
     private static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
@@ -227,38 +227,38 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         }
 
         return ((long) array[index] & 0xff) << 56
-            | //
-            ((long) array[index + 1] & 0xff) << 48
-            | //
-            ((long) array[index + 2] & 0xff) << 40
-            | //
-            ((long) array[index + 3] & 0xff) << 32
-            | //
-            ((long) array[index + 4] & 0xff) << 24
-            | //
-            ((long) array[index + 5] & 0xff) << 16
-            | //
-            ((long) array[index + 6] & 0xff) << 8
-            | //
-            (long) array[index + 7] & 0xff;
+                | //
+                ((long) array[index + 1] & 0xff) << 48
+                | //
+                ((long) array[index + 2] & 0xff) << 40
+                | //
+                ((long) array[index + 3] & 0xff) << 32
+                | //
+                ((long) array[index + 4] & 0xff) << 24
+                | //
+                ((long) array[index + 5] & 0xff) << 16
+                | //
+                ((long) array[index + 6] & 0xff) << 8
+                | //
+                (long) array[index + 7] & 0xff;
     }
 
     public static int compareInt(byte[] array, int index, int value) {
         return Integer.compare(toInt(array, index), value);
     }
-    
+
     public static int compareInt(byte[] array, int index, long value) {
         return Long.compare(toInt(array, index), value);
     }
-    
+
     public static int compareLong(byte[] array, int index, int value) {
         return Long.compare(toLong(array, index), value);
     }
-    
+
     public static int compareLong(byte[] array, int index, long value) {
         return Long.compare(toLong(array, index), value);
     }
-    
+
     public static int toInt(byte[] array, int index) {
         if (HAS_UNSAFE && UNALIGNED) {
             int v = PlatformDependent.getInt(array, index);
@@ -266,12 +266,12 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         }
 
         return ((int) array[index] & 0xff) << 24
-            | //
-            ((int) array[index + 1] & 0xff) << 16
-            | //
-            ((int) array[index + 2] & 0xff) << 8
-            | //
-            (int) array[index + 3] & 0xff;
+                | //
+                ((int) array[index + 1] & 0xff) << 16
+                | //
+                ((int) array[index + 2] & 0xff) << 8
+                | //
+                (int) array[index + 3] & 0xff;
     }
 
     public static java.sql.Timestamp toTimestamp(byte[] bytes, int offset) {
@@ -297,18 +297,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         } else if (o == POSITIVE_INFINITY) {
             return -1;
         }
-        return compare(this.data, o.data);
-    }
-
-    public static int compare(byte[] left, byte[] right) {
-        for (int i = 0, j = 0; i < left.length && j < right.length; i++, j++) {
-            int a = (left[i] & 0xff);
-            int b = (right[j] & 0xff);
-            if (a != b) {
-                return a - b;
-            }
-        }
-        return left.length - right.length;
+        return CompareBytesUtils.compare(this.data, o.data);
     }
 
     public static boolean startsWith(byte[] left, int len, byte[] right) {

--- a/herddb-utils/src/main/java/herddb/utils/CompareBytesUtils.java
+++ b/herddb-utils/src/main/java/herddb/utils/CompareBytesUtils.java
@@ -1,0 +1,49 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.utils;
+
+import java.util.logging.Logger;
+
+/**
+ * Java 8 compatibile version. In Java 8 you cannot use Arrays.compare(byte[],
+ * byte[])
+ */
+public final class CompareBytesUtils {
+
+    private static final Logger LOG = Logger.getLogger(CompareBytesUtils.class.getName());
+
+    static {
+        LOG.info("Not Using Arrays#compare(byte[], byte[]). Using legacy pure-Java implementation, use JDK10 in order to get best performances");
+    }
+
+    private CompareBytesUtils() {
+    }
+
+    public static int compare(byte[] left, byte[] right) {
+        for (int i = 0, j = 0; i < left.length && j < right.length; i++, j++) {
+            int a = (left[i] & 0xff);
+            int b = (right[j] & 0xff);
+            if (a != b) {
+                return a - b;
+            }
+        }
+        return left.length - right.length;
+    }
+}

--- a/herddb-utils/src/main/java9/herddb/utils/CompareBytesUtils.java
+++ b/herddb-utils/src/main/java9/herddb/utils/CompareBytesUtils.java
@@ -1,0 +1,43 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.utils;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+
+/**
+ * Java 9 compatibile version. Use Arrays.compare(byte[], byte[]) which leverage
+ * HotSpot intrisicts
+ */
+public final class CompareBytesUtils {
+
+    private static final Logger LOG = Logger.getLogger(CompareBytesUtils.class.getName());
+
+    static {
+        LOG.info("Using Arrays#compare(byte[], byte[])");
+    }
+
+    private CompareBytesUtils() {
+    }
+
+    public static int compare(byte[] left, byte[] right) {
+        return Arrays.compare(left, right);
+    }
+}

--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -109,6 +109,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>                                   
                                 </transformer>
                             </transformers>
                             <filters>

--- a/jmh/src/main/java/herddb/core/CompareByteWithJava9.java
+++ b/jmh/src/main/java/herddb/core/CompareByteWithJava9.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2014, Oracle America, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Oracle nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package herddb.core;
+
+import herddb.utils.Bytes;
+import herddb.utils.CompareBytesUtils;
+import java.math.BigInteger;
+import java.util.Arrays;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+@Fork(1)
+@State(Scope.Benchmark)
+public class CompareByteWithJava9 {
+
+    byte[] LONG_ARRAY_1;
+    byte[] LONG_ARRAY_2;
+
+    @Param({"8" /*long 8bytes pk*/, "500" /*email address as PK*/})
+    public int arraySize;
+
+    @Param({
+//        "first", 
+        "middle"
+//        "last", "none"
+    })
+    public String mismatchPoint;
+
+    @Setup
+    public void setup() throws Exception {
+
+        LONG_ARRAY_1 = new byte[arraySize];
+        for (int i = 0; i < LONG_ARRAY_1.length; i++) {
+            LONG_ARRAY_1[i] = (byte) i;
+        }
+        LONG_ARRAY_2 = new byte[arraySize];
+        System.arraycopy(LONG_ARRAY_1, 0, LONG_ARRAY_2, 0, arraySize);
+        switch (mismatchPoint) {
+            case "first":
+                LONG_ARRAY_1[0] = 4;
+                LONG_ARRAY_2[0] = 8;
+                break;
+            case "middle":
+                LONG_ARRAY_1[LONG_ARRAY_1.length / 2] = 4;
+                LONG_ARRAY_2[LONG_ARRAY_2.length / 2] = 8;
+                break;
+            case "last":
+                LONG_ARRAY_1[LONG_ARRAY_1.length - 1] = 4;
+                LONG_ARRAY_2[LONG_ARRAY_2.length - 1] = 8;
+                break;
+            case "none":
+                // equals
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+
+        System.out.println();
+        System.out.println("LONG ARRAY1: " + new BigInteger(LONG_ARRAY_1).toString(16));
+        System.out.println("LONG ARRAY2: " + new BigInteger(LONG_ARRAY_2).toString(16));
+    }
+
+    @TearDown
+    public void tearDown() {
+
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int compareComparator() throws Exception {
+        return CompareBytesUtils.compare(LONG_ARRAY_1, LONG_ARRAY_2);        
+    }
+}


### PR DESCRIPTION
In herddb-utils create a multi release JAR while building on JDK9 onwards.
In that multi release Jar we are adding a special version of CompareBytesUtils which leverages Arrays#compare which is a new method introduced in JDK9 instinsified by HotSpot.

Add a minimal JMH benchmark which demonstrates the usefulness of this change.
If will make PK look ups on large keys faster, no real difference with PKs of 4-8 bytes (see the implementation of Arrays#compareTo)

