### PR TITLE
Cache Pattern for Like operator

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledLikeExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledLikeExpression.java
@@ -19,6 +19,7 @@
  */
 package herddb.sql.expressions;
 
+import herddb.core.HerdDBInternalException;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.DataAccessor;
@@ -32,13 +33,13 @@ public class CompiledLikeExpression extends CompiledBinarySQLExpression {
     private final boolean not;
     private final Pattern rightConstantPattern;
 
-    public CompiledLikeExpression(boolean not, CompiledSQLExpression left, CompiledSQLExpression right) {
+    public CompiledLikeExpression(boolean not, CompiledSQLExpression left, CompiledSQLExpression right) throws HerdDBInternalException {
         super(left, right);
         this.not = not;   
         this.rightConstantPattern = compilePattern(right);
     }
     
-    private static Pattern compilePattern(CompiledSQLExpression exp) {
+    private static Pattern compilePattern(CompiledSQLExpression exp) throws HerdDBInternalException  {
         if (exp instanceof ConstantExpression) {
             ConstantExpression ce = (ConstantExpression) exp;
             if (ce.isNull()) {

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledLikeExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledLikeExpression.java
@@ -21,22 +21,47 @@ package herddb.sql.expressions;
 
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
+import herddb.utils.DataAccessor;
+import herddb.utils.SQLRecordPredicateFunctions;
 import static herddb.utils.SQLRecordPredicateFunctions.like;
+import static herddb.utils.SQLRecordPredicateFunctions.matches;
+import java.util.regex.Pattern;
 
 public class CompiledLikeExpression extends CompiledBinarySQLExpression {
 
     private final boolean not;
+    private final Pattern rightConstantPattern;
 
     public CompiledLikeExpression(boolean not, CompiledSQLExpression left, CompiledSQLExpression right) {
         super(left, right);
-        this.not = not;
+        this.not = not;   
+        this.rightConstantPattern = compilePattern(right);
+    }
+    
+    private static Pattern compilePattern(CompiledSQLExpression exp) {
+        if (exp instanceof ConstantExpression) {
+            ConstantExpression ce = (ConstantExpression) exp;
+            if (ce.isNull()) {
+                return null;
+            }
+            return SQLRecordPredicateFunctions.compileLikePattern(
+                    ce.evaluate(DataAccessor.NULL, null).toString()
+            );
+        } else {
+            return null;
+        }
     }
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
         Object leftValue = left.evaluate(bean, context);
-        Object rightValue = right.evaluate(bean, context);
-        boolean ok = like(leftValue, rightValue);
+        boolean ok;
+        if (rightConstantPattern != null) {
+            ok = matches(leftValue, rightConstantPattern);
+        } else {
+            Object rightValue = right.evaluate(bean, context);
+            ok = like(leftValue, rightValue);
+        }
         if (not) {
             return !ok;
         } else {

--- a/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
@@ -287,6 +287,13 @@ public class SimpleOperatorsTest {
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE '%AbBbCc%'", Collections.emptyList());) {
                 assertEquals(1, scan1.consume().size());
             }
+            
+            // bad "constant" pattern
+            herddb.utils.TestUtils.assertThrows(herddb.core.HerdDBInternalException.class, () -> {
+                scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE '%AbBbC(.c%'", Collections.emptyList());
+            });
+            
+            
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE ?", Arrays.asList("%AbBbCc%"));) {
                 assertEquals(1, scan1.consume().size());
             }

--- a/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
@@ -287,6 +287,9 @@ public class SimpleOperatorsTest {
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE '%AbBbCc%'", Collections.emptyList());) {
                 assertEquals(1, scan1.consume().size());
             }
+            try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE ?", Arrays.asList("%AbBbCc%"));) {
+                assertEquals(1, scan1.consume().size());
+            }
 
             // In expressions
             // Warning: jsqlParser doesn't handle this kind of expressions in select clause

--- a/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
@@ -22,6 +22,15 @@ package herddb.core;
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.executeUpdate;
 import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;
@@ -31,12 +40,6 @@ import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
 import herddb.sql.CalcitePlanner;
 import herddb.sql.DDLSQLPlanner;
-import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Collections;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
 
 /**
  *
@@ -287,13 +290,8 @@ public class SimpleOperatorsTest {
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE '%AbBbCc%'", Collections.emptyList());) {
                 assertEquals(1, scan1.consume().size());
             }
-            
-            // bad "constant" pattern
-            herddb.utils.TestUtils.assertThrows(herddb.core.HerdDBInternalException.class, () -> {
-                scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE '%AbBbC(.c%'", Collections.emptyList());
-            });
-            
-            
+
+
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE ?", Arrays.asList("%AbBbCc%"));) {
                 assertEquals(1, scan1.consume().size());
             }

--- a/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
@@ -19,12 +19,10 @@
  */
 package herddb.jdbc;
 
-import herddb.client.ClientConfiguration;
-import herddb.client.HDBClient;
-import herddb.model.TableSpace;
-import herddb.server.Server;
-import herddb.server.ServerConfiguration;
-import herddb.server.StaticClientSideMetadataProvider;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -33,12 +31,17 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.model.TableSpace;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.server.StaticClientSideMetadataProvider;
 
 /**
  * Basic client testing
@@ -108,7 +111,7 @@ public class SystemTablesTest {
                         assertTrue(records.stream().filter(s -> s.contains("mytable")).findAny().isPresent());
                         assertEquals(1, records.size());
                     }
-                    try (ResultSet rs = metaData.getTables(null, null, "m%table_", null)) {
+                    try (ResultSet rs = metaData.getTables(null, null, "m_table%", null)) {
                         List<List<String>> records = new ArrayList<>();
                         while (rs.next()) {
                             List<String> record = new ArrayList<>();

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -19,11 +19,11 @@
  */
 package herddb.utils;
 
-import herddb.core.HerdDBInternalException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+
+import herddb.core.HerdDBInternalException;
 
 /**
  * Predicate expressed using SQL syntax
@@ -225,17 +225,36 @@ public interface SQLRecordPredicateFunctions {
     }
 
     public static Pattern compileLikePattern(String b) throws HerdDBInternalException {
-        String like = b
-                .replace("\\", "\\\\")
-                .replace("[", "\\[")
-                .replace(".", "\\.")
-                .replace("\\*", "\\*")
-                .replace("%", ".*")
-                .replace("(", "\\(")
-                .replace("+", "\\+")
-                .replace("|", "\\|")
-                .replace("_", ".?");
-        System.out.println("LIKE '" + b + "' -> '" + like + "'");
+
+        /*
+         * We presume that in string there will be 1 or 2 '%' or '_' characters. To avoid multiple array
+         * copies in standard cases we preallocate a builder size of string input size plus 6 chars per
+         * special character (4 chars for wrapping quoting sequence and 2 for pattern characters: \\E.*\\Q
+         * or \\E.?\\Q) plus 4 chars for whole string wrapping quote sequence (\\Qstring\\E).
+         */
+        final StringBuilder builder = new StringBuilder(b.length() + 18);
+
+        builder.append("\\Q");
+
+        int limit = b.length();
+        for (int idx = 0; idx < limit; ++idx) {
+            char ch = b.charAt(idx);
+            switch(ch) {
+                case '%':
+                    builder.append("\\E.*\\Q");
+                    break;
+                case '_':
+                    builder.append("\\E.?\\Q");
+                    break;
+                default:
+                    builder.append(ch);
+                    break;
+            }
+        }
+
+        builder.append("\\E");
+
+        String like = builder.toString();
         try {
             return Pattern.compile(like, Pattern.DOTALL);
         } catch (IllegalArgumentException err) {

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -244,7 +244,7 @@ public interface SQLRecordPredicateFunctions {
                     builder.append("\\E.*\\Q");
                     break;
                 case '_':
-                    builder.append("\\E.?\\Q");
+                    builder.append("\\E.{1}\\Q");
                     break;
                 default:
                     builder.append(ch);

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -222,21 +222,29 @@ public interface SQLRecordPredicateFunctions {
         return Objects.equals(a, b);
     }
 
-    public static boolean like(Object a, Object b) {
-        if (a == null || b == null) {
-            return false;
-        }
-        String like = b.toString()
+    public static Pattern compileLikePattern(String b) {        
+        String like = b
                 .replace(".", "\\.")
                 .replace("\\*", "\\*")
                 .replace("%", ".*")
                 .replace("_", ".?");
 
-        Pattern pattern = Pattern.compile(like, Pattern.DOTALL);
+        return Pattern.compile(like, Pattern.DOTALL);
+    }
+    public static boolean like(Object a, Object b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        Pattern pattern = compileLikePattern(b.toString());
+        return matches(a, pattern);
+    }
+    
+    public static boolean matches(Object a, Pattern pattern) {
+        if (a == null) {
+            return false;
+        }        
         Matcher matcher = pattern.matcher(a.toString());
-
         return matcher.matches();
-
     }
 
 }

--- a/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
@@ -41,12 +41,12 @@ public class SQLRecordPredicateFunctionsTest {
         assertTrue(SQLRecordPredicateFunctions.like("test", "%es%"));
         assertFalse(SQLRecordPredicateFunctions.like("tesst", "te_t"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "te_t"));
-        assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "%(fo"));
-        assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "oo)%"));
         assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "%(foo)%"));
+        assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "%(fo"));
+        assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "oo)%"));
         assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo]%"));
