### PR TITLE
Save Bytes allocation on read/write path

### DIFF
--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -669,6 +669,10 @@ public final class RecordSerializer {
     }
 
     public static Bytes serializeValue(Map<String, Object> record, Table table) {
+        return new Bytes(serializeValueRaw(record, table));
+    }
+    
+    public static byte[] serializeValueRaw(Map<String, Object> record, Table table) {
         ByteArrayOutputStream value = new ByteArrayOutputStream();
         try (ExtendedDataOutputStream doo = new ExtendedDataOutputStream(value);) {
             for (Column c : table.columns) {
@@ -682,7 +686,7 @@ public final class RecordSerializer {
             throw new RuntimeException(err);
         }
 
-        return new Bytes(value.toByteArray());
+        return value.toByteArray();
     }
 
     public static Record toRecord(Map<String, Object> record, Table table) {

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
@@ -20,6 +20,7 @@
 package herddb.sql;
 
 import herddb.codec.RecordSerializer;
+import static herddb.codec.RecordSerializer.serializeValue;
 import herddb.model.Record;
 import herddb.model.RecordFunction;
 import herddb.model.StatementEvaluationContext;
@@ -63,7 +64,8 @@ public class SQLRecordFunction extends RecordFunction {
         try {
             Map<String, Object> res = previous != null ? new HashMap<>(previous.toBean(table)) : new HashMap<>();
             DataAccessor bean = previous != null ? previous.getDataAccessor(table) : DataAccessor.NULL;
-            for (int i = 0; i < columns.size(); i++) {
+            final int size = columns.size();
+            for (int i = 0; i < size; i++) {
                 CompiledSQLExpression e = expressions.get(i);
                 String columnName = columns.get(i);
                 herddb.model.Column column = table.getColumn(columnName);
@@ -74,7 +76,7 @@ public class SQLRecordFunction extends RecordFunction {
                 Object value = RecordSerializer.convert(column.type, e.evaluate(bean, context));
                 res.put(columnName, value);
             }
-            return RecordSerializer.toRecord(res, table).value.data;
+            return RecordSerializer.serializeValueRaw(res, table);
         } catch (IllegalArgumentException err) {
             throw new StatementExecutionException(err);
         }

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
@@ -82,9 +82,10 @@ public class SQLRecordKeyFunction extends RecordFunction {
     public SQLRecordKeyFunction(List<String> expressionToColumn,
             List<CompiledSQLExpression> expressions, ColumnsList table) {
         this.table = table;
-        this.columns = new Column[expressions.size()];
+        final int size = expressions.size();
+        this.columns = new Column[size];
         this.expressions = new ArrayList<>();
-        this.pkColumnNames = new String[expressions.size()];
+        this.pkColumnNames = new String[size];
         int i = 0;
         boolean constant = true;
         for (String cexp : expressionToColumn) {
@@ -123,8 +124,8 @@ public class SQLRecordKeyFunction extends RecordFunction {
             }
         }
 
-        Map<String, Object> pk = new HashMap<>();
-        for (int i = 0; i < expressions.size(); i++) {
+        Map<String, Object> pk = new HashMap<>();        
+        for (int i = 0; i < columns.length; i++) {
             herddb.model.Column c = columns[i];
             CompiledSQLExpression expression = expressions.get(i);
             Object value = expression.evaluate(DataAccessor.NULL, context);
@@ -150,7 +151,7 @@ public class SQLRecordKeyFunction extends RecordFunction {
             if (i > 0) {
                 b.append(" AND ");
             }
-            b.append(pkColumnNames[i] + "=" + expressions.get(i));
+            b.append(pkColumnNames[i]).append("=").append(expressions.get(i));
         }
         return b.toString();
 

--- a/ycsb-runner/prepare.sh
+++ b/ycsb-runner/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd ..
-JAVA_HOME=/usr/java/current10 mvn clean install -DskipTests
+JAVA_HOME=~/dev/jdk-11 mvn clean install -DskipTests
 cd herddb-services/target
 unzip herddb-services*zip
 cd ../../ycsb-runner
-cp setsenv_bench_jdk10.sh ../herddb-services/target/herddb-service*-SNAPSHOT/bin/setenv.sh
+cp setsenv_bench_jdk11.sh ../herddb-services/target/herddb-service*-SNAPSHOT/bin/setenv.sh


### PR DESCRIPTION
This change saves a lot of allocation an useless serialization on SQLRecordFunction, used both on read and write paths (and index seek/scan paths)