### PR TITLE
Drop 'Long' return from KeyToPageIndex#put

### DIFF
--- a/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
@@ -65,12 +65,11 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
     }
 
     @Override
-    public Long put(Bytes key, Long currentPage) {
+    public void put(Bytes key, Long currentPage) {
         Long res = map.put(key, currentPage);
         if (res == null) {
             keyAdded(key);
         }
-        return res;
     }
 
     private void keyAdded(Bytes key) {
@@ -177,7 +176,7 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
                 predicate = (Map.Entry<Bytes, Long> entry) -> {
                     byte[] datum = entry.getKey().data;
                     return Bytes.compare(datum, refmaxvalue) <= 0
-                        && Bytes.compare(datum, refminvalue) >= 0;
+                            && Bytes.compare(datum, refminvalue) >= 0;
                 };
             } else {
                 predicate = (Map.Entry<Bytes, Long> entry) -> {

--- a/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
@@ -56,7 +56,9 @@ public interface KeyToPageIndex extends AutoCloseable {
     public List<PostCheckpointAction> checkpoint(LogSequenceNumber sequenceNumber, boolean pin) throws DataStorageManagerException;
 
     /**
-     * Unpin a previously pinned checkpont (see {@link #checkpoint(LogSequenceNumber, boolean)})
+     * Unpin a previously pinned checkpont (see
+     * {@link #checkpoint(LogSequenceNumber, boolean)})
+     *
      * @throws DataStorageManagerException
      */
     public abstract void unpinCheckpoint(LogSequenceNumber sequenceNumber) throws DataStorageManagerException;
@@ -66,7 +68,7 @@ public interface KeyToPageIndex extends AutoCloseable {
     public Stream<Map.Entry<Bytes, Long>> scanner(IndexOperation operation, StatementEvaluationContext context,
             TableContext tableContext, AbstractIndexManager index) throws DataStorageManagerException, StatementExecutionException;
 
-    public Long put(Bytes key, Long currentPage);
+    public void put(Bytes key, Long currentPage);
 
     public boolean containsKey(Bytes key);
 

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -119,8 +119,8 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
     }
 
     @Override
-    public Long put(Bytes key, Long currentPage) {
-        return getTree().insert(key, currentPage);
+    public void put(Bytes key, Long currentPage) {
+        getTree().insert(key, currentPage);
     }
 
     @Override


### PR DESCRIPTION
This change relaxes the KeyToPageIndex interface, but not forcing the implementation to return the previous value on put operations