-        assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo"));
-        assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "foo]%"));
+        assertFalse(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo"));
+        assertFalse(SQLRecordPredicateFunctions.like("bar [foo]", "foo]%"));
         assertTrue(SQLRecordPredicateFunctions.like("bar+foo", "%+%"));
 
         assertTrue(SQLRecordPredicateFunctions.like("a\nb", "a%"));

--- a/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
@@ -33,14 +33,32 @@ public class SQLRecordPredicateFunctionsTest {
 
     @Test
     public void testCompareAndLike() throws Exception {
+        assertTrue(SQLRecordPredicateFunctions.like("test", "test"));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "est"));
+
+
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%%"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "____"));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "___"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "_%"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%_"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "_%_"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%_%"));
+
         assertTrue(SQLRecordPredicateFunctions.like("test", "%est"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "test%"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%"));
         assertFalse(SQLRecordPredicateFunctions.like("test", "a%"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "%test%"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "%es%"));
+
         assertFalse(SQLRecordPredicateFunctions.like("tesst", "te_t"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "te_t"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "_est"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "tes_"));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "tes__"));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "__est"));
+
         assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "%(foo)%"));
         assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "%(fo"));
         assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "oo)%"));

--- a/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
@@ -41,6 +41,13 @@ public class SQLRecordPredicateFunctionsTest {
         assertTrue(SQLRecordPredicateFunctions.like("test", "%es%"));
         assertFalse(SQLRecordPredicateFunctions.like("tesst", "te_t"));
         assertTrue(SQLRecordPredicateFunctions.like("test", "te_t"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "%(fo"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "oo)%"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "%(foo)%"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo]%"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "foo]%"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar+foo", "%+%"));
 
         assertTrue(SQLRecordPredicateFunctions.like("a\nb", "a%"));
         assertTrue(SQLRecordPredicateFunctions.like("a\nb", "%b"));


### PR DESCRIPTION
Cache the "Pattern" in LIKE operator in case of a constant expression,
this way we will "parse" the pattern only once in case of repeated queries.

Follow up for  789e436f0b29be184d13d2d81a8128b3f8424d32
