### PR TITLE
Open multiple sockets per server

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -62,6 +62,9 @@ public class ClientConfiguration {
     public static final String PROPERTY_SERVER_ADDRESS = "client.server.address";
     public static final String PROPERTY_SERVER_PORT = "client.server.port";
     public static final String PROPERTY_SERVER_SSL = "client.server.ssl";
+    
+    public static final String PROPERTY_MAX_CONNECTIONS_PER_SERVER = "client.maxconnections.perserver";
+    public static final int PROPERTY_MAX_CONNECTIONS_PER_SERVER_DEFAULT = 1;
 
     public static final String PROPERTY_ZOOKEEPER_ADDRESS = "client.zookeeper.address";
     public static final String PROPERTY_ZOOKEEPER_SESSIONTIMEOUT = "client.zookeeper.session.timeout";

--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -64,7 +64,7 @@ public class ClientConfiguration {
     public static final String PROPERTY_SERVER_SSL = "client.server.ssl";
     
     public static final String PROPERTY_MAX_CONNECTIONS_PER_SERVER = "client.maxconnections.perserver";
-    public static final int PROPERTY_MAX_CONNECTIONS_PER_SERVER_DEFAULT = 1;
+    public static final int PROPERTY_MAX_CONNECTIONS_PER_SERVER_DEFAULT = 10;
 
     public static final String PROPERTY_ZOOKEEPER_ADDRESS = "client.zookeeper.address";
     public static final String PROPERTY_ZOOKEEPER_SESSIONTIMEOUT = "client.zookeeper.session.timeout";

--- a/herddb-core/src/test/java/herddb/server/SimpleClientServerAutoTransactionTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientServerAutoTransactionTest.java
@@ -42,6 +42,7 @@ import herddb.client.ScanResultSet;
 import herddb.model.TableSpace;
 import herddb.model.TransactionContext;
 import herddb.utils.RawString;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Basic server/client boot test
@@ -75,7 +76,6 @@ public class SimpleClientServerAutoTransactionTest {
                 long countInsert = executeUpdateResult.updateCount;
                 Assert.assertEquals(1, countInsert);
 
-
                 GetResult res = connection.executeGet(TableSpace.DEFAULT,
                         "SELECT * FROM mytable WHERE id='test'", tx, true, Collections.emptyList());;
                 Map<RawString, Object> record = res.data;
@@ -100,11 +100,10 @@ public class SimpleClientServerAutoTransactionTest {
                     List<Map<String, Object>> all = scan.consume();
                     for (Map<String, Object> aa : all) {
                         assertEquals(RawString.of("jvm-local"), aa.get("address"));
-                        assertEquals("1", aa.get("id") + "");
                         assertEquals(RawString.of(ClientConfiguration.PROPERTY_CLIENT_USERNAME_DEFAULT), aa.get("username"));
                         assertNotNull(aa.get("connectionts"));
                     }
-                    assertEquals(1, all.size());
+                    assertTrue(all.size() >= 1);
                 }
 
             }

--- a/herddb-core/src/test/java/herddb/server/SimpleClientServerTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientServerTest.java
@@ -161,7 +161,7 @@ public class SimpleClientServerTest {
                         assertEquals(RawString.of(ClientConfiguration.PROPERTY_CLIENT_USERNAME_DEFAULT), aa.get("username"));
                         assertNotNull(aa.get("connectionts"));
                     }
-                    assertEquals(1, all.size());
+                    assertTrue(all.size() >= 1);
                 }
 
                 List<DMLResult> executeUpdatesWithoutParams = connection.executeUpdates(TableSpace.DEFAULT,

--- a/herddb-core/src/test/java/herddb/server/SimpleClientServerTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientServerTest.java
@@ -189,8 +189,7 @@ public class SimpleClientServerTest {
     }
 
     /**
-     * Testing that if the server discards the query the client will resend the
-     * PREPARE_STATEMENT COMMAND
+     * Testing that if the server discards the query the client will resend the PREPARE_STATEMENT COMMAND
      *
      * @throws Exception
      */

--- a/herddb-jdbc/src/test/java/herddb/jdbc/ConnectionPoolMaxActiveTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/ConnectionPoolMaxActiveTest.java
@@ -26,11 +26,8 @@ import java.sql.Connection;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
-import java.util.logging.SimpleFormatter;
 import static org.junit.Assert.assertEquals;
-import org.junit.Before;
+import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -69,7 +66,7 @@ public class ConnectionPoolMaxActiveTest {
                     }
                 }
                 // this is the number of sockets
-                assertEquals(1, server.getConnectionCount());
+                assertTrue(server.getConnectionCount() >= 1);
             } finally {
                 for (Connection c : connections) {
                     c.close();

--- a/herddb-jdbc/src/test/java/herddb/jdbc/GetConnectionTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/GetConnectionTest.java
@@ -61,7 +61,7 @@ public class GetConnectionTest {
 
             }
             Server server = dataSource.getServer();
-            assertEquals(1, server.getConnectionCount());
+            assertTrue(server.getConnectionCount() > 0);
 
             Connection _con;
             try (Connection con = dataSource.getConnection()) {

--- a/herddb-jdbc/src/test/java/herddb/jdbc/JdbcDriverTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/JdbcDriverTest.java
@@ -94,7 +94,9 @@ public class JdbcDriverTest {
                     count++;
                 }
                 assertTrue(count > 0);
-                assertEquals(1, server.getActualConnections().connections.size());
+                // since 0.8.0 we will open multiple sockets, so this test may flap
+                assertTrue(server.getActualConnections().connections.size() <= 2
+                        && server.getActualConnections().connections.size() >= 1);
             }
 
             try (Connection connection = DriverManager.getConnection("jdbc:herddb:server:localhost:9123?");
@@ -106,7 +108,9 @@ public class JdbcDriverTest {
                     count++;
                 }
                 assertTrue(count > 0);
-                assertEquals(1, server.getActualConnections().connections.size());
+                // since 0.8.0 we will open multiple sockets, so this test may flap
+                assertTrue(server.getActualConnections().connections.size() <= 3
+                        && server.getActualConnections().connections.size() >= 1);
             }
         }
     }


### PR DESCRIPTION
This is a very naive implementation, but it is the most effective way of opening multiple sockets towards each server.
I have a 30% gain in YCSB benchmarks.
Initially I was using Commons Pool but the overhead is overkilling.

The idea is to have a fixed number of RoutedClientSideConnections. RoutedClientSideConnection handles internally reconnnections, so it is not really a problem to have such naive pooling.