### PR TITLE
Serialize column names as CSV

### DIFF
--- a/herddb-proto/src/main/flatc/herddb/proto/flatbuf/Response.java
+++ b/herddb-proto/src/main/flatc/herddb/proto/flatbuf/Response.java
@@ -29,9 +29,9 @@ public final class Response extends Table {
   public ByteBuffer stackTraceInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 14, 1); }
   public boolean notLeader() { int o = __offset(16); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
   public boolean last() { int o = __offset(18); return o != 0 ? 0!=bb.get(o + bb_pos) : false; }
-  public ColumnDefinition columnNames(int j) { return columnNames(new ColumnDefinition(), j); }
-  public ColumnDefinition columnNames(ColumnDefinition obj, int j) { int o = __offset(20); return o != 0 ? obj.__assign(__indirect(__vector(o) + j * 4), bb) : null; }
-  public int columnNamesLength() { int o = __offset(20); return o != 0 ? __vector_len(o) : 0; }
+  public String columnNames() { int o = __offset(20); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer columnNamesAsByteBuffer() { return __vector_as_bytebuffer(20, 1); }
+  public ByteBuffer columnNamesInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 20, 1); }
   public Row rows(int j) { return rows(new Row(), j); }
   public Row rows(Row obj, int j) { int o = __offset(22); return o != 0 ? obj.__assign(__indirect(__vector(o) + j * 4), bb) : null; }
   public int rowsLength() { int o = __offset(22); return o != 0 ? __vector_len(o) : 0; }
@@ -91,8 +91,6 @@ public final class Response extends Table {
   public static void addNotLeader(FlatBufferBuilder builder, boolean notLeader) { builder.addBoolean(6, notLeader, false); }
   public static void addLast(FlatBufferBuilder builder, boolean last) { builder.addBoolean(7, last, false); }
   public static void addColumnNames(FlatBufferBuilder builder, int columnNamesOffset) { builder.addOffset(8, columnNamesOffset, 0); }
-  public static int createColumnNamesVector(FlatBufferBuilder builder, int[] data) { builder.startVector(4, data.length, 4); for (int i = data.length - 1; i >= 0; i--) builder.addOffset(data[i]); return builder.endVector(); }
-  public static void startColumnNamesVector(FlatBufferBuilder builder, int numElems) { builder.startVector(4, numElems, 4); }
   public static void addRows(FlatBufferBuilder builder, int rowsOffset) { builder.addOffset(9, rowsOffset, 0); }
   public static int createRowsVector(FlatBufferBuilder builder, int[] data) { builder.startVector(4, data.length, 4); for (int i = data.length - 1; i >= 0; i--) builder.addOffset(data[i]); return builder.endVector(); }
   public static void startRowsVector(FlatBufferBuilder builder, int numElems) { builder.startVector(4, numElems, 4); }

--- a/herddb-proto/src/main/resources/Response.fbs
+++ b/herddb-proto/src/main/resources/Response.fbs
@@ -35,7 +35,8 @@ table Response {
 
   notLeader :bool;
   last: bool;
-  columnNames: [ColumnDefinition];
+  // comma separated list (it is better that a vector in this case)
+  columnNames: string;
   rows: [Row];
   data: [byte];
 

--- a/herddb-utils/src/main/java/herddb/network/MessageBuilder.java
+++ b/herddb-utils/src/main/java/herddb/network/MessageBuilder.java
@@ -311,18 +311,18 @@ public abstract class MessageBuilder {
     }
 
     private static int encodeColumDefinitionsList(String[] columnNames, FlatBufferBuilder builder) throws IllegalArgumentException {
-        int[] columnsOffsets = new int[columnNames.length];
+        StringBuilder res = new StringBuilder();
         int pIndex = 0;
 
         for (String colName : columnNames) {
-            int stringOffset = addString(builder, colName);
-            StringValue.startStringValue(builder);
-            StringValue.addValue(builder, stringOffset);
-            int end = StringValue.endStringValue(builder);
-            columnsOffsets[pIndex++] = end;
+            if (pIndex != 0) {
+                res.append(',');
+            }
+            res.append(colName);
+            pIndex++;
         }
-        return Response.createColumnNamesVector(builder, columnsOffsets);
-    }
+        return builder.createString(res.toString());
+    }    
 
     public static ByteBuf TX_COMMAND(long id, String tableSpace, int type, long tx) {
         try (ByteBufFlatBufferBuilder builder = newFlatBufferBuilder();) {

--- a/herddb-utils/src/main/java/herddb/utils/RecordsBatch.java
+++ b/herddb-utils/src/main/java/herddb/utils/RecordsBatch.java
@@ -49,20 +49,8 @@ public class RecordsBatch {
     public RecordsBatch(MessageWrapper replyWrapper) {
         this.response = replyWrapper.getResponse();
         this.numRecords = response.rowsLength();
-        this.columnNames = new String[response.columnNamesLength()];
+        this.columnNames = response.columnNames().split(",");
         this.message = replyWrapper;
-        for (int i = 0; i < columnNames.length; i++) {
-            ColumnDefinition columnNameDef = response.columnNames(i);
-            ByteBuffer byteBuffer = columnNameDef.getByteBuffer();
-            int position = byteBuffer.position();
-            int limit = byteBuffer.limit();
-            String columnName = MessageUtils
-                    .readString(columnNameDef.nameInByteBuffer(columnNameDef.getByteBuffer()));
-            columnNames[i] = columnName;
-            ((Buffer) byteBuffer).position(position);
-            ((Buffer) byteBuffer).limit(limit);
-        }
-
         this.currentRecordIndex = -1;
         if (numRecords == 0) {
             finished = true;


### PR DESCRIPTION
FlatBuffers is very expensive, in order to serialize a list of strings you have to perform a lot of computation on the writer side.
It turns out that it is very cheaper to use a simple CSV list in this case