### PR TITLE
New LocalLockManager based con ConcurrentHashMap#compute

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -102,6 +102,8 @@ import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import herddb.utils.EnsureLongIncrementAccumulator;
 import herddb.utils.Holder;
+import herddb.utils.ILocalLockManager;
+import herddb.utils.LegacyLocalLockManager;
 import herddb.utils.LocalLockManager;
 import herddb.utils.LockHandle;
 import herddb.utils.SystemProperties;
@@ -134,6 +136,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private static final boolean ENABLE_STREAMING_DATA_SCANNER = SystemProperties.
             getBooleanSystemProperty("herddb.tablemanager.enableStreamingDataScanner", true);
 
+    private static final boolean USE_LEGACY_LOCK_MANAGER = SystemProperties
+            .getBooleanSystemProperty("herddb.tablemanager.legacylocks", false);
+
     private final ConcurrentMap<Long, DataPage> newPages;
 
     private final ConcurrentMap<Long, DataPage> pages;
@@ -160,11 +165,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
      * Counts how many pages had been loaded
      */
     private final LongAdder unloadedPagesCount = new LongAdder();
-
     /**
      * Local locks
      */
-    private final LocalLockManager locksManager = new LocalLockManager();
+    private final ILocalLockManager locksManager
+            = USE_LEGACY_LOCK_MANAGER ? new LegacyLocalLockManager() : new LocalLockManager();
 
     /**
      * Set to {@code true} when this {@link TableManage} is fully started

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -38,7 +38,7 @@ import herddb.log.LogSequenceNumber;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
-import herddb.utils.LocalLockManager;
+import herddb.utils.ILocalLockManager;
 import herddb.utils.LockHandle;
 import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
@@ -165,7 +165,7 @@ public class Transaction {
 
     }
 
-    public void releaseLocksOnTable(String tableName, LocalLockManager lockManager) {
+    public void releaseLocksOnTable(String tableName, ILocalLockManager lockManager) {
         Map<Bytes, LockHandle> ll = locks.get(tableName);
         if (ll != null) {
             for (LockHandle l : ll.values()) {
@@ -477,7 +477,7 @@ public class Transaction {
 
     }
 
-    public void releaseLockOnKey(String tableName, Bytes key, LocalLockManager locksManager) {
+    public void releaseLockOnKey(String tableName, Bytes key, ILocalLockManager locksManager) {
         Map<Bytes, LockHandle> ll = locks.get(tableName);
         if (ll != null) {
             LockHandle lock = ll.remove(key);

--- a/herddb-utils/src/main/java/herddb/utils/ILocalLockManager.java
+++ b/herddb-utils/src/main/java/herddb/utils/ILocalLockManager.java
@@ -20,29 +20,24 @@
 package herddb.utils;
 
 /**
- * Handle to a lock
+ * Handle locks by key
  *
  * @author enrico.olivelli
  */
