### PR TITLE
Share tcp connections

### DIFF
--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 public class HDBConnection implements AutoCloseable {
 
     private final Map<String, RoutedClientSideConnection> routes = new HashMap<>();
-    private final AtomicLong IDGENERATOR = new AtomicLong();
+    private final static AtomicLong IDGENERATOR = new AtomicLong();
     private final long id = IDGENERATOR.incrementAndGet();
     private final HDBClient client;
     private final ReentrantLock routesLock = new ReentrantLock(true);
@@ -103,12 +103,12 @@ public class HDBConnection implements AutoCloseable {
             try {
                 RoutedClientSideConnection route = getRouteToTableSpace(tableSpace);
                 try (ScanResultSet result = route.executeScan(tableSpace,
-                    "select * "
-                    + "from systablespaces "
-                    + "where tablespace_name=?",
-                    Arrays.asList(tableSpace), TransactionContext.NOTRANSACTION_ID,
-                    1,
-                    1);) {
+                        "select * "
+                        + "from systablespaces "
+                        + "where tablespace_name=?",
+                        Arrays.asList(tableSpace), TransactionContext.NOTRANSACTION_ID,
+                        1,
+                        1);) {
                     boolean ok = result.hasNext();
                     if (ok) {
                         LOGGER.log(Level.INFO, "table space {0} is up now: info {1}", new Object[]{tableSpace,
@@ -250,7 +250,7 @@ public class HDBConnection implements AutoCloseable {
     }
 
     public void dumpTableSpace(String tableSpace, TableSpaceDumpReceiver receiver, int fetchSize,
-        boolean includeTransactionLog) throws ClientSideMetadataProviderException, HDBException, InterruptedException {
+            boolean includeTransactionLog) throws ClientSideMetadataProviderException, HDBException, InterruptedException {
         RoutedClientSideConnection route = getRouteToTableSpace(tableSpace);
         route.dumpTableSpace(tableSpace, fetchSize, includeTransactionLog, receiver);
     }

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -747,7 +747,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             if (saslNettyServer.isComplete()) {
                 username = saslNettyServer.getUserName();
                 authenticated = true;
-                LOGGER.log(Level.INFO, "client {0} completed SASL authentication as {1}", new Object[]{channel, username});
+                LOGGER.log(Level.INFO, "client {0} connected as '{1}'", new Object[]{channel.getRemoteAddress(), username});
                 saslNettyServer = null;
             }
             _channel.sendReplyMessage(message, tokenChallenge);

--- a/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
@@ -263,13 +263,11 @@ public class BasicHerdDBDataSource implements javax.sql.DataSource, AutoCloseabl
         @Override
         public PooledObject<HerdDBConnection> makeObject() throws Exception {
             HerdDBConnection res = new HerdDBConnection(BasicHerdDBDataSource.this, getHDBConnection(), defaultSchema);
-            LOGGER.log(Level.SEVERE, "makeObject {0}", res);
             return new DefaultPooledObject<>(res);
         }
 
         @Override
         public void destroyObject(PooledObject<HerdDBConnection> po) throws Exception {
-            LOGGER.log(Level.SEVERE, "destroyObject {0}", po.getObject());
             po.getObject().close();
         }
 
@@ -281,7 +279,6 @@ public class BasicHerdDBDataSource implements javax.sql.DataSource, AutoCloseabl
         @Override
         public void activateObject(PooledObject<HerdDBConnection> po) throws Exception {
             po.getObject().reset(defaultSchema);
-            LOGGER.log(Level.SEVERE, "activateObject {0}", po.getObject());
         }
 
         @Override

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
@@ -68,9 +68,16 @@ public class HerdDBConnection implements java.sql.Connection {
         if (connection == null) {
             throw new NullPointerException();
         }
-        this.tableSpace = defaultTablespace;
         this.connection = connection;
         this.datasource = datasource;
+        reset(defaultTablespace);
+    }
+
+    final void reset(String defaultTablespace) {
+        this.autocommit = true;
+        this.tableSpace = defaultTablespace;
+        this.transactionId = 0;
+        this.closed = false;
     }
 
     long ensureTransaction() throws SQLException {
@@ -175,11 +182,12 @@ public class HerdDBConnection implements java.sql.Connection {
             return;
         }
         if (transactionId != NOTRANSACTION_ID
-            && transactionId != AUTOTRANSACTION_ID) {
+                && transactionId != AUTOTRANSACTION_ID) {
             rollback();
         }
-        this.datasource.releaseConnection(connection);
         closed = true;
+
+        datasource.releaseConnection(this);
     }
 
     @Override

--- a/herddb-jdbc/src/test/java/herddb/jdbc/ConnectionPoolMaxActiveTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/ConnectionPoolMaxActiveTest.java
@@ -42,7 +42,6 @@ import org.junit.rules.TemporaryFolder;
  */
 public class ConnectionPoolMaxActiveTest {
 
-
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -55,14 +54,13 @@ public class ConnectionPoolMaxActiveTest {
             dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
             dataSource.getProperties().setProperty(ClientConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
             try (Connection con = dataSource.getConnection();
-                Statement statement = con.createStatement();) {
+                    Statement statement = con.createStatement();) {
                 statement.execute("CREATE TABLE mytable (key string primary key, name string)");
             }
 
             Server server = dataSource.getServer();
             List<Connection> connections = new ArrayList<>();
             try {
-
                 for (int i = 0; i < 10; i++) {
                     Connection con = dataSource.getConnection();
                     connections.add(con);
@@ -70,7 +68,8 @@ public class ConnectionPoolMaxActiveTest {
                         assertEquals(1, statement.executeUpdate("INSERT INTO mytable (key,name) values('k1" + i + "','name1')"));
                     }
                 }
-                assertEquals(10, server.getConnectionCount());
+                // this is the number of sockets
+                assertEquals(1, server.getConnectionCount());
             } finally {
                 for (Connection c : connections) {
                     c.close();

--- a/herddb-net/src/main/java/herddb/network/Channel.java
+++ b/herddb-net/src/main/java/herddb/network/Channel.java
@@ -50,7 +50,7 @@ public abstract class Channel implements AutoCloseable {
 
     public abstract void sendReplyMessage(Message inAnswerTo, Message message);
 
-    public abstract void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback);
+    protected abstract void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback);
 
     public abstract void channelIdle();
 

--- a/herddb-net/src/main/java/herddb/network/netty/NettyChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyChannel.java
@@ -173,14 +173,12 @@ public class NettyChannel extends Channel {
     }
 
     @Override
-    public void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
+    protected void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
         if (message.getMessageId() < 0) {
             message.assignMessageId();
         }
         if (!isValid()) {
-            submitCallback(() -> {
-                callback.replyReceived(message, null, new Exception(this + " connection is not active"));
-            });
+            callback.replyReceived(message, null, new Exception(this + " connection is not active"));
             return;
         }
         pendingReplyMessages.put(message.getMessageId(), callback);
@@ -192,9 +190,7 @@ public class NettyChannel extends Channel {
             public void messageSent(Message originalMessage, Throwable error) {
                 if (error != null) {
                     LOGGER.log(Level.SEVERE, this + ": error while sending reply message to " + originalMessage, error);
-                    submitCallback(() -> {
-                        callback.replyReceived(message, null, new Exception(this + ": error while sending reply message to " + originalMessage, error));
-                    });
+                    callback.replyReceived(message, null, new Exception(this + ": error while sending reply message to " + originalMessage, error));
                 }
             }
         });


### PR DESCRIPTION
Use only one TCP socket per server and leverage multiplexed protocol in JDBC driver.

It is better to use a single TCP connection, the protocol itself was designed to use only one connection, but in the JDBC driver a new Channel was created per each JDBC Connection.