### PR TITLE
New CommitLog batch system + new metrics + restore default maxActive 200

### DIFF
--- a/herddb-core/src/main/java/herddb/core/RunningStatementInfo.java
+++ b/herddb-core/src/main/java/herddb/core/RunningStatementInfo.java
@@ -34,17 +34,19 @@ public class RunningStatementInfo {
     private final String query;
     private final String tablespace;
     private final String info;
+    private final int numBatches;
     private final long startTimestamp;
 
-    public RunningStatementInfo(String query, long startTimestamp, String tablespace, String info) {
+    public RunningStatementInfo(String query, long startTimestamp, String tablespace, String info, int numBatches) {
         this.query = query;
         this.startTimestamp = startTimestamp;
         this.tablespace = tablespace;
         this.info = info;
+        this.numBatches = numBatches;
     }
 
-    public static AtomicLong getIDGENERATOR() {
-        return IDGENERATOR;
+    public int getNumBatches() {
+        return numBatches;
     }
 
     public long getId() {

--- a/herddb-core/src/main/java/herddb/core/RunningStatementsStats.java
+++ b/herddb-core/src/main/java/herddb/core/RunningStatementsStats.java
@@ -1,0 +1,65 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.core;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.bookkeeper.stats.Gauge;
+import org.apache.bookkeeper.stats.StatsLogger;
+
+/**
+ * Statistics about current activity
+ *
+ * @author enrico.olivelli
+ */
+public class RunningStatementsStats {
+
+    final private ConcurrentHashMap<Long, RunningStatementInfo> runningStatements = new ConcurrentHashMap<>();
+
+    final private StatsLogger mainStatsLogger;
+
+    RunningStatementsStats(StatsLogger mainStatsLogger) {
+        this.mainStatsLogger = mainStatsLogger;
+        this.mainStatsLogger.registerGauge("runningstatements", new Gauge<Integer>() {
+            @Override
+            public Integer getDefaultValue() {
+                return 0;
+            }
+
+            @Override
+            public Integer getSample() {
+                return runningStatements.size();
+            }
+
+        });
+    }
+
+    public void registerRunningStatement(RunningStatementInfo info) {
+        runningStatements.put(info.getId(), info);
+    }
+
+    public void unregisterRunningStatement(RunningStatementInfo info) {
+
+        runningStatements.remove(info.getId());
+    }
+
+    public ConcurrentHashMap<Long, RunningStatementInfo> getRunningStatements() {
+        return runningStatements;
+    }
+}

--- a/herddb-core/src/main/java/herddb/core/system/SysstatementsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysstatementsTableManager.java
@@ -44,6 +44,7 @@ public class SysstatementsTableManager extends AbstractSystemTableManager {
             .column("query", ColumnTypes.STRING)
             .column("startts", ColumnTypes.TIMESTAMP)
             .column("runningtime", ColumnTypes.LONG)
+            .column("batches", ColumnTypes.INTEGER)
             .column("info", ColumnTypes.STRING)
             .primaryKey("id", false)
             .build();
@@ -54,7 +55,7 @@ public class SysstatementsTableManager extends AbstractSystemTableManager {
 
     @Override
     protected Iterable<Record> buildVirtualRecordList() {
-        ConcurrentHashMap<Long, RunningStatementInfo> runningStatements = tableSpaceManager.getDbmanager().getRunningStatements();
+        ConcurrentHashMap<Long, RunningStatementInfo> runningStatements = tableSpaceManager.getDbmanager().getRunningStatements().getRunningStatements();
         List<Record> result = new ArrayList<>();
         long now = System.currentTimeMillis();
         for (RunningStatementInfo info : runningStatements.values()) {
@@ -66,6 +67,7 @@ public class SysstatementsTableManager extends AbstractSystemTableManager {
                     "query", info.getQuery(),
                     "startts", new java.sql.Timestamp(info.getStartTimestamp()),
                     "runningtime", (now - info.getStartTimestamp()),
+                    "batches", info.getNumBatches(),
                     "info", info.getInfo())
             );
         }

--- a/herddb-core/src/main/java/herddb/file/FileCommitLog.java
+++ b/herddb-core/src/main/java/herddb/file/FileCommitLog.java
@@ -33,7 +33,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -45,15 +44,17 @@ import herddb.log.CommitLogResult;
 import herddb.log.LogEntry;
 import herddb.log.LogNotAvailableException;
 import herddb.log.LogSequenceNumber;
-import herddb.utils.EnsureLongIncrementAccumulator;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.FileUtils;
 import herddb.utils.SimpleBufferedOutputStream;
 import herddb.utils.SystemProperties;
 import java.nio.channels.ClosedChannelException;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 
@@ -79,8 +80,10 @@ public class FileCommitLog extends CommitLog {
     private volatile CommitFileWriter writer;
     private Thread spool;
     private final OpStatsLogger statsFsyncTime;
+    private final AtomicInteger queueSize = new AtomicInteger();
+    private final AtomicInteger pendingEntries = new AtomicInteger();
     private final OpStatsLogger statsEntryLatency;
-    private final Counter queueSize;
+    private final OpStatsLogger batchWriteSize;
     private final ExecutorService fsyncThreadPool;
 
     private final static int WRITE_QUEUE_SIZE = SystemProperties.getIntSystemProperty(
@@ -279,7 +282,32 @@ public class FileCommitLog extends CommitLog {
         this.spool.setDaemon(true);
         this.statsFsyncTime = statslogger.getOpStatsLogger("fsync");
         this.statsEntryLatency = statslogger.getOpStatsLogger("entrylatency");
-        this.queueSize = statslogger.getCounter("queuesize");
+        this.batchWriteSize = statslogger.getOpStatsLogger("batchWriteSize");
+        statslogger.registerGauge("queuesize", new Gauge<Integer>() {
+            @Override
+            public Integer getDefaultValue() {
+                return 0;
+            }
+
+            @Override
+            public Integer getSample() {
+                return queueSize.get();
+            }
+
+        });
+        statslogger.registerGauge("pendingentries", new Gauge<Integer>() {
+            @Override
+            public Integer getDefaultValue() {
+                return 0;
+            }
+
+            @Override
+            public Integer getSample() {
+                return pendingEntries.get();
+            }
+
+        });
+
         this.fsyncThreadPool = fsyncThreadPool;
         LOGGER.log(Level.FINE, "tablespace {2}, logdirectory: {0}, maxLogFileSize {1} bytes", new Object[]{logDirectory, maxLogFileSize, tableSpaceName});
     }
@@ -319,39 +347,54 @@ public class FileCommitLog extends CommitLog {
             try {
                 openNewLedger();
                 int count = 0;
-                List<LogEntryHolderFuture> doneEntries = new ArrayList<>();
+                List<LogEntryHolderFuture> batch = new ArrayList<>();
                 while (!closed || !writeQueue.isEmpty()) {
                     LogEntryHolderFuture entry = writeQueue.poll(MAX_SYNC_TIME, TimeUnit.MILLISECONDS);
                     boolean timedOut = false;
                     if (entry != null) {
-                        queueSize.dec();
-                        writeEntry(entry);
-                        doneEntries.add(entry);
+                        batch.add(entry);
                         count++;
                     } else {
                         timedOut = true;
                     }
                     if (timedOut || count >= MAX_UNSYNCHED_BATCH) {
-                        if (!doneEntries.isEmpty()) {
-                            flush();
-                            List<LogEntryHolderFuture> entriesToNotify = doneEntries;
-                            doneEntries = new ArrayList<>();
-                            count = 0;
-                            SyncTask syncTask = new SyncTask(entriesToNotify);
-                            fsyncThreadPool.submit(syncTask);
-                        }
-
+                        List<LogEntryHolderFuture> entriesToNotify = flushBatch(batch);
+                        batch = new ArrayList<>();
+                        count = 0;
+                        SyncTask syncTask = new SyncTask(entriesToNotify);
+                        fsyncThreadPool.submit(syncTask);
                     }
                 }
+                List<LogEntryHolderFuture> entriesToNotify = flushBatch(batch);
+                if (entriesToNotify.isEmpty()) {
+                    LOGGER.log(Level.INFO, "flushing last {0} entries", entriesToNotify.size());
+                    SyncTask syncTask = new SyncTask(entriesToNotify);
+                    syncTask.run();
+                }
+
             } catch (LogNotAvailableException | IOException | InterruptedException t) {
                 failed = true;
                 LOGGER.log(Level.SEVERE, "general commit log failure on " + FileCommitLog.this.logDirectory, t);
             }
         }
 
+        private List<LogEntryHolderFuture> flushBatch(List<LogEntryHolderFuture> batch) throws LogNotAvailableException, IOException, InterruptedException {
+            if (!batch.isEmpty()) {
+                flush();
+                List<LogEntryHolderFuture> entriesToWrite = batch;
+                for (LogEntryHolderFuture _entry : entriesToWrite) {
+                    queueSize.decrementAndGet();
+                    writeEntry(_entry);
+                }
+                batchWriteSize.registerSuccessfulValue(entriesToWrite.size());
+                return entriesToWrite;
+            } else {
+                return Collections.emptyList();
+            }
+        }
     }
 
-    private static class LogEntryHolderFuture {
+    private class LogEntryHolderFuture {
 
         final CompletableFuture<LogSequenceNumber> ack = new CompletableFuture<>();
         final LogEntry entry;
@@ -382,6 +425,7 @@ public class FileCommitLog extends CommitLog {
             if (sequenceNumber == null && error == null) {
                 throw new IllegalStateException();
             }
+            pendingEntries.decrementAndGet();
             if (error != null) {
                 ack.completeExceptionally(error);
             } else {
@@ -435,8 +479,8 @@ public class FileCommitLog extends CommitLog {
         _writer.sync();
     }
 
-    public Counter getQueueSize() {
-        return queueSize;
+    public int getQueueSize() {
+        return queueSize.get();
     }
 
     @Override
@@ -444,7 +488,8 @@ public class FileCommitLog extends CommitLog {
         if (failed) {
             throw new LogNotAvailableException("file commit log is failed");
         }
-        if (isHasListeners()) {
+        boolean hasListeners = isHasListeners();
+        if (hasListeners) {
             sync = true;
         }
         if (LOGGER.isLoggable(Level.FINEST)) {
@@ -452,14 +497,17 @@ public class FileCommitLog extends CommitLog {
         }
         LogEntryHolderFuture future = new LogEntryHolderFuture(edit, sync);
         try {
-            queueSize.inc();
+            queueSize.incrementAndGet();
+            pendingEntries.incrementAndGet();
             writeQueue.put(future);
             if (!sync) {
                 return new CommitLogResult(future.ack, false /* deferred */, false);
             } else {
-                future.ack.thenAccept((pos) -> {
-                    notifyListeners(pos, edit);
-                });
+                if (hasListeners) {
+                    future.ack.thenAccept((pos) -> {
+                        notifyListeners(pos, edit);
+                    });
+                }
                 return new CommitLogResult(future.ack, false /* deferred */, true);
             }
         } catch (InterruptedException err) {

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -111,7 +111,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
     }
 
     public Server(ServerConfiguration configuration, StatsLogger statsLogger) {
-        this.statsLogger = statsLogger  == null ? new NullStatsLogger() : statsLogger;
+        this.statsLogger = statsLogger == null ? new NullStatsLogger() : statsLogger;
         this.configuration = configuration;
 
         String nodeId = configuration.getString(ServerConfiguration.PROPERTY_NODEID, "");
@@ -209,7 +209,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 metadataStorageManager,
                 buildDataStorageManager(),
                 buildCommitLogManager(),
-                tmpDirectory, serverHostData, configuration
+                tmpDirectory, serverHostData, configuration, statsLogger
         );
 
         this.manager.setClearAtBoot(configuration.getBoolean(ServerConfiguration.PROPERTY_CLEAR_AT_BOOT, ServerConfiguration.PROPERTY_CLEAR_AT_BOOT_DEFAULT));
@@ -255,7 +255,8 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         String realHost = serverHostData.getAdditionalData().get(ServerConfiguration.PROPERTY_HOST);
         int realPort = Integer.parseInt(serverHostData.getAdditionalData().get(ServerConfiguration.PROPERTY_PORT));
 
-        NettyChannelAcceptor acceptor = new NettyChannelAcceptor(realHost, realPort, serverHostData.isSsl());
+        NettyChannelAcceptor acceptor = new NettyChannelAcceptor(realHost, realPort, serverHostData.isSsl(),
+                statsLogger.scope("network"));
         // with 'local' mode we are disabling network by default
         // but in case you want to run benchmarks with 'local' mode using
         // the client on a separate process/machine you should be able
@@ -358,7 +359,6 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 throw new RuntimeException();
         }
     }
-
 
     public void start() throws Exception {
         boolean startBookie = configuration.getBoolean(ServerConfiguration.PROPERTY_BOOKKEEPER_START,

--- a/herddb-core/src/test/java/herddb/core/FlushFileTest.java
+++ b/herddb-core/src/test/java/herddb/core/FlushFileTest.java
@@ -81,7 +81,9 @@ public class FlushFileTest extends BaseTestcase {
             @Override
             public CommitLog createCommitLog(String tableSpace, String name, String nodeId) {
                 try {
-                    return new FileCommitLog(folder.newFolder(tableSpace).toPath(), name, 1024 * 1024, threadPool, new NullStatsLogger());
+                    return new FileCommitLog(folder.newFolder(tableSpace).toPath(),
+                            name, 1024 * 1024, threadPool, new NullStatsLogger(), 
+                            l -> {});
                 } catch (IOException err) {
                     throw new RuntimeException(err);
                 }

--- a/herddb-core/src/test/java/herddb/core/SystemTablesTest.java
+++ b/herddb-core/src/test/java/herddb/core/SystemTablesTest.java
@@ -336,13 +336,16 @@ public class SystemTablesTest {
                         ).findAny().isPresent());
             }
 
-            manager.registerRunningStatement(new RunningStatementInfo("mock query", System.currentTimeMillis(), "tblspace1", "info"));
+            RunningStatementInfo runningStatementInfo = new RunningStatementInfo("mock query", System.currentTimeMillis(), "tblspace1", "info", 1);
+            manager.getRunningStatements().registerRunningStatement(runningStatementInfo);
             try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.sysstatements ", Collections.emptyList());) {
                 List<DataAccessor> records = scan.consume();
                 assertEquals(1, records.size());
                 records.forEach(s -> {
                     System.out.println("STATEMENT: " + s);
                 });
+            } finally {
+                manager.getRunningStatements().unregisterRunningStatement(runningStatementInfo);
             }
 
         }

--- a/herddb-core/src/test/java/herddb/file/FileCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/file/FileCommitLogTest.java
@@ -227,8 +227,8 @@ public class FileCommitLogTest {
                     writeCount++;
                 }
                 TestUtils.waitForCondition(() -> {
-                    Long qsize = log.getQueueSize().get();
-                    return qsize != null && qsize == 0;
+                    int qsize = log.getQueueSize();
+                    return qsize == 0;
                 }, TestUtils.NOOP, 100);
             }
             final long _endWrite = System.currentTimeMillis();

--- a/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
@@ -47,7 +47,7 @@ public class BasicHerdDBDataSource implements javax.sql.DataSource, AutoCloseabl
     protected HDBClient client;
     protected final Properties properties = new Properties();
     protected int loginTimeout;
-    protected int maxActive = 100;
+    protected int maxActive = 200;
 
     private static final Logger LOGGER = Logger.getLogger(BasicHerdDBDataSource.class.getName());
     protected String url;


### PR DESCRIPTION
Change grouping policy in FileCommitLog in order to group I/O, so that the main look in SpoolTask will be:
- collect entries until we hit max batch size or timeout
- write and fsync

Before this change in the loop we were taking and entry and writing it to disk, and then performing the fsych at every batchsize/timeout

Change default maxActive in HerdDBDatasource, because we are usually running with such parallelism in all the benchmarks.

Introduce metrics to monitor:
- network
- write batch size
- pending operations
- running statements