### PR TITLE
Do not allocate HashMaps during updates and inserts

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
@@ -28,7 +28,6 @@ import herddb.model.Table;
 import herddb.model.TableContext;
 import herddb.sql.expressions.CompiledSQLExpression;
 import herddb.utils.DataAccessor;
-import java.util.Arrays;
 
 import java.util.HashMap;
 import java.util.List;
@@ -45,83 +44,61 @@ import net.sf.jsqlparser.schema.Column;
 public class SQLRecordFunction extends RecordFunction {
 
     private final Table table;
-    private final List<String> columns;
-    private final List<CompiledSQLExpression> expressions;
     private final Map<String, CompiledSQLExpression> expressionsByColumnName;
 
     public SQLRecordFunction(Table table, List<Column> columns, List<CompiledSQLExpression> expressions) {
         this.table = table;
-        this.columns = columns.stream().map(Column::getColumnName).collect(Collectors.toList());
-        this.expressions = expressions;
+        List<String> _columns = columns.stream().map(Column::getColumnName).collect(Collectors.toList());
         this.expressionsByColumnName = new HashMap<>();
-        final int size = columns.size();
+        final int size = _columns.size();
         for (int i = 0; i < size; i++) {
-            expressionsByColumnName.put(this.columns.get(i), expressions.get(i));
+            expressionsByColumnName.put(_columns.get(i), expressions.get(i));
         }
     }
 
     public SQLRecordFunction(List<String> columns, Table table, List<CompiledSQLExpression> expressions) {
         this.table = table;
-        this.columns = columns;
-        this.expressions = expressions;
         this.expressionsByColumnName = new HashMap<>();
         final int size = columns.size();
         for (int i = 0; i < size; i++) {
-            expressionsByColumnName.put(this.columns.get(i), expressions.get(i));
+            expressionsByColumnName.put(columns.get(i), expressions.get(i));
         }
     }
 
     @Override
     public byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
         try {
-            byte[] oldRes = _computeNewValueOld(previous, context);
-            byte[] newRes = _computeNewValue(previous, context, tableContext);
-            if (!Arrays.equals(oldRes, newRes)) {
-                throw new IllegalArgumentException("this is a bug!");
-            }
-            return newRes;
-        } catch (IllegalArgumentException err) {
-            throw new StatementExecutionException(err);
-        }
-    }
-
-    byte[] _computeNewValueOld(Record previous, StatementEvaluationContext context) throws StatementExecutionException {
-        Map<String, Object> res = previous != null ? new HashMap<>(previous.toBean(table)) : new HashMap<>(table.columns.length);
-        DataAccessor bean = previous != null ? previous.getDataAccessor(table) : DataAccessor.NULL;
-        final int size = columns.size();
-        for (int i = 0; i < size; i++) {
-            CompiledSQLExpression e = expressions.get(i);
-            String columnName = columns.get(i);
-            herddb.model.Column column = table.getColumn(columnName);
-            if (column == null) {
-                throw new StatementExecutionException("unknown column " + columnName + " in table " + table.name);
-            }
-            columnName = column.name;
-            Object value = RecordSerializer.convert(column.type, e.evaluate(bean, context));
-            res.put(columnName, value);
-        }
-        return RecordSerializer.serializeValueRaw(res, table, previous != null && previous.value != null ? previous.value.data.length : 0);
-    }
-
-    private byte[] _computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException {
-        try {
-            DataAccessor bean = previous != null ? previous.getDataAccessor(table) : DataAccessor.NULL;
-            Function<String, Object> fieldValueComputer = (columnName) -> {
-                CompiledSQLExpression e = expressionsByColumnName.get(columnName);
-                if (e == null) {
-                    return bean.get(columnName);
-                } else {
-                    herddb.model.Column column = table.getColumn(columnName);
-                    if (column == null) {
-                        throw new StatementExecutionException("unknown column " + columnName + " in table " + table.name);
+            if (previous != null) {
+                DataAccessor bean = previous.getDataAccessor(table);
+                Function<String, Object> fieldValueComputer = (columnName) -> {
+                    CompiledSQLExpression e = expressionsByColumnName.get(columnName);
+                    if (e == null) {
+                        return bean.get(columnName);
+                    } else {
+                        herddb.model.Column column = table.getColumn(columnName);
+                        if (column == null) {
+                            throw new StatementExecutionException("unknown column " + columnName + " in table " + table.name);
+                        }
+                        return RecordSerializer.convert(column.type, e.evaluate(bean, context));
                     }
-                    return RecordSerializer.convert(column.type, e.evaluate(bean, context));
-                }
-            };
+                };
+                return RecordSerializer.buildRecord(previous.value != null ? previous.value.data.length : 0, table, fieldValueComputer);
+            } else {
+                Function<String, Object> fieldValueComputer = (columnName) -> {
+                    CompiledSQLExpression e = expressionsByColumnName.get(columnName);
+                    if (e == null) {
+                        return null;
+                    } else {
+                        herddb.model.Column column = table.getColumn(columnName);
+                        if (column == null) {
+                            throw new StatementExecutionException("unknown column " + columnName + " in table " + table.name);
+                        }
+                        return RecordSerializer.convert(column.type, e.evaluate(DataAccessor.NULL, context));
+                    }
+                };
+                return RecordSerializer.buildRecord(0, table, fieldValueComputer);
+            }
 
-            byte[] finalRes = RecordSerializer.buildRecord(previous != null && previous.value != null ? previous.value.data.length : 0, table,
-                    fieldValueComputer);
-            return finalRes;
         } catch (IllegalArgumentException err) {
             throw new StatementExecutionException(err);
         }
@@ -129,7 +106,7 @@ public class SQLRecordFunction extends RecordFunction {
 
     @Override
     public String toString() {
-        return "SQLRecordFunction{" + "table=" + table + ", columns=" + columns + ", expressions=" + expressions + '}';
+        return "SQLRecordFunction{" + "table=" + table + ", exp=" + expressionsByColumnName + '}';
     }
 
 }


### PR DESCRIPTION
Do not create and fill temporary HashMaps when executing updates.

The new record to be built can simply be re-created on the flight without materializing all the values and filling 2 hashmaps.

