### PR TITLE
Save resources by saving a PrimaryKey lookup inside applyInsert

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -117,29 +117,30 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private static final Logger LOGGER = Logger.getLogger(TableManager.class.getName());
 
     private static final long CHECKPOINT_LOCK_WRITE_TIMEOUT = SystemProperties.
-        getIntSystemProperty("herddb.tablemanager.checkpoint.lock.write.timeout", 60);
+            getIntSystemProperty("herddb.tablemanager.checkpoint.lock.write.timeout", 60);
 
     private static final long CHECKPOINT_LOCK_READ_TIMEOUT = SystemProperties.
-        getIntSystemProperty("herddb.tablemanager.checkpoint.lock.read.timeout", 10);
+            getIntSystemProperty("herddb.tablemanager.checkpoint.lock.read.timeout", 10);
 
     private static final int SORTED_PAGE_ACCESS_WINDOW_SIZE = SystemProperties.
-        getIntSystemProperty("herddb.tablemanager.sortedPageAccessWindowSize", 2000);
+            getIntSystemProperty("herddb.tablemanager.sortedPageAccessWindowSize", 2000);
 
     private static final boolean ENABLE_LOCAL_SCAN_PAGE_CACHE = SystemProperties.
-        getBooleanSystemProperty("herddb.tablemanager.enableLocalScanPageCache", true);
+            getBooleanSystemProperty("herddb.tablemanager.enableLocalScanPageCache", true);
 
     private static final int HUGE_TABLE_SIZE_FORCE_MATERIALIZED_RESULTSET = SystemProperties.
-        getIntSystemProperty("herddb.tablemanager.hugeTableSizeForceMaterializedResultSet", 100_000);
+            getIntSystemProperty("herddb.tablemanager.hugeTableSizeForceMaterializedResultSet", 100_000);
 
     private static final boolean ENABLE_STREAMING_DATA_SCANNER = SystemProperties.
-        getBooleanSystemProperty("herddb.tablemanager.enableStreamingDataScanner", true);
+            getBooleanSystemProperty("herddb.tablemanager.enableStreamingDataScanner", true);
 
     private final ConcurrentMap<Long, DataPage> newPages;
 
     private final ConcurrentMap<Long, DataPage> pages;
 
     /**
-     * A structure which maps each key to the ID of the page (map<byte[], long>) (this can be quite large)
+     * A structure which maps each key to the ID of the page (map<byte[], long>)
+     * (this can be quite large)
      */
     private final KeyToPageIndex keyToPage;
 
@@ -207,7 +208,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private final Semaphore maxCurrentPagesLoads = new Semaphore(4, true);
 
     /**
-     * This value is not empty until the transaction who creates the table does not commit
+     * This value is not empty until the transaction who creates the table does
+     * not commit
      */
     private long createdInTransaction;
 
@@ -235,7 +237,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
     void prepareForRestore(LogSequenceNumber dumpLogSequenceNumber) {
         LOGGER.log(Level.SEVERE, "Table " + table.name + ", receiving dump,"
-            + "done at external logPosition " + dumpLogSequenceNumber);
+                + "done at external logPosition " + dumpLogSequenceNumber);
         this.dumpLogSequenceNumber = dumpLogSequenceNumber;
     }
 
@@ -311,8 +313,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     TableManager(Table table, CommitLog log, MemoryManager memoryManager,
-        DataStorageManager dataStorageManager, TableSpaceManager tableSpaceManager, String tableSpaceUUID,
-        long createdInTransaction) throws DataStorageManagerException {
+            DataStorageManager dataStorageManager, TableSpaceManager tableSpaceManager, String tableSpaceUUID,
+            long createdInTransaction) throws DataStorageManagerException {
         this.stats = new TableManagerStatsImpl();
 
         this.log = log;
@@ -332,22 +334,22 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         this.newPages = new ConcurrentHashMap<>();
 
         this.dirtyThreshold = tableSpaceManager.getDbmanager().getServerConfiguration().getDouble(
-            ServerConfiguration.PROPERTY_DIRTY_PAGE_THRESHOLD,
-            ServerConfiguration.PROPERTY_DIRTY_PAGE_THRESHOLD_DEFAULT);
+                ServerConfiguration.PROPERTY_DIRTY_PAGE_THRESHOLD,
+                ServerConfiguration.PROPERTY_DIRTY_PAGE_THRESHOLD_DEFAULT);
 
         this.fillThreshold = tableSpaceManager.getDbmanager().getServerConfiguration().getDouble(
-            ServerConfiguration.PROPERTY_FILL_PAGE_THRESHOLD,
-            ServerConfiguration.PROPERTY_FILL_PAGE_THRESHOLD_DEFAULT);
+                ServerConfiguration.PROPERTY_FILL_PAGE_THRESHOLD,
+                ServerConfiguration.PROPERTY_FILL_PAGE_THRESHOLD_DEFAULT);
 
         long checkpointTargetTime = tableSpaceManager.getDbmanager().getServerConfiguration().getLong(
-            ServerConfiguration.PROPERTY_CHECKPOINT_DURATION,
-            ServerConfiguration.PROPERTY_CHECKPOINT_DURATION_DEFAULT);
+                ServerConfiguration.PROPERTY_CHECKPOINT_DURATION,
+                ServerConfiguration.PROPERTY_CHECKPOINT_DURATION_DEFAULT);
 
         this.checkpointTargetTime = checkpointTargetTime < 0 ? Long.MAX_VALUE : checkpointTargetTime;
 
         long compactionTargetTime = tableSpaceManager.getDbmanager().getServerConfiguration().getLong(
-            ServerConfiguration.PROPERTY_COMPACTION_DURATION,
-            ServerConfiguration.PROPERTY_COMPACTION_DURATION_DEFAULT);
+                ServerConfiguration.PROPERTY_COMPACTION_DURATION,
+                ServerConfiguration.PROPERTY_COMPACTION_DURATION_DEFAULT);
 
         this.compactionTargetTime = compactionTargetTime < 0 ? Long.MAX_VALUE : compactionTargetTime;
     }