-public class LockHandle {
+public interface ILocalLockManager {
 
-    public final long stamp;
-    public final boolean write;
-    public final Bytes key;
-    public final Object handle;
+    LockHandle acquireReadLockForKey(Bytes key);
 
-    public LockHandle(long stamp, Bytes key, boolean write) {
-        this.stamp = stamp;
-        this.key = key;
-        this.write = write;
-        this.handle = null;
-    }
+    LockHandle acquireWriteLockForKey(Bytes key);
 
-    public LockHandle(long stamp, Bytes key, boolean write, Object handle) {
-        this.stamp = stamp;
-        this.key = key;
-        this.write = write;
-        this.handle = handle;
-    }
+    void clear();
+
+    void releaseLock(LockHandle l);
+
+    void releaseReadLockForKey(Bytes key, LockHandle lockStamp);
+
+    void releaseWriteLockForKey(Bytes key, LockHandle lockStamp);
+
+    public int getNumKeys();
 
 }

--- a/herddb-utils/src/main/java/herddb/utils/LegacyLocalLockManager.java
+++ b/herddb-utils/src/main/java/herddb/utils/LegacyLocalLockManager.java
@@ -1,0 +1,221 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.utils;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.StampedLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Handle locks by key
+ *
+ * @author enrico.olivelli
+ * @author diego.salvi
+ */
+public class LegacyLocalLockManager implements ILocalLockManager {
+
+    private static final Logger LOGGER = Logger.getLogger(LegacyLocalLockManager.class.getName());
+
+    private StampedLock makeLock() {
+        return new StampedLock();
+    }
+
+    private final ConcurrentMap<Bytes, LockInstance> locks = new ConcurrentHashMap<Bytes, LockInstance>();
+
+    @SuppressWarnings("serial")
+    private static final class LockInstance extends ReentrantLock {
+
+        private final StampedLock lock;
+        private int count;
+
+        public LockInstance(StampedLock lock, int count) {
+            super();
+            this.lock = lock;
+            this.count = count;
+        }
+    }
+
+    private StampedLock makeLockForKey(Bytes key) {
+
+        LockInstance instance = locks.computeIfAbsent(key, (k) -> {
+
+            /* No existing instance, inserting an already locked instance */
+            final LockInstance li = new LockInstance(makeLock(), 1);
+            li.lock();
+
+            return li;
+
+        });
+
+        try {
+            /* If held by current thread all work has been already done! */
+            if (!instance.isHeldByCurrentThread()) {
+                instance.lock();
+
+                /*
+                 * The lock wasn't created by this thread. We should check if it was released from another thread
+                 * between instance retrieval from map and instance lock.
+                 */
+                if (instance.count < 1) {
+                    /* Worst concurrent case: released by another thread, retry */
+
+ /*
+                     * Do not release current lock before doing another attemp. Other threads checking the
+                     * same instance will have to wait here untill a live lock is created (trying to avoid
+                     * spinning and contention between threads). The lock will released in finally block upon
+                     * method exit.
+                     */
+                    return makeLockForKey(key);
+                }
+
+                ++instance.count;
+            }
+        } finally {
+            instance.unlock();
+        }
+
+        return instance.lock;
+    }
+
+    private StampedLock returnLockForKey(Bytes key) throws IllegalStateException {
+
+        /* Retrieve the instance... other threads could have this pointer too */
+        LockInstance instance = locks.get(key);
+
+        /* If there was no instance fail */
+        if (instance == null) {
+            LOGGER.log(Level.SEVERE, "no lock object exists for key {0}", key);
+            throw new IllegalStateException("no lock object exists for key " + key);
+        }
+
+        instance.lock();
+
+        try {
+
+            if (--instance.count < 1) {
+
+                /*
+                 * If was already released too much times fail (multiple concurrent releases, if they weren't
+                 * really concurrent the map would have returned a null instance)
+                 */
+                if (instance.count < 0) {
+                    LOGGER.log(Level.SEVERE, "too much lock releases for key {0}", key);
+                    throw new IllegalStateException("too much lock releases for key " + key);
+                } else {
+                    boolean ok = locks.remove(key, instance);
+                    if (!ok) {
+                        throw new IllegalStateException("illegal lock releases for key " + key);
+                    }
+                }
+
+            }
+        } finally {
+            instance.unlock();
+        }
+
+        return instance.lock;
+    }
+
+    private int writeLockTimeout = 60 * 30;
+
+    public int getWriteLockTimeout() {
+        return writeLockTimeout;
+    }
+
+    public void setWriteLockTimeout(int writeLockTimeout) {
+        this.writeLockTimeout = writeLockTimeout;
+    }
+
+    private int readLockTimeout = 60 * 30;
+
+    public int getReadLockTimeout() {
+        return readLockTimeout;
+    }
+
+    public void setReadLockTimeout(int readLockTimeout) {
+        this.readLockTimeout = readLockTimeout;
+    }
+
+    @Override
+    public LockHandle acquireWriteLockForKey(Bytes key) {
+        StampedLock lock = makeLockForKey(key);
+        try {
+            long tryWriteLock = lock.tryWriteLock(writeLockTimeout, TimeUnit.SECONDS);
+            if (tryWriteLock == 0) {
+                throw new RuntimeException("timed out acquiring lock for write");
+            }
+            return new LockHandle(tryWriteLock, key, true);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(err);
+        }
+    }
+
+    @Override
+    public void releaseWriteLockForKey(Bytes key, LockHandle lockStamp) {
+        StampedLock lock = returnLockForKey(key);
+        lock.unlockWrite(lockStamp.stamp);
+    }
+
+    @Override
+    public LockHandle acquireReadLockForKey(Bytes key) {
+        StampedLock lock = makeLockForKey(key);
+        try {
+            long tryReadLock = lock.tryReadLock(readLockTimeout, TimeUnit.SECONDS);
+            if (tryReadLock == 0) {
+                throw new RuntimeException("timedout trying to read lock");
+            }
+            return new LockHandle(tryReadLock, key, false);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(err);
+        }
+    }
+
+    @Override
+    public void releaseReadLockForKey(Bytes key, LockHandle lockStamp) {
+        StampedLock lock = returnLockForKey(key);
+        lock.unlockRead(lockStamp.stamp);
+    }
+
+    @Override
+    public void releaseLock(LockHandle l) {
+        if (l.write) {
+            releaseWriteLockForKey(l.key, l);
+        } else {
+            releaseReadLockForKey(l.key, l);
+        }
+    }
+
+    @Override
+    public void clear() {
+        this.locks.clear();
+    }
+
+    @Override
+    public int getNumKeys() {
+        return locks.size();
+    }
+
+}

--- a/herddb-utils/src/test/java/herddb/utils/LocalLockManagerTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/LocalLockManagerTest.java
@@ -1,0 +1,278 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Tests on LocalLocalManager
+ *
+ * @author eolivelli
+ */
+@RunWith(Parameterized.class)
+public class LocalLockManagerTest {
+
+    private static final Bytes KEY = Bytes.from_int(1);
+
+    @Rule
+    public Timeout timeout = new Timeout(10000);
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {true}, {false}
+        });
+    }
+    private final boolean legacy;
+
+    public LocalLockManagerTest(boolean legacy) {
+        this.legacy = legacy;
+    }
+
+    @Test
+    public void testSimple() {
+        ILocalLockManager manager = makeLockManager();
+        LockHandle h = manager.acquireReadLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+
+        manager.releaseLock(h);
+        assertEquals(0, manager.getNumKeys());
+
+        LockHandle h2 = manager.acquireWriteLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+
+        manager.releaseLock(h2);
+        assertEquals(0, manager.getNumKeys());
+    }
+
+    @Test
+    public void testReentrantReads() {
+        ILocalLockManager manager = makeLockManager();
+        LockHandle h = manager.acquireReadLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+
+        LockHandle hb = manager.acquireReadLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+
+        manager.releaseLock(hb);
+        manager.releaseLock(h);
+        assertEquals(0, manager.getNumKeys());
+
+    }
+
+    @Test
+    public void testReentrantReads2() {
+        ILocalLockManager manager = makeLockManager();
+        LockHandle h = manager.acquireReadLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+
+        LockHandle hb = manager.acquireReadLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+
+        manager.releaseLock(h);
+        manager.releaseLock(hb);
+        assertEquals(0, manager.getNumKeys());
+
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testWriterBlockedByReaderNonRentrant() {
+        ILocalLockManager manager = makeLockManager();
+        manager.acquireReadLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+        manager.acquireWriteLockForKey(KEY);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testReaderBlockedByWriterNonRentrant() {
+        ILocalLockManager manager = makeLockManager();
+        manager.acquireWriteLockForKey(KEY);
+        assertEquals(1, manager.getNumKeys());
+        manager.acquireReadLockForKey(KEY);
+    }
+
+    @Test
+    public void testHammer() {
+        ILocalLockManager manager = makeLockManager();
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            List<Future> res = new ArrayList<>();
+            for (int i = 0; i < 10000; i++) {
+                int _i = i;
+                res.add(executor.submit(() -> {
+                    LockHandle l;
+                    if (_i % 5 == 0) {
+                        l = manager.acquireWriteLockForKey(KEY);
+                    } else {
+                        l = manager.acquireReadLockForKey(KEY);
+                    }
+                    manager.releaseLock(l);
+                }));
+            }
+            res.forEach(new Consumer<Future>() {
+                int count;
+
+                @Override
+                public void accept(Future f) {
+                    try {
+                        f.get(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+            });
+            assertEquals(0, manager.getNumKeys());
+
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testTwoThreads() throws InterruptedException {
+        ILocalLockManager manager = makeLockManager();
+        CountDownLatch ww = new CountDownLatch(1);
+        CountDownLatch ww2 = new CountDownLatch(1);
+        AtomicReference<Throwable> error1 = new AtomicReference<>();
+        AtomicReference<Throwable> error2 = new AtomicReference<>();
+        Thread thread1 = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    ww2.countDown();
+                    LockHandle l = manager.acquireReadLockForKey(KEY);
+                    ww.await();
+                    manager.releaseLock(l);
+                } catch (Throwable ex) {
+                    ex.printStackTrace();
+                    error1.set(ex);
+                }
+            }
+        };
+        Thread thread2 = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    ww2.await();
+                    LockHandle l = manager.acquireReadLockForKey(KEY);
+                    ww.countDown();
+                    manager.releaseLock(l);
+                } catch (Throwable ex) {
+                    ex.printStackTrace();
+                    error2.set(ex);
+                }
+            }
+        };
+        thread2.start();
+        thread1.start();
+
+        thread1.join();
+        thread2.join();
+
+        assertNull(error1.get());
+        assertNull(error2.get());
+
+        assertEquals(0, manager.getNumKeys());
+
+    }
+
+    @Test
+    public void testTwoThreadsInterleaved() throws InterruptedException {
+        ILocalLockManager manager = makeLockManager();
+        CountDownLatch ww = new CountDownLatch(1);
+        CountDownLatch ww2 = new CountDownLatch(1);
+        AtomicReference<Throwable> error1 = new AtomicReference<>();
+        AtomicReference<Throwable> error2 = new AtomicReference<>();
+        Thread thread1 = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    ww2.countDown();
+                    LockHandle l = manager.acquireReadLockForKey(KEY);
+                    ww.await();
+                    manager.releaseLock(l);
+                } catch (Throwable ex) {
+                    ex.printStackTrace();
+                    error1.set(ex);
+                }
+            }
+        };
+        Thread thread2 = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    ww2.await();
+                    LockHandle l = manager.acquireReadLockForKey(KEY);
+
+                    manager.releaseLock(l);
+                    ww.countDown();
+                } catch (Throwable ex) {
+                    ex.printStackTrace();
+                    error2.set(ex);
+                }
+            }
+        };
+        thread2.start();
+        thread1.start();
+
+        thread1.join();
+        thread2.join();
+
+        assertNull(error1.get());
+        assertNull(error2.get());
+
+        assertEquals(0, manager.getNumKeys());
+
+    }
+
+    private ILocalLockManager makeLockManager() {
+        if (legacy) {
+            LegacyLocalLockManager res = new LegacyLocalLockManager();
+            res.setWriteLockTimeout(1);
+            res.setReadLockTimeout(1);
+            return res;
+        } else {
+            LocalLockManager res = new LocalLockManager();
+            res.setWriteLockTimeout(1);
+            res.setReadLockTimeout(1);
+            return res;
+        }
+    }
+
+}


### PR DESCRIPTION
Provide a new LockLockManager which leverages ConcurrentHashMap#compute.

This new solution has these advantages:
- does not need additional ReentranLocks
- reduce locks contention (no more the lock on the LockInstance instance)
- reduce number of calls to ConcurrentHashMap

This change also add unit tests for any LockManager implementation, for future improvements

Legacy LocalManager is still available, in order to perform comparative benchmarks