### PR TITLE
Issue 244: Error importing table from MySQL in case of table with PK not as first column and INSERT without explicit column names

### DIFF
--- a/herddb-core/src/test/java/herddb/core/HeapTest.java
+++ b/herddb-core/src/test/java/herddb/core/HeapTest.java
@@ -98,4 +98,27 @@ public class HeapTest {
         }
     }
 
+    @Test
+    public void insertWithoutValuesAndPrimaryKeyIsNotTheFirstColumn() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null);) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE `ao_21d670_whitelist_rules` (\n"
+                    + "  `ALLOWINBOUND` tinyint(1) DEFAULT NULL,\n"
+                    + "  `EXPRESSION` longtext COLLATE utf8_bin NOT NULL,\n"
+                    + "  `ID` int(11) NOT NULL AUTO_INCREMENT,\n"
+                    + "  `TYPE` varchar(255) COLLATE utf8_bin NOT NULL,\n"
+                    + "  PRIMARY KEY (`ID`)\n"
+                    + ") ", Collections.emptyList());
+
+            execute(manager, "INSERT INTO `ao_21d670_whitelist_rules` VALUES (?,?,?,?)\n"
+                    + "", Arrays.asList(0, "http://www.xxx.com/*", 3, "WILDCARD_EXPRESSION"));
+
+        }
+    }
+
 }


### PR DESCRIPTION
Detect if the Table is using the best case primary key layout and we can perform a single scan in DataAccessForFullRecord and fallback to unordered scan of the record otherwise

Fixes #244