@@ -431,7 +433,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             // non persistent primary key index, we need a full table scan
             LOGGER.log(Level.SEVERE, "loading in memory all the keys for table {0}", new Object[]{table.name});
             dataStorageManager.fullTableScan(tableSpaceUUID, table.uuid,
-                new FullTableScanConsumer() {
+                    new FullTableScanConsumer() {
 
                 Long currentPage;
 
@@ -485,7 +487,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
         initNewPage();
         LOGGER.log(Level.SEVERE, "loaded {0} keys for table {1}, newPageId {2}, nextPrimaryKeyValue {3}, activePages {4}",
-            new Object[]{keyToPage.size(), table.name, nextPageId, nextPrimaryKeyValue.get(), pageSet.getActivePages() + ""});
+                new Object[]{keyToPage.size(), table.name, nextPageId, nextPrimaryKeyValue.get(), pageSet.getActivePages() + ""});
 
         started = true;
     }
@@ -534,8 +536,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     /**
      * Create a new page with given data, save it and update keyToPage records
      * <p>
-     * Will not place any lock, this method should be invoked at startup time or during checkpoint: <b>during
-     * "stop-the-world" procedures!</b>
+     * Will not place any lock, this method should be invoked at startup time or
+     * during checkpoint: <b>during "stop-the-world" procedures!</b>
      * </p>
      */
     private long createImmutablePage(Map<Bytes, Record> newPage, long newPageSize) throws DataStorageManagerException {
@@ -543,7 +545,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         final DataPage dataPage = buildImmutableDataPage(pageId, newPage, newPageSize);
 
         LOGGER.log(Level.FINER, "createNewPage table {0}, pageId={1} with {2} records, {3} logical page size",
-            new Object[]{table.name, pageId, newPage.size(), newPageSize});
+                new Object[]{table.name, pageId, newPage.size(), newPageSize});
         dataStorageManager.writePage(tableSpaceUUID, table.uuid, pageId, newPage.values());
         pageSet.pageCreated(pageId, dataPage);
         pages.put(pageId, dataPage);
@@ -650,7 +652,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
     @Override
     public void unload(long pageId) {
-        pages.computeIfPresent(pageId, (k,remove) -> {
+        pages.computeIfPresent(pageId, (k, remove) -> {
 
             unloadedPagesCount.increment();
             LOGGER.log(Level.FINER, "table {0} removed page {1}, {2}", new Object[]{table.name, pageId, remove.getUsedMemory() / (1024 * 1024) + " MB"});
@@ -662,10 +664,10 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
             if (dataFlushed) {
                 LOGGER.log(Level.FINER, "table {0} remove and save 'new' page {1}, {2}",
-                        new Object[] {table.name, remove.pageId, remove.getUsedMemory() / (1024 * 1024) + " MB"});
+                        new Object[]{table.name, remove.pageId, remove.getUsedMemory() / (1024 * 1024) + " MB"});
             } else {
                 LOGGER.log(Level.FINER, "table {0} unload page {1}, {2}",
-                        new Object[] {table.name, pageId, remove.getUsedMemory() / (1024 * 1024) + " MB"});
+                        new Object[]{table.name, pageId, remove.getUsedMemory() / (1024 * 1024) + " MB"});
             }
 
             return null;
@@ -673,12 +675,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         );
     }
 
-
     /**
-     * Remove the page from {@link #newPages}, set it as "unloaded" and write it to disk
+     * Remove the page from {@link #newPages}, set it as "unloaded" and write it
+     * to disk
      * <p>
-     * Add as much spare data as possible to fillup the page. If added must change key to page pointers too for spare
-     * data
+     * Add as much spare data as possible to fillup the page. If added must
+     * change key to page pointers too for spare data
      * </p>
      *
      * @param page new page to flush
@@ -697,28 +699,30 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     /**
-     * Remove the page from {@link #newPages}, set it as "unloaded" and write it to
-     * disk
+     * Remove the page from {@link #newPages}, set it as "unloaded" and write it
+     * to disk
      *
      * @param page new page to flush
-     * @return {@code true} if the page has been flushed, {@code false} if already
-     *         flushed by another thread
+     * @return {@code true} if the page has been flushed, {@code false} if
+     * already flushed by another thread
      */
     private boolean flushNewPageForUnload(DataPage page) {
         return flushNewPage(page, Collections.emptyMap()) != -1;
     }
 
     /**
-     * Remove the page from {@link #newPages}, set it as "unloaded" and write it to disk
+     * Remove the page from {@link #newPages}, set it as "unloaded" and write it
+     * to disk
      * <p>
-     * Add as much spare data as possible to fillup the page. If added must change key to page pointers too for spare
-     * data
+     * Add as much spare data as possible to fillup the page. If added must
+     * change key to page pointers too for spare data
      * </p>
      *
      * @param page new page to flush
      * @param spareData old spare data to fit in the new page if possible
      * @return spare memory size used (and removed), {@code 0} if no spare used,
-     *         {@code -1L} if no flush has been done because the page isn't writable anymore
+     * {@code -1L} if no flush has been done because the page isn't writable
+     * anymore
      */
     private long flushNewPage(DataPage page, Map<Bytes, Record> spareData) {
 
@@ -756,9 +760,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
              * lock we can't known if no page has been removed because already removed by a
              * concurrent thread or because it wasn't present in the first place.
              */
-
-
-            /* Set the new page as a fully active page */
+ /* Set the new page as a fully active page */
             pageSet.pageCreated(page.pageId, page);
 
             /* Remove it from "new" pages */
@@ -791,7 +793,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
         long spareUsedMemory = page.getUsedMemory() - usedMemory;
         LOGGER.log(Level.FINER, "flushNewPage table {0}, pageId={1} with {2} records, {3} logical page size",
-            new Object[]{table.name, page.pageId, page.size(), page.getUsedMemory()});
+                new Object[]{table.name, page.pageId, page.size(), page.getUsedMemory()});
         dataStorageManager.writePage(tableSpaceUUID, table.uuid, page.pageId, page.data.values());
 
         return spareUsedMemory;
@@ -853,7 +855,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             try {
                 DataAccessor values = new Record(key, Bytes.from_array(value)).getDataAccessor(table);
                 for (AbstractIndexManager index : indexes.values()) {
-                   RecordSerializer.validatePrimaryKey(values, index.getIndex(), index.getColumnNames());
+                    RecordSerializer.validatePrimaryKey(values, index.getIndex(), index.getColumnNames());
                 }
             } catch (IllegalArgumentException err) {
                 throw new StatementExecutionException(err.getMessage(), err);
@@ -946,7 +948,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     try {
                         DataAccessor values = new Record(actual.key, Bytes.from_array(newValue)).getDataAccessor(table);
                         for (AbstractIndexManager index : indexes.values()) {
-                           RecordSerializer.validatePrimaryKey(values, index.getIndex(), index.getColumnNames());
+                            RecordSerializer.validatePrimaryKey(values, index.getIndex(), index.getColumnNames());
                         }
                     } catch (IllegalArgumentException err) {
                         throw new StatementExecutionException(err.getMessage(), err);
@@ -955,8 +957,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 final long size = DataPage.estimateEntrySize(actual.key, newValue);
                 if (size > maxLogicalPageSize) {
                     throw new RecordTooBigException("New version of record " + actual.key
-                        + " is to big to be update: new size " + size + ", actual size " + DataPage.estimateEntrySize(actual)
-                        + ", max size " + maxLogicalPageSize);
+                            + " is to big to be update: new size " + size + ", actual size " + DataPage.estimateEntrySize(actual)
+                            + ", max size " + maxLogicalPageSize);
                 }
 
                 LogEntry entry = LogEntryFactory.update(table, actual.key.data, newValue, transaction);
@@ -969,7 +971,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         }, transaction, true, true);
 
         return new DMLStatementExecutionResult(transactionId, updateCount.get(), lastKey.value,
-            update.isReturnValues() ? (lastValue.value != null ? Bytes.from_array(lastValue.value) : null) : null);
+                update.isReturnValues() ? (lastValue.value != null ? Bytes.from_array(lastValue.value) : null) : null);
 
     }
 
