### PR TITLE
Bytes next len preservation and 'overflow' error

### DIFF
--- a/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
+++ b/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
@@ -1,0 +1,58 @@
+package herddb.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Check if bytes generated with Bytes.next are then compared the <i>correct</i>. Byte comparison
+ * should be unsigned nut it wasn't (issue #276).
+ *
+ * <p>
+ * This test is placed here and not in herd-utils package due to a Surefire issue. Surefire will not
+ * use specialized versions placed under java9/... if run on the same project (src). When correctly
+ * packed in a jar it will use them depending on Java version.
+ * </p>
+ *
+ * @author diego.salvi
+ */
+public class BytesCompareJavaTest {
+
+    /**
+     * Check Bytes comparison on byte values greater than 127.
+     *
+     * <p>
+     * Checked Bytes are:
+     * <ul>
+     * <li>08000000000008d4<b>7f</b></li>
+     * <li>08000000000008d4<b>80</b></li>
+     * </ul>
+     * Last bytes switch from positive +127 to negative -128 but the should checked unsigned.
+     * </p>
+     */
+    @Test
+    public void checkCompare() {
+
+        /* Builds 08000000000008d47f */
+
+        Bytes suffix = Bytes.from_long(578687L);
+
+        byte[] array = new byte[suffix.data.length + 1];
+        array[0] = 8;
+
+        System.arraycopy(suffix.data, 0, array, 1, suffix.data.length);
+
+        Bytes low = Bytes.from_array(array);
+
+        Assert.assertEquals("08000000000008d47f", low.toString());
+
+        /* Builds 08000000000008d480 */
+        Bytes hi = low.next();
+
+        Assert.assertEquals("08000000000008d480", hi.toString());
+
+
+        Assert.assertTrue(low.compareTo(hi) < 0);
+
+    }
+
+}

--- a/herddb-utils/src/test/java/herddb/utils/BytesTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/BytesTest.java
@@ -20,14 +20,17 @@
 package herddb.utils;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
 /**
+ * Test on {@link Bytes} facility
  *
  * @author enrico.olivelli
+ * @author diego.salvi
  */
 public class BytesTest {
 
@@ -40,12 +43,85 @@ public class BytesTest {
         Bytes bytes1 = Bytes.from_array(array1);
         Bytes next = bytes1.next();
         byte[] array2 = "tesu".getBytes(StandardCharsets.UTF_8);
-        System.out.println("a:"+bytes1.to_string());
-        System.out.println("b:"+next.to_string());
+        System.out.println("a:" + bytes1.to_string());
+        System.out.println("b:" + next.to_string());
         assertArrayEquals(array2, next.data);
     }
 
-    public void testLenPreservation() {
+    @Test
+    public void testNextSameByte() {
+
+        byte[] array = new byte[] { 0, 1 };
+        byte[] nextExpected = new byte[] { 0, 2 };
+
+        Bytes bytes = Bytes.from_array(array);
+        Bytes next = bytes.next();
+
+        assertArrayEquals(nextExpected, next.data);
+    }
+
+    /** Check that the change propagate to next byte if 255 (-1) */
+    @Test
+    public void testNextChangeByte() {
+
+        byte[] array = new byte[] { 0, -1 };
+        byte[] nextExpected = new byte[] { 1, 0 };
+
+        Bytes bytes = Bytes.from_array(array);
+        Bytes next = bytes.next();
+
+        assertArrayEquals(nextExpected, next.data);
+    }
+
+    /** Check that more than one byte is changed if needed */
+    @Test
+    public void testNextChangeByteMoreTimes() {
+
+        byte[] array = new byte[] { 0, -1, -1 };
+        byte[] nextExpected = new byte[] { 1, 0, 0 };
+
+        Bytes bytes = Bytes.from_array(array);
+        Bytes next = bytes.next();
+
+        assertArrayEquals(nextExpected, next.data);
+    }
+
+    /** Checks that prefix bytes aren't touched */
+    @Test
+    public void testNextChangeByteMoreTimesWithPrefix() {
+
+        byte[] array = new byte[] { 1, 0, -1, -1 };
+        byte[] nextExpected = new byte[] { 1, 1, 0, 0 };
+
+        Bytes bytes = Bytes.from_array(array);
+        Bytes next = bytes.next();
+
+        assertArrayEquals(nextExpected, next.data);
+    }
+
+    /** Checks that next fails if there is no more space */
+    @Test(expected=IllegalStateException.class)
+    public void testNextNoMoreSpace() {
+
+        byte[] array = new byte[] { -1, -1 };
+
+        Bytes bytes = Bytes.from_array(array);
+        bytes.next();
+    }
+
+    /** Check that leading zeros are preserved */
+    @Test
+    public void testNextLenPreservation() {
+
+        byte[] src = new byte[] { 0, 0, 0, -1 };
+
+        Bytes bytes = Bytes.from_array(src);
+
+        assertArrayEquals(src, bytes.data);
+
+        Bytes next = bytes.next();
+
+        assertEquals(bytes.data.length, next.data.length);
 
     }
 


### PR DESCRIPTION
Bytes.next doesn't preserve leading zeros due to BigInteger usage.

This implementation rewrite Bytes.next() method to handle byte array copies and increment.

BigInteger generate also an erronous value when received array is composed only of 1 bits (all bits on): in such cases we preferred to explicitly throw an IllegalStateException instead