### PR TITLE
Fix/like multiline

### DIFF
--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -237,7 +237,6 @@ public interface SQLRecordPredicateFunctions {
 
         return matcher.matches();
 
-//        return a.toString().matches(like);
     }
 
 }

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -20,6 +20,8 @@
 package herddb.utils;
 
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Predicate expressed using SQL syntax
@@ -229,7 +231,13 @@ public interface SQLRecordPredicateFunctions {
                 .replace("\\*", "\\*")
                 .replace("%", ".*")
                 .replace("_", ".?");
-        return a.toString().matches(like);
+
+        Pattern pattern = Pattern.compile(like, Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(a.toString());
+
+        return matcher.matches();
+
+//        return a.toString().matches(like);
     }
 
 }

--- a/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
@@ -19,8 +19,6 @@
  */
 package herddb.utils;
 
-import herddb.utils.RawString;
-import herddb.utils.SQLRecordPredicateFunctions;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -37,11 +35,21 @@ public class SQLRecordPredicateFunctionsTest {
     public void testCompareAndLike() throws Exception {
         assertTrue(SQLRecordPredicateFunctions.like("test", "%est"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "test%"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%"));
         assertFalse(SQLRecordPredicateFunctions.like("test", "a%"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "%test%"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "%es%"));
         assertFalse(SQLRecordPredicateFunctions.like("tesst", "te_t"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "te_t"));
+
+        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "a%"));
+        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "%b"));
+        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "%"));
+        assertFalse(SQLRecordPredicateFunctions.like("ax\nb", "x%"));
+        assertFalse(SQLRecordPredicateFunctions.like("a\nxb", "x%"));
+        assertFalse(SQLRecordPredicateFunctions.like("ax\nb", "%x"));
+        assertFalse(SQLRecordPredicateFunctions.like("a\nxb", "%x"));
+
         assertTrue(SQLRecordPredicateFunctions.compare(1, 2) < 0);
         assertTrue(SQLRecordPredicateFunctions.compare(1, 1) == 0);
         assertTrue(SQLRecordPredicateFunctions.compare(2, 1) > 0);


### PR DESCRIPTION
Like filters doesn't work if string contains a new line.

For example:
- input: 'This is a\nmultiline string'
- expression: like '%multiline%'

The expression should be matched. Actually it doesn't match even if expression is just '%'.

A possible improvement would be compile like expression just one time in CompiledLikeExpression when "rightValue" is constant.