@@ -995,7 +997,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
         }, transaction, true, true);
         return new DMLStatementExecutionResult(transactionId, updateCount.get(), lastKey.value,
-            delete.isReturnValues() ? (lastValue.value != null ? Bytes.from_array(lastValue.value) : null) : null);
+                delete.isReturnValues() ? (lastValue.value != null ? Bytes.from_array(lastValue.value) : null) : null);
     }
 
     private StatementExecutionResult executeTruncate(TruncateTableStatement truncate, Transaction transaction, StatementEvaluationContext context) throws StatementExecutionException, DataStorageManagerException {
@@ -1009,7 +1011,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             CommitLogResult pos = log.log(entry, entry.transactionId <= 0);
             apply(pos, entry, false);
             return new DMLStatementExecutionResult(0, estimatedSize > Integer.MAX_VALUE
-                ? Integer.MAX_VALUE : (int) estimatedSize, null, null);
+                    ? Integer.MAX_VALUE : (int) estimatedSize, null, null);
         } catch (LogNotAvailableException error) {
             throw new StatementExecutionException(error);
         }
@@ -1024,14 +1026,14 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         }
         if (tableSpaceManager.isTransactionRunningOnTable(table.name)) {
             throw new DataStorageManagerException("TRUNCATE TABLE cannot be executed table " + table.name
-                + ": at least one transaction is pending on it");
+                    + ": at least one transaction is pending on it");
         }
         Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
         if (indexes != null) {
             for (AbstractIndexManager index : indexes.values()) {
                 if (!index.isAvailable()) {
                     throw new DataStorageManagerException("index " + index.getIndexName()
-                        + " in not full available. Cannot TRUNCATE table " + table.name);
+                            + " in not full available. Cannot TRUNCATE table " + table.name);
                 }
             }
         }
@@ -1039,8 +1041,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         /* Do not unload the current working page not known to replacement policy */
         final long currentDirtyPageId = currentDirtyRecordsPage.get();
         final List<DataPage> unload = pages.values().stream()
