### PR TITLE
Add ability to flush log counting pending bytes and not operations

### DIFF
--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -72,6 +72,12 @@
             <groupId>org.apache.bookkeeper</groupId>
             <artifactId>bookkeeper-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.bookkeeper</groupId>
+            <artifactId>bookkeeper-server</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
         <dependency>             
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>            

--- a/herddb-core/src/test/java/herddb/core/AutocheckPointTest.java
+++ b/herddb-core/src/test/java/herddb/core/AutocheckPointTest.java
@@ -68,7 +68,7 @@ public class AutocheckPointTest {
         try (DBManager manager = new DBManager(nodeId,
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -118,7 +118,7 @@ public class AutocheckPointTest {
         try (DBManager manager = new DBManager(nodeId,
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);

--- a/herddb-core/src/test/java/herddb/core/CheckpointTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointTest.java
@@ -139,7 +139,7 @@ public class CheckpointTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmpDir, null, config1, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -176,7 +176,7 @@ public class CheckpointTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmpDir, null, config1, null)) {
             manager.start();
 
@@ -215,7 +215,7 @@ public class CheckpointTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmpDir, null, config1, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -250,7 +250,7 @@ public class CheckpointTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmpDir, null, config2, null)) {
             manager.start();
 
@@ -293,7 +293,7 @@ public class CheckpointTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmpDir, null, config1, null)) {
 
             // we want frequent checkpoints
@@ -388,7 +388,7 @@ public class CheckpointTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmpDir, null, config1, null)) {
 
             // we want frequent checkpoints

--- a/herddb-core/src/test/java/herddb/core/FlushFileTest.java
+++ b/herddb-core/src/test/java/herddb/core/FlushFileTest.java
@@ -42,6 +42,7 @@ import herddb.model.commands.DeleteStatement;
 import herddb.model.commands.GetStatement;
 import herddb.model.commands.InsertStatement;
 import herddb.model.commands.UpdateStatement;
+import herddb.server.ServerConfiguration;
 import herddb.storage.DataStorageManager;
 import herddb.utils.Bytes;
 import java.util.concurrent.ExecutorService;
@@ -82,8 +83,12 @@ public class FlushFileTest extends BaseTestcase {
             public CommitLog createCommitLog(String tableSpace, String name, String nodeId) {
                 try {
                     return new FileCommitLog(folder.newFolder(tableSpace).toPath(),
-                            name, 1024 * 1024, threadPool, new NullStatsLogger(), 
-                            l -> {});
+                            name, 1024 * 1024, threadPool, new NullStatsLogger(),
+                            l -> {
+                            }, ServerConfiguration.PROPERTY_MAX_UNSYNCHED_BATCH_DEFAULT,
+                            ServerConfiguration.PROPERTY_MAX_UNSYNCHED_BATCH_BYTES_DEFAULT,
+                            ServerConfiguration.PROPERTY_MAX_SYNC_TIME_DEFAULT, false /* require fsync */
+                    );
                 } catch (IOException err) {
                     throw new RuntimeException(err);
                 }

--- a/herddb-core/src/test/java/herddb/core/IndexCreationTest.java
+++ b/herddb-core/src/test/java/herddb/core/IndexCreationTest.java
@@ -85,7 +85,7 @@ public class IndexCreationTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -117,7 +117,7 @@ public class IndexCreationTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 

--- a/herddb-core/src/test/java/herddb/core/LocalTableSnapshotRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/core/LocalTableSnapshotRecoveryTest.java
@@ -62,7 +62,7 @@ public class LocalTableSnapshotRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -94,7 +94,7 @@ public class LocalTableSnapshotRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 

--- a/herddb-core/src/test/java/herddb/core/RestartPendingTransactionTest.java
+++ b/herddb-core/src/test/java/herddb/core/RestartPendingTransactionTest.java
@@ -73,7 +73,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -104,7 +104,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -130,7 +130,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -161,7 +161,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -187,7 +187,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -220,7 +220,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -246,7 +246,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -275,7 +275,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -301,7 +301,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -334,7 +334,7 @@ public class RestartPendingTransactionTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 

--- a/herddb-core/src/test/java/herddb/core/RestartTest.java
+++ b/herddb-core/src/test/java/herddb/core/RestartTest.java
@@ -82,7 +82,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -108,7 +108,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -122,7 +122,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -146,7 +146,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -174,7 +174,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -188,7 +188,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -212,7 +212,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -255,7 +255,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -279,7 +279,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -311,7 +311,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -335,7 +335,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -367,7 +367,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -394,7 +394,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -436,7 +436,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
            
@@ -473,7 +473,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -514,7 +514,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -554,7 +554,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -594,7 +594,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -631,7 +631,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -694,7 +694,7 @@ public class RestartTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 

--- a/herddb-core/src/test/java/herddb/core/SimpleBrinIndexRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleBrinIndexRecoveryTest.java
@@ -71,7 +71,7 @@ public class SimpleBrinIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -119,7 +119,7 @@ public class SimpleBrinIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             assertTrue(manager.waitForBootOfLocalTablespaces(10000));
@@ -147,7 +147,7 @@ public class SimpleBrinIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -196,7 +196,7 @@ public class SimpleBrinIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             assertTrue(manager.waitForBootOfLocalTablespaces(10000));
@@ -224,7 +224,7 @@ public class SimpleBrinIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -280,7 +280,7 @@ public class SimpleBrinIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             new FileDataStorageManager(dataPath),
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
             assertTrue(manager.waitForBootOfLocalTablespaces(10000));

--- a/herddb-core/src/test/java/herddb/core/SimpleDMLFileTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleDMLFileTest.java
@@ -53,7 +53,7 @@ public class SimpleDMLFileTest extends BaseTestcase {
 
     @Override
     protected CommitLogManager makeCommitLogManager() throws Exception {
-        return new FileCommitLogManager(folder.newFolder().toPath(), 64 * 1024 * 1024);
+        return new FileCommitLogManager(folder.newFolder().toPath());
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/core/SimpleIHashIndexRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleIHashIndexRecoveryTest.java
@@ -68,7 +68,7 @@ public class SimpleIHashIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -116,7 +116,7 @@ public class SimpleIHashIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
             assertTrue(manager.waitForTablespace("tblspace1", 10000));
@@ -144,7 +144,7 @@ public class SimpleIHashIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -193,7 +193,7 @@ public class SimpleIHashIndexRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
             assertTrue(manager.waitForTablespace("tblspace1", 10000));

--- a/herddb-core/src/test/java/herddb/core/SimpleRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleRecoveryTest.java
@@ -78,7 +78,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -103,7 +103,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -140,7 +140,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -165,7 +165,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -205,7 +205,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -233,7 +233,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -262,7 +262,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -294,7 +294,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -324,7 +324,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -362,7 +362,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -399,7 +399,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -444,7 +444,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -481,7 +481,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -515,7 +515,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -555,7 +555,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -589,7 +589,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -622,7 +622,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -656,7 +656,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -689,7 +689,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -738,7 +738,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -768,7 +768,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -807,7 +807,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -841,7 +841,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 
@@ -878,7 +878,7 @@ public class SimpleRecoveryTest {
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),
-                new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+                new FileCommitLogManager(logsPath),
                 tmoDir, null)) {
             manager.start();
 

--- a/herddb-core/src/test/java/herddb/file/CleanupOnCheckPointTest.java
+++ b/herddb-core/src/test/java/herddb/file/CleanupOnCheckPointTest.java
@@ -72,7 +72,7 @@ public class CleanupOnCheckPointTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             storageManager,
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 
@@ -141,7 +141,7 @@ public class CleanupOnCheckPointTest {
         try (DBManager manager = new DBManager("localhost",
             new FileMetadataStorageManager(metadataPath),
             storageManager,
-            new FileCommitLogManager(logsPath, 64 * 1024 * 1024),
+            new FileCommitLogManager(logsPath),
             tmoDir, null)) {
             manager.start();
 

--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -23,9 +23,26 @@ server.tmp.dir=tmp
 # metadata directory. in clustered mode metadata are store on ZooKeeper, not in this directory
 server.metadata.dir=metadata
 
+#####################################
+# standalone mode txlog configuration
+#####################################
+
 # this directory contains the transaction log
 server.log.dir=txlog
 
+# max number of unflushed operation
+# txlog.maxsyncbatchsize=10000
+# max number of unflushed bytes
+# txlog.maxsyncbatchbytes=524288
+# max time (in ms) to wait before acknowledging a write
+# txlog.synctimeout=1
+# background fsync task period, in seconds, 0 to disable
+# txlog.deferredsyncperiod=0
+# max txlog file size
+# txlog.maxfilesize=67108864;
+
+# force fsync on txlog (only standalone) and on data pages (standalone and cluster)
+#requirefsync=true
 
 # SSL configuration
 # if no file is configured a self signed certificate will be generated at every boot

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,43 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.apache.bookkeeper</groupId>
+                <artifactId>bookkeeper-server</artifactId>
+                <version>${libs.bookkeeper}</version>
+                <classifier>tests</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>netty</groupId>
+                        <artifactId>io.netty</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-digester</groupId>
+                        <artifactId>commons-digester</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-beanutils-core</groupId>
+                        <artifactId>commons-beanutils</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-cli</groupId>
+                        <artifactId>commons-cli</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jna</groupId>
+                        <artifactId>net.java.dev.jna</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <dependency>             
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Make configurable every parameter of FileCommitLog and add a max number of bytes waiting for flush.
This is better that putting a limit on the number of operations, because this kind of configuration fits better the underlying disk/SO and it does not depend on the size of writes (1000 writes of 1KB are different than 1000 writes of 1MB)

In order to add tests new metrics have been added as well

 