-            .filter(page -> page.pageId != currentDirtyPageId)
-            .collect(Collectors.toList());
+                .filter(page -> page.pageId != currentDirtyPageId)
+                .collect(Collectors.toList());
 
         pageReplacementPolicy.remove(unload);
 
@@ -1121,7 +1123,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
     @Override
     public void apply(CommitLogResult writeResult, LogEntry entry, boolean recovery) throws DataStorageManagerException,
-        LogNotAvailableException {
+            LogNotAvailableException {
         if (recovery) {
             if (writeResult.deferred) {
                 throw new DataStorageManagerException("impossibile to have a deferred CommitLogResult during recovery");
@@ -1410,7 +1412,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
     @Override
     public void dropTableData() throws DataStorageManagerException {
-        dataStorageManager.dropTable(tableSpaceUUID, table.uuid);        
+        dataStorageManager.dropTable(tableSpaceUUID, table.uuid);
         keyToPage.truncate();
         final Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
         if (indexes != null) {
@@ -1470,9 +1472,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         LOGGER.log(Level.SEVERE, "rebuildNextPrimaryKeyValue");
         try {
             Stream<Entry<Bytes, Long>> scanner = keyToPage.scanner(null,
-                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                tableContext,
-                null);
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    tableContext,
+                    null);
             scanner.forEach((Entry<Bytes, Long> t) -> {
                 Bytes key = t.getKey();
                 long pk_logical_value;
@@ -1507,146 +1509,52 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
          */
         final Record record = new Record(key, value);
 
-        /* Normally we expect this value null or pointing to a temporary modifiable page */
-        final Long prevPageId = keyToPage.get(key);
+        /* Do real insertion */
+        Long insertionPageId = currentDirtyRecordsPage.get();
 
-        final Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
+        while (true) {
+            final DataPage newPage = newPages.get(insertionPageId);
 
-        /*
-         * When index is enabled we need the old value to update them, we'll force the page load only if that
-         * record is really needed.
-         */
-        final DataPage prevPage;
-        final Record previous;
-        boolean insertedInSamePage = false;
-        if (prevPageId != null) {
+            if (newPage != null) {
+                pageReplacementPolicy.pageHit(newPage);
 
-            /* Very strage but possible inside a transaction which executes DELETE THEN INSERT */
-            if (!onTransaction) {
-                throw new DataStorageManagerException("new record " + key + " already present in keyToPage?");
-            }
-
-            if (indexes == null) {
-                /* We don't need the page if isn't loaded or isn't a mutable new page*/
-                prevPage = newPages.get(prevPageId);
-                previous = null;
-
-                if (prevPage != null) {
-                    pageReplacementPolicy.pageHit(prevPage);
-                }
-
-            } else {
-                /* We really need the page for update index old values */
-                prevPage = loadPageToMemory(prevPageId, false);
-                previous = prevPage.get(key);
-
-                if (previous == null) {
-                    throw new RuntimeException("insert upon delete record at " + key + " was not found?");
-                }
-            }
-
-            if (prevPage == null || prevPage.immutable) {
-                /* Unloaded or immutable, set it as dirty */
-                pageSet.setPageDirty(prevPageId, previous);
-            } else {
-                /* Mutable page, need to check if still modifiable or already unloaded */
-                final Lock lock = prevPage.pageLock.readLock();
-                lock.lock();
-                try {
-                    if (prevPage.writable) {
-                        /* We can try to modify the page directly */
-                        insertedInSamePage = prevPage.put(record);
-                    } else {
-                        /* Unfortunately is not writable (anymore), set it as dirty */
-                        pageSet.setPageDirty(prevPageId, previous);
-                    }
-                } finally {
-                    lock.unlock();
-                }
-            }
-
-        } else {
-            /*
-             * Initialize previous record to null... Non really needed but otherwise compiler cannot compile
-             * indexing instructions below.
-             */
-            previous = null;
-        }
-
-        /* Insertion page */
-        Long insertionPageId;
-
-        if (insertedInSamePage) {
-            /* Inserted in temporary mutable previous page, no need to alter keyToPage too: no record page change */
-            insertionPageId = prevPageId;
-        } else {
-            /* Do real insertion */
-            insertionPageId = currentDirtyRecordsPage.get();
-
-            while (true) {
-                final DataPage newPage = newPages.get(insertionPageId);
-
-                if (newPage != null) {
-                    pageReplacementPolicy.pageHit(newPage);
-
-                    /* The temporary memory page could have been unloaded and loaded again in meantime */
-                    if (!newPage.immutable) {
-                        /* Mutable page, need to check if still modifiable or already unloaded */
-                        final Lock lock = newPage.pageLock.readLock();
-                        lock.lock();
-                        try {
-                            if (newPage.writable) {
-                                /* We can try to modify the page directly */
-                                if (newPage.put(record)) {
-                                    break;
-                                }
+                /* The temporary memory page could have been unloaded and loaded again in meantime */
+                if (!newPage.immutable) {
+                    /* Mutable page, need to check if still modifiable or already unloaded */
+                    final Lock lock = newPage.pageLock.readLock();
+                    lock.lock();
+                    try {
+                        if (newPage.writable) {
+                            /* We can try to modify the page directly */
+                            if (newPage.put(record)) {
+                                break;
                             }
-                        } finally {
-                            lock.unlock();
                         }
-
+                    } finally {
+                        lock.unlock();
                     }
-                }
 
-                /* Try allocate a new page if no already done */
-                insertionPageId = allocateLivePage(insertionPageId);
+                }
             }
 
-            /* Insert/update the value on keyToPage */
-            keyToPage.put(key, insertionPageId);
+            /* Try allocate a new page if no already done */
+            insertionPageId = allocateLivePage(insertionPageId);
         }
+
+        /* Insert  the value on keyToPage */
+        keyToPage.put(key, insertionPageId);
 
         if (LOGGER.isLoggable(Level.FINEST)) {
-            if (prevPageId == null) {
-                LOGGER.log(Level.FINEST, "Inserted key " + key + " into page " + insertionPageId);
-            } else {
-                LOGGER.log(Level.FINEST, "Inserted key " + key + " into page " + insertionPageId + " previously was in page " + prevPageId);
-            }
-
+            LOGGER.log(Level.FINEST, "Inserted key " + key + " into page " + insertionPageId);
         }
 
+        final Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
         if (indexes != null) {
-            if (previous == null) {
-
-                /* Standard insert */
-                DataAccessor values = record.getDataAccessor(table);
-                for (AbstractIndexManager index : indexes.values()) {
-                    Bytes indexKey = RecordSerializer.serializePrimaryKey(values, index.getIndex(), index.getColumnNames());
-                    index.recordInserted(key, indexKey);
-                }
-            } else {
-
-                /* If there is a previous page this is a delete and insert, we really need to update indexes
-                 * from old "deleted" values to the new ones. Previus record has already been loaded  */
-                DataAccessor prevValues = previous.getDataAccessor(table);
-                DataAccessor newValues = record.getDataAccessor(table);
-                for (AbstractIndexManager index : indexes.values()) {
-                    Index indexDef = index.getIndex();
-                    String[] indexColumnNames = index.getColumnNames();
-                    Bytes indexKeyRemoved = RecordSerializer.serializePrimaryKey(prevValues, indexDef, indexColumnNames);
-                    Bytes indexKeyAdded = RecordSerializer.serializePrimaryKey(newValues, indexDef, indexColumnNames);
-                    index.recordUpdated(key, indexKeyRemoved, indexKeyAdded);
-                }
+            /* Standard insert */
+            DataAccessor values = record.getDataAccessor(table);
+            for (AbstractIndexManager index : indexes.values()) {
+                Bytes indexKey = RecordSerializer.serializePrimaryKey(values, index.getIndex(), index.getColumnNames());
+                index.recordInserted(key, indexKey);
             }
         }
 
@@ -1668,8 +1576,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private StatementExecutionResult executeGet(GetStatement get, Transaction transaction,
-        StatementEvaluationContext context)
-        throws StatementExecutionException, DataStorageManagerException {
+            StatementEvaluationContext context)
+            throws StatementExecutionException, DataStorageManagerException {
         Bytes key = new Bytes(get.getKey().computeNewValue(null, context, tableContext));
         Predicate predicate = get.getPredicate();
         boolean requireLock = get.isRequireLock();
@@ -1728,9 +1636,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         if (LOGGER.isLoggable(Level.FINEST)) {
             long _stop = System.currentTimeMillis();
             LOGGER.log(Level.FINEST, "tmp table " + table.name + ","
-                + "loaded " + result.size() + " records from page " + pageId
-                + " in " + (_stop - _start) + " ms"
-                + ", (" + (_io - _start) + " ms read)");
+                    + "loaded " + result.size() + " records from page " + pageId
+                    + " in " + (_stop - _start) + " ms"
+                    + ", (" + (_io - _start) + " ms read)");
         }
         return result;
     }
@@ -1789,11 +1697,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         if (computed.get()) {
             long _stop = System.currentTimeMillis();
             LOGGER.log(Level.FINE,
-                "table " + table.name + ","
-                + "loaded " + result.size() + " records from page " + pageId
-                + " in " + (_stop - _start) + " ms"
-                + ", (" + (_ioAndLock - _start) + " ms read + plock"
-                + ", " + (_stop - _ioAndLock) + " ms unlock)");
+                    "table " + table.name + ","
+                    + "loaded " + result.size() + " records from page " + pageId
+                    + " in " + (_stop - _start) + " ms"
+                    + ", (" + (_ioAndLock - _start) + " ms read + plock"
+                    + ", " + (_stop - _ioAndLock) + " ms unlock)");
         }
         return result;
     }
@@ -1861,7 +1769,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     /**
-     * Sums two long values caring of overflows. Assumes that both values are positive!
+     * Sums two long values caring of overflows. Assumes that both values are
+     * positive!
      */
     private static final long sumOverflowWise(long a, long b) {
         long total = a + b;
@@ -1879,14 +1788,14 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      * @throws DataStorageManagerException
      */
     private TableCheckpoint checkpoint(double dirtyThreshold, double fillThreshold,
-        long checkpointTargetTime, long compactionTargetTime, boolean pin) throws DataStorageManagerException {
-        LOGGER.log(Level.INFO, "tableCheckpoint dirtyThreshold: "+dirtyThreshold+", {0}.{1} (pin: {2})", new Object[]{tableSpaceUUID, table.name, pin});
+            long checkpointTargetTime, long compactionTargetTime, boolean pin) throws DataStorageManagerException {
+        LOGGER.log(Level.INFO, "tableCheckpoint dirtyThreshold: " + dirtyThreshold + ", {0}.{1} (pin: {2})", new Object[]{tableSpaceUUID, table.name, pin});
         if (createdInTransaction > 0) {
             LOGGER.log(Level.SEVERE, "checkpoint for table " + table.name + " skipped,"
-                + "this table is created on transaction " + createdInTransaction + " which is not committed");
+                    + "this table is created on transaction " + createdInTransaction + " which is not committed");
             return null;
         }
-        
+
         final long fillPageThreshold = (long) (fillThreshold * maxLogicalPageSize);
         final long dirtyPageThreshold = (long) (dirtyThreshold * maxLogicalPageSize);
 
@@ -1911,7 +1820,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             throw new DataStorageManagerException("interrupted while waiting for checkpoint lock", err);
         }
         if (!lockAcquired) {
-            throw new DataStorageManagerException("timed out while waiting for checkpoint lock, write lock "+checkpointLock.writeLock());
+            throw new DataStorageManagerException("timed out while waiting for checkpoint lock, write lock " + checkpointLock.writeLock());
         }
         try {
 
@@ -1953,7 +1862,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
                 /* Check emptiness (with a really dirty check to avoid to rewrite an unfillable page) */
                 if (metadata.size <= fillPageThreshold
-                    && maxLogicalPageSize - metadata.avgRecordSize >= fillPageThreshold) {
+                        && maxLogicalPageSize - metadata.avgRecordSize >= fillPageThreshold) {
                     flushingSmallPages.add(new WeightedPage(pageId, metadata.size));
                     continue;
                 }
@@ -2099,11 +2008,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             newPagesFlush = System.currentTimeMillis();
 
             LOGGER.log(Level.INFO, "checkpoint {0}, logpos {1}, flushed: {2} dirty pages, {3} small pages, {4} new pages, {5} records",
-                new Object[]{table.name, sequenceNumber, flushedDirtyPages, flushedSmallPages, flushedNewPages, flushedRecords});
+                    new Object[]{table.name, sequenceNumber, flushedDirtyPages, flushedSmallPages, flushedNewPages, flushedRecords});
 
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "checkpoint {0}, logpos {1}, flushed pages: {2}",
-                    new Object[]{table.name, sequenceNumber, flushedPages.toString()});
+                        new Object[]{table.name, sequenceNumber, flushedPages.toString()});
             }
 
             /* Checkpoint the key to page too */
@@ -2124,8 +2033,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             pageSet.checkpointDone(flushedPages);
 
             TableStatus tableStatus = new TableStatus(table.name, sequenceNumber,
-                Bytes.from_long(nextPrimaryKeyValue.get()).data, nextPageId,
-                pageSet.getActivePages());
+                    Bytes.from_long(nextPrimaryKeyValue.get()).data, nextPageId,
+                    pageSet.getActivePages());
 
             actions.addAll(dataStorageManager.tableCheckpoint(tableSpaceUUID, table.uuid, tableStatus, pin));
             tablecheckpoint = System.currentTimeMillis();
@@ -2157,13 +2066,13 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             end = System.currentTimeMillis();
 
             LOGGER.log(Level.INFO, "checkpoint {0} finished, logpos {1}, {2} active pages, {3} dirty pages, "
-                + "flushed {4} records, total time {5} ms",
-                new Object[]{table.name, sequenceNumber, pageSet.getActivePagesCount(),
-                    pageSet.getDirtyPagesCount(), flushedRecords, Long.toString(end - start)});
+                    + "flushed {4} records, total time {5} ms",
+                    new Object[]{table.name, sequenceNumber, pageSet.getActivePagesCount(),
+                        pageSet.getDirtyPagesCount(), flushedRecords, Long.toString(end - start)});
 
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "checkpoint {0} finished, logpos {1}, pageSet: {2}",
-                    new Object[]{table.name, sequenceNumber, pageSet.toString()});
+                        new Object[]{table.name, sequenceNumber, pageSet.toString()});
             }
 
         } finally {
@@ -2200,13 +2109,13 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
     @Override
     public DataScanner scan(ScanStatement statement, StatementEvaluationContext context,
-        Transaction transaction, boolean lockRequired, boolean forWrite) throws StatementExecutionException {
+            Transaction transaction, boolean lockRequired, boolean forWrite) throws StatementExecutionException {
         TupleComparator comparator = statement.getComparator();
         if (!ENABLE_STREAMING_DATA_SCANNER || (comparator != null
-            && this.stats.getTablesize() > HUGE_TABLE_SIZE_FORCE_MATERIALIZED_RESULTSET)) {
+                && this.stats.getTablesize() > HUGE_TABLE_SIZE_FORCE_MATERIALIZED_RESULTSET)) {
             boolean sortedByClusteredIndex = comparator != null
-                && comparator.isOnlyPrimaryKeyAndAscending()
-                && keyToPage.isSortedAscending();
+                    && comparator.isOnlyPrimaryKeyAndAscending()
+                    && keyToPage.isSortedAscending();
             if (!sortedByClusteredIndex) {
                 return scanNoStream(statement, context, transaction, lockRequired, forWrite);
             }
@@ -2215,21 +2124,21 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private DataScanner scanNoStream(ScanStatement statement, StatementEvaluationContext context,
-        Transaction transaction, boolean lockRequired, boolean forWrite) throws StatementExecutionException {
+            Transaction transaction, boolean lockRequired, boolean forWrite) throws StatementExecutionException {
 
         boolean sorted = statement.getComparator() != null;
         boolean sortedByClusteredIndex = statement.getComparator() != null
-            && statement.getComparator().isOnlyPrimaryKeyAndAscending()
-            && keyToPage.isSortedAscending();
+                && statement.getComparator().isOnlyPrimaryKeyAndAscending()
+                && keyToPage.isSortedAscending();
         final Projection projection = statement.getProjection();
         boolean applyProjectionDuringScan = !sorted && projection != null;
         MaterializedRecordSet recordSet;
         if (applyProjectionDuringScan) {
             recordSet = tableSpaceManager.getDbmanager().getRecordSetFactory()
-                .createRecordSet(projection.getFieldNames(), projection.getColumns());
+                    .createRecordSet(projection.getFieldNames(), projection.getColumns());
         } else {
             recordSet = tableSpaceManager.getDbmanager().getRecordSetFactory()
-                .createRecordSet(table.columnNames, table.columns);
+                    .createRecordSet(table.columnNames, table.columns);
         }
         ScanLimits limits = statement.getLimits();
         int maxRows = limits == null ? 0 : limits.computeMaxRows(context);
@@ -2338,12 +2247,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private DataScanner scanWithStream(ScanStatement statement, StatementEvaluationContext context,
-        Transaction transaction, boolean lockRequired, boolean forWrite) throws StatementExecutionException {
+            Transaction transaction, boolean lockRequired, boolean forWrite) throws StatementExecutionException {
         final TupleComparator comparator = statement.getComparator();
         boolean sorted = comparator != null;
         boolean sortedByClusteredIndex = comparator != null
-            && comparator.isOnlyPrimaryKeyAndAscending()
-            && keyToPage.isSortedAscending();
+                && comparator.isOnlyPrimaryKeyAndAscending()
+                && keyToPage.isSortedAscending();
         final Projection projection = statement.getProjection();
         final boolean applyProjectionDuringScan = projection != null && !sorted;
         ScanLimits limits = statement.getLimits();
@@ -2361,14 +2270,14 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         };
 
         Stream<DataAccessor> fromTransactionSorted
-            = streamTransactionData(transaction, statement.getPredicate(), context)
-                .map(mapper);
+                = streamTransactionData(transaction, statement.getPredicate(), context)
+                        .map(mapper);
         if (comparator != null) {
             fromTransactionSorted = fromTransactionSorted.sorted(comparator);
         }
 
         Stream<DataAccessor> tableData = streamTableData(statement, context, transaction, lockRequired, forWrite)
-            .map(mapper);
+                .map(mapper);
         if (maxRows > 0) {
             if (sortedByClusteredIndex) {
                 // already sorted from index
@@ -2377,7 +2286,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 fromTransactionSorted = fromTransactionSorted.limit(maxRows + offset);
                 // we need to re-sort
                 result = Stream.concat(fromTransactionSorted, tableData)
-                    .sorted(comparator);
+                        .sorted(comparator);
             } else if (sorted) {
                 // need to sort
                 tableData = tableData.sorted(comparator);
@@ -2386,7 +2295,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 fromTransactionSorted = fromTransactionSorted.limit(maxRows + offset);
                 // we need to re-sort
                 result = Stream.concat(fromTransactionSorted, tableData)
-                    .sorted(comparator);
+                        .sorted(comparator);
             } else {
                 result = Stream.concat(fromTransactionSorted, tableData);
             }
@@ -2397,13 +2306,13 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 // fromTransactionSorted is already sorted
                 // we need to re-sort
                 result = Stream.concat(fromTransactionSorted, tableData)
-                    .sorted(comparator);
+                        .sorted(comparator);
             } else if (sorted) {
                 // tableData already sorted from index
                 // fromTransactionSorted is already sorted
                 // we need to re-sort
                 result = Stream.concat(fromTransactionSorted, tableData)
-                    .sorted(comparator);
+                        .sorted(comparator);
             } else {
                 // no need to sort
                 result = Stream.concat(fromTransactionSorted, tableData);
@@ -2431,7 +2340,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private void accessTableData(ScanStatement statement, StatementEvaluationContext context, ScanResultOperation consumer, Transaction transaction,
-        boolean lockRequired, boolean forWrite) throws StatementExecutionException {
+            boolean lockRequired, boolean forWrite) throws StatementExecutionException {
         statement.validateContext(context);
         Predicate predicate = statement.getPredicate();
         long _start = System.currentTimeMillis();
@@ -2472,7 +2381,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                             boolean pkFilterCompleteMatch = false;
                             if (!primaryIndexSeek && predicate != null) {
                                 Predicate.PrimaryKeyMatchOutcome outcome
-                                    = predicate.matchesRawPrimaryKey(key, context);
+                                        = predicate.matchesRawPrimaryKey(key, context);
                                 if (outcome == Predicate.PrimaryKeyMatchOutcome.FAILED) {
                                     continue;
                                 } else if (outcome == Predicate.PrimaryKeyMatchOutcome.FULL_CONDITION_VERIFIED) {
@@ -2502,7 +2411,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 }
             };
             BatchOrderedExecutor<Map.Entry<Bytes, Long>> executor = new BatchOrderedExecutor<>(SORTED_PAGE_ACCESS_WINDOW_SIZE,
-                scanExecutor, SORTED_PAGE_ACCESS_COMPARATOR);
+                    scanExecutor, SORTED_PAGE_ACCESS_COMPARATOR);
             Stream<Map.Entry<Bytes, Long>> scanner = keyToPage.scanner(indexOperation, context, tableContext, useIndex);
             boolean exit = false;
             try {
@@ -2533,7 +2442,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 Collection<Record> newRecordsForTable = transaction.getNewRecordsForTable(table.name);
                 for (Record record : newRecordsForTable) {
                     if (!transaction.recordDeleted(table.name, record.key)
-                        && (predicate == null || predicate.evaluate(record, context))) {
+                            && (predicate == null || predicate.evaluate(record, context))) {
                         consumer.accept(record);
                     }
                 }
@@ -2553,8 +2462,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private Stream<Record> streamTableData(ScanStatement statement, StatementEvaluationContext context,
-        Transaction transaction,
-        boolean lockRequired, boolean forWrite) throws StatementExecutionException {
+            Transaction transaction,
+            boolean lockRequired, boolean forWrite) throws StatementExecutionException {
         statement.validateContext(context);
         Predicate predicate = statement.getPredicate();
         boolean acquireLock = transaction != null || forWrite || lockRequired;
@@ -2566,7 +2475,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
         Stream<Record> resultFromTable = scanner.map(entry -> {
             return accessRecord(entry, predicate, context,
-                transaction, lastPageRead, primaryIndexSeek, forWrite, acquireLock);
+                    transaction, lastPageRead, primaryIndexSeek, forWrite, acquireLock);
         }).filter(r -> r != null);
         return resultFromTable;
     }
@@ -2575,24 +2484,24 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         if (transaction != null) {
             Collection<Record> newRecordsForTable = transaction.getNewRecordsForTable(table.name);
             return newRecordsForTable
-                .stream()
-                .map(record -> {
-                    if (!transaction.recordDeleted(table.name, record.key)
-                        && (predicate == null || predicate.evaluate(record, context))) {
-                        return record;
-                    } else {
-                        return null;
-                    }
-                }).filter(r -> r != null);
+                    .stream()
+                    .map(record -> {
+                        if (!transaction.recordDeleted(table.name, record.key)
+                                && (predicate == null || predicate.evaluate(record, context))) {
+                            return record;
+                        } else {
+                            return null;
+                        }
+                    }).filter(r -> r != null);
         } else {
             return Stream.empty();
         }
     }
 
     public Record accessRecord(Map.Entry<Bytes, Long> entry,
-        Predicate predicate, StatementEvaluationContext context,
-        Transaction transaction, LocalScanPageCache lastPageRead, boolean primaryIndexSeek,
-        boolean forWrite, boolean acquireLock) {
+            Predicate predicate, StatementEvaluationContext context,
+            Transaction transaction, LocalScanPageCache lastPageRead, boolean primaryIndexSeek,
+            boolean forWrite, boolean acquireLock) {
 
         Bytes key = entry.getKey();
         boolean keep_lock = false;
@@ -2619,7 +2528,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 boolean pkFilterCompleteMatch = false;
                 if (!primaryIndexSeek && predicate != null) {
                     Predicate.PrimaryKeyMatchOutcome outcome
-                        = predicate.matchesRawPrimaryKey(key, context);
+                            = predicate.matchesRawPrimaryKey(key, context);
                     if (outcome == Predicate.PrimaryKeyMatchOutcome.FAILED) {
                         return null;
                     } else if (outcome == Predicate.PrimaryKeyMatchOutcome.FULL_CONDITION_VERIFIED) {
@@ -2671,7 +2580,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             return Collections.emptyList();
         }
         return indexes.values().stream().filter(AbstractIndexManager::isAvailable).map(AbstractIndexManager::getIndex)
-            .collect(Collectors.toList());
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -2692,7 +2601,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
             Long relocatedPageId = keyToPage.get(key);
             LOGGER.log(Level.SEVERE, table.name + " fetchRecord " + key + " failed,"
-                + "checkPointRunning:" + checkPointRunning + " pageId:" + pageId + " relocatedPageId:" + relocatedPageId);
+                    + "checkPointRunning:" + checkPointRunning + " pageId:" + pageId + " relocatedPageId:" + relocatedPageId);
             if (relocatedPageId == null) {
                 // deleted
                 LOGGER.log(Level.SEVERE, "table " + table.name + ", activePages " + pageSet.getActivePages() + ", record " + key + " deleted during data access");
@@ -2708,8 +2617,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private DataPage fetchDataPage(Long pageId, LocalScanPageCache localScanPageCache) throws DataStorageManagerException {
         DataPage dataPage;
         if (localScanPageCache == null
-            || !ENABLE_LOCAL_SCAN_PAGE_CACHE
-            || pages.containsKey(pageId)) {
+                || !ENABLE_LOCAL_SCAN_PAGE_CACHE
+                || pages.containsKey(pageId)) {
             dataPage = loadPageToMemory(pageId, false);
         } else {
             if (pageId.equals(localScanPageCache.pageId)) {

--- a/herddb-core/src/test/java/herddb/core/SimpleTransactionTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleTransactionTest.java
@@ -281,7 +281,7 @@ public class SimpleTransactionTest extends BaseTestcase {
 
         Bytes key = Bytes.from_int(1234);
         Bytes value = Bytes.from_long(8888);
-        
+
         Table transacted_table = Table
                 .builder()
                 .tablespace(tableSpace)


### PR DESCRIPTION
In order to fix an edge case we had introduced an additional PrimaryKey lookup inside applyInsert, this can be saved.
The edge case is about a transaction with a DELETE followed by an INSERT, this case can be replace by a single UPDATE, instead of a special INSERT

The idea is from @diegosalvi 