### PR TITLE
Allow Bytes to wrap a slice of byte[]

### DIFF
--- a/herddb-core/src/main/java/herddb/backup/TableSpaceDumpFileWriter.java
+++ b/herddb-core/src/main/java/herddb/backup/TableSpaceDumpFileWriter.java
@@ -91,8 +91,8 @@ class TableSpaceDumpFileWriter extends TableSpaceDumpReceiver {
         try {
             out.writeVInt(record.size());
             for (Record r : record) {
-                out.writeArray(r.key.data);
-                out.writeArray(r.value.data);
+                out.writeArray(r.key);
+                out.writeArray(r.value);
             }
             tableRecordsCount += record.size();
         } catch (IOException err) {

--- a/herddb-core/src/main/java/herddb/backup/TableSpaceRestoreSourceFromFile.java
+++ b/herddb-core/src/main/java/herddb/backup/TableSpaceRestoreSourceFromFile.java
@@ -70,8 +70,8 @@ class TableSpaceRestoreSourceFromFile extends TableSpaceRestoreSource {
             for (int i = 0; i < numRecords; i++) {
                 long ledgerId = in.readVLong();
                 long offset = in.readVLong();
-                byte[] value = in.readArray();
-                records.add(new KeyValue(new LogSequenceNumber(ledgerId, offset).serialize(), value));
+                Bytes value = in.readBytes();
+                records.add(new KeyValue(Bytes.from_array(new LogSequenceNumber(ledgerId, offset).serialize()), value));
             }
             return records;
         } catch (IOException err) {
@@ -107,8 +107,8 @@ class TableSpaceRestoreSourceFromFile extends TableSpaceRestoreSource {
             listener.log("sendtabledata", "sending " + numRecords + ", total " + currentTableSize, Collections.singletonMap("count", numRecords));
             List<KeyValue> records = new ArrayList<>(numRecords);
             for (int i = 0; i < numRecords; i++) {
-                byte[] key = in.readArray();
-                byte[] value = in.readArray();
+                Bytes key = in.readBytes();
+                Bytes value = in.readBytes();
                 records.add(new KeyValue(key, value));
             }
             currentTableSize += numRecords;

--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -195,7 +195,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
                             case "data": {
                                 List<Record> records = new ArrayList<>();
                                 PduCodec.TablespaceDumpData.readRecords(message, (key, value) -> {
-                                    records.add(new Record(new Bytes(key), new Bytes(value)));
+                                    records.add(new Record(Bytes.from_array(key), Bytes.from_array(value)));
                                 });
                                 receiver.receiveTableDataChunk(records);
                                 break;

--- a/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
+++ b/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
@@ -118,13 +118,13 @@ public class DataAccessorForFullRecord extends AbstractDataAccessor {
             // no need to create a Map
             if (table.primaryKey.length == 1) {
                 String pkField = table.primaryKey[0];
-                Object value = RecordSerializer.deserialize(record.key.data, table.getColumn(pkField).type);
+                Object value = RecordSerializer.deserialize(record.key, table.getColumn(pkField).type);
                 consumer.accept(pkField, value);
                 if (value instanceof RawString) {
                     ((RawString) value).recycle();
                 }
             } else {
-                try (final SimpleByteArrayInputStream key_in = new SimpleByteArrayInputStream(record.key.data); final ExtendedDataInputStream din = new ExtendedDataInputStream(key_in)) {
+                try (final ByteArrayCursor din = record.key.newCursor()) {
                     for (String primaryKeyColumn : table.primaryKey) {
                         byte[] value = din.readArray();
                         Object theValue = RecordSerializer.deserialize(value, table.getColumn(primaryKeyColumn).type);
@@ -138,7 +138,7 @@ public class DataAccessorForFullRecord extends AbstractDataAccessor {
                 }
             }
 
-            try (ByteArrayCursor din = ByteArrayCursor.wrap(record.value.data);) {
+            try (ByteArrayCursor din = record.value.newCursor()) {
                 while (!din.isEof()) {
                     int serialPosition;
                     serialPosition = din.readVIntNoEOFException();

--- a/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
+++ b/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
@@ -25,9 +25,8 @@ import herddb.model.Record;
 import herddb.model.Table;
 import herddb.utils.AbstractDataAccessor;
 import herddb.utils.ByteArrayCursor;
-import herddb.utils.ExtendedDataInputStream;
+import herddb.utils.Bytes;
 import herddb.utils.RawString;
-import herddb.utils.SimpleByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -126,7 +125,7 @@ public class DataAccessorForFullRecord extends AbstractDataAccessor {
             } else {
                 try (final ByteArrayCursor din = record.key.newCursor()) {
                     for (String primaryKeyColumn : table.primaryKey) {
-                        byte[] value = din.readArray();
+                        Bytes value = din.readBytesNoCopy();
                         Object theValue = RecordSerializer.deserialize(value, table.getColumn(primaryKeyColumn).type);
                         consumer.accept(primaryKeyColumn, theValue);
                         if (theValue instanceof RawString) {

--- a/herddb-core/src/main/java/herddb/core/SingleTableDumper.java
+++ b/herddb-core/src/main/java/herddb/core/SingleTableDumper.java
@@ -87,7 +87,7 @@ class SingleTableDumper implements FullTableScanConsumer {
     @Override
     public void acceptRecord(Record record) {
         try {
-            batch.add(new KeyValue(record.key.data, record.value.data));
+            batch.add(new KeyValue(record.key, record.value));
             if (batch.size() == fetchSize) {
                 sendBatch();
             }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1736,8 +1736,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             StatementEvaluationContext context) {
         Bytes key;
         try {
-            key = Bytes.from_nullable_array(get.getKey().computeNewValue(null, context, tableContext))
-                    ;
+            key = Bytes.from_nullable_array(get.getKey().computeNewValue(null, context, tableContext));
         } catch (StatementExecutionException validationError) {
             return FutureUtils.exception(validationError);
         }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -395,7 +395,7 @@ public class TableSpaceManager {
             }
             break;
             case LogEntryType.CREATE_TABLE: {
-                Table table = Table.deserialize(entry.value);
+                Table table = Table.deserialize(entry.value.to_array());
                 if (entry.transactionId > 0) {
                     long id = entry.transactionId;
                     Transaction transaction = transactions.get(id);
@@ -409,7 +409,7 @@ public class TableSpaceManager {
             }
             break;
             case LogEntryType.CREATE_INDEX: {
-                Index index = Index.deserialize(entry.value);
+                Index index = Index.deserialize(entry.value.to_array());
                 if (entry.transactionId > 0) {
                     long id = entry.transactionId;
                     Transaction transaction = transactions.get(id);
@@ -446,7 +446,7 @@ public class TableSpaceManager {
             }
             break;
             case LogEntryType.DROP_INDEX: {
-                String indexName = Bytes.from_array(entry.value).to_string();
+                String indexName = entry.value.to_string();
                 if (entry.transactionId > 0) {
                     long id = entry.transactionId;
                     Transaction transaction = transactions.get(id);
@@ -471,7 +471,7 @@ public class TableSpaceManager {
             }
             break;
             case LogEntryType.ALTER_TABLE: {
-                Table table = Table.deserialize(entry.value);
+                Table table = Table.deserialize(entry.value.to_array());
                 alterTable(table, null);
                 writeTablesOnDataStorageManager(position);
             }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -878,7 +878,7 @@ public class TableSpaceManager {
         List<KeyValue> encodedTransactions = batch
                 .stream()
                 .map(tr -> {
-                    return new KeyValue(Bytes.longToByteArray(tr.transactionId), tr.serialize());
+                    return new KeyValue(Bytes.from_long(tr.transactionId), Bytes.from_array(tr.serialize()));
                 })
                 .collect(Collectors.toList());
         long id = _channel.generateRequestId();
@@ -896,7 +896,8 @@ public class TableSpaceManager {
     private void sendDumpedCommitLog(List<DumpedLogEntry> txlogentries, Channel _channel, String dumpId, final int timeout) throws TimeoutException, InterruptedException {
         List<KeyValue> batch = new ArrayList<>();
         for (DumpedLogEntry e : txlogentries) {
-            batch.add(new KeyValue(e.logSequenceNumber.serialize(), e.entryData));
+            batch.add(new KeyValue(Bytes.from_array(e.logSequenceNumber.serialize()),
+                    Bytes.from_array(e.entryData)));
         }
         long id = _channel.generateRequestId();
         try (Pdu response_to_txlog = _channel.sendMessageWithPduReply(id, PduCodec.TablespaceDumpData.write(

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -278,9 +278,9 @@ public class FileDataStorageManager extends DataStorageManager {
             int numRecords = dataIn.readInt();
             result = new ArrayList<>(numRecords);
             for (int i = 0; i < numRecords; i++) {
-                byte[] key = dataIn.readArray();
-                byte[] value = dataIn.readArray();
-                result.add(new Record(new Bytes(key), new Bytes(value)));
+                Bytes key = dataIn.readBytes();
+                Bytes value = dataIn.readBytes();
+                result.add(new Record(key, value));
             }
             hashFromDigest = hash.hash();
             hashFromFile = dataIn.readLong();
@@ -307,9 +307,9 @@ public class FileDataStorageManager extends DataStorageManager {
             int numRecords = dataIn.readInt();
             result = new ArrayList<>(numRecords);
             for (int i = 0; i < numRecords; i++) {
-                byte[] key = dataIn.readArray();
-                byte[] value = dataIn.readArray();
-                result.add(new Record(new Bytes(key), new Bytes(value)));
+                Bytes key = dataIn.readBytes();
+                Bytes value = dataIn.readBytes();
+                result.add(new Record(key, value));
             }
             hashFromDigest = hash.hash();
             hashFromFile = dataIn.readLong();

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -456,7 +456,7 @@ public class FileDataStorageManager extends DataStorageManager {
             TableStatus latestStatus;
             if (lastFile == null) {
                 latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
-                        Bytes.from_long(1).data, 1, Collections.emptyMap());
+                        Bytes.longToByteArray(1), 1, Collections.emptyMap());
             } else {
                 latestStatus = readTableStatusFromFile(lastFile);
             }
@@ -821,8 +821,8 @@ public class FileDataStorageManager extends DataStorageManager {
             dataOutput.writeVLong(0); // flags for future implementations
             dataOutput.writeInt(newPage.size());
             for (Record record : newPage) {
-                dataOutput.writeArray(record.key.data);
-                dataOutput.writeArray(record.value.data);
+                dataOutput.writeArray(record.key);
+                dataOutput.writeArray(record.value);
             }
 
             long size = hash.size();

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -130,7 +130,7 @@ public class BRINIndexManager extends AbstractIndexManager {
                         out.writeByte(blockFlags);
 
                         if (!head) {
-                            out.writeArray(md.firstKey.data);
+                            out.writeArray(md.firstKey);
                         }
                         out.writeVLong(md.blockId);
                         out.writeVLong(md.size);
@@ -144,8 +144,8 @@ public class BRINIndexManager extends AbstractIndexManager {
                 case TYPE_BLOCKDATA:
                     out.writeVInt(pageData.size());
                     for (Map.Entry<Bytes, Bytes> entry : pageData) {
-                        out.writeArray(entry.getKey().data);
-                        out.writeArray(entry.getValue().data);
+                        out.writeArray(entry.getKey());
+                        out.writeArray(entry.getValue());
                     }
                     break;
                 default:

--- a/herddb-core/src/main/java/herddb/log/LogEntry.java
+++ b/herddb-core/src/main/java/herddb/log/LogEntry.java
@@ -61,11 +61,11 @@ public class LogEntry {
     public final short type;
     public final long transactionId;
     public final String tableName;
-    public final byte[] key;
-    public final byte[] value;
+    public final Bytes key;
+    public final Bytes value;
     public final long timestamp;
 
-    public LogEntry(long timestamp, short type, long transactionId, String tableName, byte[] key, byte[] value) {
+    public LogEntry(long timestamp, short type, long transactionId, String tableName, Bytes key, Bytes value) {
         this.timestamp = timestamp;
         this.type = type;
         this.transactionId = transactionId;
@@ -167,40 +167,40 @@ public class LogEntry {
             long transactionId = dis.readLong();
             dis.readUTF(); // in 0.2 it was 'tablespace uuid'
 
-            byte[] key = null;
-            byte[] value = null;
+            Bytes key = null;
+            Bytes value = null;
             String tableName = null;
             switch (type) {
                 case LogEntryType.UPDATE:
                     tableName = dis.readUTF();
-                    key = dis.readArray();
-                    value = dis.readArray();
+                    key = dis.readBytes();
+                    value = dis.readBytes();
                     break;
                 case LogEntryType.INSERT:
                     tableName = dis.readUTF();
-                    key = dis.readArray();
-                    value = dis.readArray();
+                    key = dis.readBytes();
+                    value = dis.readBytes();
                     break;
                 case LogEntryType.DELETE:
                     tableName = dis.readUTF();
-                    key = dis.readArray();
+                    key = dis.readBytes();
                     break;
                 case LogEntryType.DROP_TABLE:
                 case LogEntryType.TRUNCATE_TABLE:
                     tableName = dis.readUTF();
                     break;
                 case LogEntryType.DROP_INDEX:
-                    value = dis.readArray();
+                    value = dis.readBytes();
                     break;
                 case LogEntryType.CREATE_INDEX:
                     tableName = dis.readUTF();
-                    value = dis.readArray();
+                    value = dis.readBytes();
                     break;
                 case LogEntryType.CREATE_TABLE:
                 case LogEntryType.ALTER_TABLE:
                     // value contains the table definition
                     tableName = dis.readUTF();
-                    value = dis.readArray();
+                    value = dis.readBytes();
                     break;
                 case LogEntryType.BEGINTRANSACTION:
                 case LogEntryType.COMMITTRANSACTION:
@@ -223,7 +223,7 @@ public class LogEntry {
 
     @Override
     public String toString() {
-        return "LogEntry{" + "type=" + type + ", transactionId=" + transactionId + ", tableName=" + tableName + ", key=" + (key != null ? Bytes.from_array(key) : null) + ", value=" + Bytes.from_array(value) + ", timestamp=" + timestamp + '}';
+        return "LogEntry{" + "type=" + type + ", transactionId=" + transactionId + ", tableName=" + tableName + ", key=" + key + ", value=" + value + ", timestamp=" + timestamp + '}';
     }
 
 }

--- a/herddb-core/src/main/java/herddb/log/LogEntryFactory.java
+++ b/herddb-core/src/main/java/herddb/log/LogEntryFactory.java
@@ -46,7 +46,7 @@ public class LogEntryFactory {
     }
 
     public static LogEntry dropIndex(String indexName, Transaction transaction) {
-        return new LogEntry(System.currentTimeMillis(), LogEntryType.DROP_INDEX, transaction != null ? transaction.transactionId : 0, null, null, Bytes.from_string(indexName).data);
+        return new LogEntry(System.currentTimeMillis(), LogEntryType.DROP_INDEX, transaction != null ? transaction.transactionId : 0, null, null, Bytes.string_to_array(indexName));
     }
 
     public static LogEntry beginTransaction(long transactionId) {

--- a/herddb-core/src/main/java/herddb/log/LogEntryFactory.java
+++ b/herddb-core/src/main/java/herddb/log/LogEntryFactory.java
@@ -33,12 +33,12 @@ public class LogEntryFactory {
 
     public static LogEntry createTable(Table table, Transaction transaction) {
         byte[] payload = table.serialize();
-        return new LogEntry(System.currentTimeMillis(), LogEntryType.CREATE_TABLE, transaction != null ? transaction.transactionId : 0, table.name, null, payload);
+        return new LogEntry(System.currentTimeMillis(), LogEntryType.CREATE_TABLE, transaction != null ? transaction.transactionId : 0, table.name, null, Bytes.from_array(payload));
     }
 
     public static LogEntry alterTable(Table table, Transaction transaction) {
         byte[] payload = table.serialize();
-        return new LogEntry(System.currentTimeMillis(), LogEntryType.ALTER_TABLE, transaction != null ? transaction.transactionId : 0, table.name, null, payload);
+        return new LogEntry(System.currentTimeMillis(), LogEntryType.ALTER_TABLE, transaction != null ? transaction.transactionId : 0, table.name, null, Bytes.from_array(payload));
     }
 
     public static LogEntry dropTable(String table, Transaction transaction) {
@@ -46,7 +46,7 @@ public class LogEntryFactory {
     }
 
     public static LogEntry dropIndex(String indexName, Transaction transaction) {
-        return new LogEntry(System.currentTimeMillis(), LogEntryType.DROP_INDEX, transaction != null ? transaction.transactionId : 0, null, null, Bytes.string_to_array(indexName));
+        return new LogEntry(System.currentTimeMillis(), LogEntryType.DROP_INDEX, transaction != null ? transaction.transactionId : 0, null, null, Bytes.from_string(indexName));
     }
 
     public static LogEntry beginTransaction(long transactionId) {
@@ -61,21 +61,22 @@ public class LogEntryFactory {
         return new LogEntry(System.currentTimeMillis(), LogEntryType.ROLLBACKTRANSACTION, transactionId, null, null, null);
     }
 
-    public static LogEntry insert(Table table, byte[] key, byte[] value, Transaction transaction) {
+    public static LogEntry insert(Table table, Bytes key, Bytes value, Transaction transaction) {
         return new LogEntry(System.currentTimeMillis(), LogEntryType.INSERT, transaction != null ? transaction.transactionId : 0, table.name, key, value);
     }
 
-    public static LogEntry update(Table table, byte[] key, byte[] value, Transaction transaction) {
+    public static LogEntry update(Table table, Bytes key, Bytes value, Transaction transaction) {
         return new LogEntry(System.currentTimeMillis(), LogEntryType.UPDATE, transaction != null ? transaction.transactionId : 0, table.name, key, value);
     }
 
-    public static LogEntry delete(Table table, byte[] key, Transaction transaction) {
+    public static LogEntry delete(Table table, Bytes key, Transaction transaction) {
         return new LogEntry(System.currentTimeMillis(), LogEntryType.DELETE, transaction != null ? transaction.transactionId : 0, table.name, key, null);
     }
 
     public static LogEntry createIndex(Index index, Transaction transaction) {
         byte[] payload = index.serialize();
-        return new LogEntry(System.currentTimeMillis(), LogEntryType.CREATE_INDEX, transaction != null ? transaction.transactionId : 0, index.table, null, payload);
+        return new LogEntry(System.currentTimeMillis(), LogEntryType.CREATE_INDEX, transaction != null ? transaction.transactionId : 0, index.table, null, Bytes.from_array(payload))
+                ;
     }
 
     public static LogEntry truncate(Table table, Transaction transaction) {

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -53,6 +53,7 @@ import herddb.storage.DataStorageManagerException;
 import herddb.storage.FullTableScanConsumer;
 import herddb.storage.IndexStatus;
 import herddb.storage.TableStatus;
+import herddb.utils.ByteArrayCursor;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
@@ -127,7 +128,8 @@ public class MemoryDataStorageManager extends DataStorageManager {
         if (page == null) {
             throw new DataStorageManagerException("No such page: " + tableSpace + "." + indexName + " page " + pageId);
         }
-        try (SimpleByteArrayInputStream in = new SimpleByteArrayInputStream(page.data);
+        //TODO: do not perform copy
+        try (SimpleByteArrayInputStream in = new SimpleByteArrayInputStream(page.to_array());
             ExtendedDataInputStream ein = new ExtendedDataInputStream(in)) {
             return reader.read(ein);
         } catch (IOException e) {
@@ -174,12 +176,12 @@ public class MemoryDataStorageManager extends DataStorageManager {
         TableStatus latestStatus;
         if (max == null) {
             latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
-                Bytes.from_long(1).data, 1, Collections.emptyMap());
+                Bytes.longToByteArray(1), 1, Collections.emptyMap());
         } else {
             byte[] data = tableStatuses.get(checkpointName(tableSpace, tableName, max));
             if (data == null) {
                 latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
-                    Bytes.from_long(1).data, 1, Collections.emptyMap());
+                    Bytes.longToByteArray(1), 1, Collections.emptyMap());
             } else {
                 try {
                     try (InputStream input = new SimpleByteArrayInputStream(data);

--- a/herddb-core/src/main/java/herddb/model/ConstValueRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/model/ConstValueRecordFunction.java
@@ -20,6 +20,7 @@
 package herddb.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import herddb.utils.Bytes;
 
 /**
  * A Constant value for the record
@@ -33,6 +34,10 @@ public class ConstValueRecordFunction extends RecordFunction {
 
     public ConstValueRecordFunction(byte[] value) {
         this.value = value;
+    }
+    
+    public ConstValueRecordFunction(Bytes value) {
+        this.value = value.to_array();
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -332,8 +332,8 @@ public class Transaction {
             out.writeUTF(table.getKey());
             out.writeVInt(table.getValue().size());
             for (Record r : table.getValue().values()) {
-                out.writeArray(r.key.data);
-                out.writeArray(r.value.data);
+                out.writeArray(r.key);
+                out.writeArray(r.value);
             }
         }
         out.writeVInt(newRecords.size());
@@ -341,8 +341,8 @@ public class Transaction {
             out.writeUTF(table.getKey());
             out.writeVInt(table.getValue().size());
             for (Record r : table.getValue().values()) {
-                out.writeArray(r.key.data);
-                out.writeArray(r.value.data);
+                out.writeArray(r.key);
+                out.writeArray(r.value);
             }
         }
         out.writeVInt(deletedRecords.size());
@@ -350,7 +350,7 @@ public class Transaction {
             out.writeUTF(table.getKey());
             out.writeVInt(table.getValue().size());
             for (Bytes key : table.getValue()) {
-                out.writeArray(key.data);
+                out.writeArray(key);
             }
         }
         if (newTables == null) {

--- a/herddb-core/src/main/java/herddb/model/commands/DeleteStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/DeleteStatement.java
@@ -54,7 +54,7 @@ public class DeleteStatement extends DMLStatement {
             }
         }
         if (key != null) {
-            predicate.setIndexOperation(new PrimaryIndexSeek(new ConstValueRecordFunction(key.data)));
+            predicate.setIndexOperation(new PrimaryIndexSeek(new ConstValueRecordFunction(key)));
         }
         this.predicate = predicate;
     }

--- a/herddb-core/src/main/java/herddb/model/commands/GetStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/GetStatement.java
@@ -40,7 +40,7 @@ public class GetStatement extends TableAwareStatement {
 
     public GetStatement(String tableSpace, String table, Bytes key, Predicate predicate, boolean requireLock) {
         super(table, tableSpace);
-        this.key = new ConstValueRecordFunction(key.data);
+        this.key = new ConstValueRecordFunction(key);
         this.predicate = predicate;
         this.requireLock = requireLock;
     }

--- a/herddb-core/src/main/java/herddb/model/commands/InsertStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/InsertStatement.java
@@ -36,8 +36,8 @@ public class InsertStatement extends DMLStatement {
 
     public InsertStatement(String tableSpace, String table, Record record) {
         super(table, tableSpace);
-        this.keyFunction = new ConstValueRecordFunction(record.key.data);
-        this.valuesFunction = new ConstValueRecordFunction(record.value.data);
+        this.keyFunction = new ConstValueRecordFunction(record.key);
+        this.valuesFunction = new ConstValueRecordFunction(record.value);
     }
 
     public InsertStatement(String tableSpace, String table, RecordFunction keyFunction, RecordFunction function) {

--- a/herddb-core/src/main/java/herddb/model/commands/UpdateStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/UpdateStatement.java
@@ -40,7 +40,7 @@ public class UpdateStatement extends DMLStatement {
     private final Predicate predicate;
 
     public UpdateStatement(String tableSpace, String table, Record record, Predicate predicate) {
-        this(tableSpace, table, new ConstValueRecordFunction(record.key.data), new ConstValueRecordFunction(record.value.data), predicate);
+        this(tableSpace, table, new ConstValueRecordFunction(record.key), new ConstValueRecordFunction(record.value), predicate);
     }
 
     public UpdateStatement(String tableSpace, String table, RecordFunction key, RecordFunction function, Predicate predicate) {

--- a/herddb-core/src/main/java/herddb/model/predicates/RawKeyEquals.java
+++ b/herddb-core/src/main/java/herddb/model/predicates/RawKeyEquals.java
@@ -38,7 +38,7 @@ public final class RawKeyEquals extends Predicate {
 
     public RawKeyEquals(Bytes value) {
         this.value = value;
-        setIndexOperation(new PrimaryIndexSeek(new ConstValueRecordFunction(value.data)));
+        setIndexOperation(new PrimaryIndexSeek(new ConstValueRecordFunction(value)));
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -620,7 +620,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                             Statement statement = translatedQuery.plan.mainStatement;
                             TableAwareStatement tableStatement = (TableAwareStatement) statement;
                             Table table = server.getManager().getTableSpaceManager(statement.getTableSpace()).getTableManager(tableStatement.getTable()).getTable();
-                            Object key = RecordSerializer.deserializePrimaryKey(dml.getKey().data, table);
+                            Object key = RecordSerializer.deserializePrimaryKey(dml.getKey(), table);
                             otherData = new HashMap<>();
                             otherData.put("_key", key);
                             if (dml.getNewvalue() != null) {
@@ -745,7 +745,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                                 .getManager()
                                 .getTableSpaceManager(statement.getTableSpace()).getTableManager(tableStatement.getTable()).getTable();
                         newRecord = new HashMap<>();
-                        Object newKey = RecordSerializer.deserializePrimaryKey(dml.getKey().data, table);
+                        Object newKey = RecordSerializer.deserializePrimaryKey(dml.getKey(), table);
                         newRecord.put("_key", newKey);
                         if (dml.getNewvalue() != null) {
                             newRecord.putAll(RecordSerializer.toBean(new Record(dml.getKey(), dml.getNewvalue()), table));

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
@@ -83,7 +83,7 @@ public class SQLRecordFunction extends RecordFunction {
                         return RecordSerializer.convert(column.type, e.evaluate(bean, context));
                     }
                 };
-                return RecordSerializer.buildRecord(previous.value != null ? previous.value.data.length : 0, table, fieldValueComputer);
+                return RecordSerializer.buildRecord(previous.value != null ? previous.value.getLength() : 0, table, fieldValueComputer);
             } else {
                 Function<String, Object> fieldValueComputer = (columnName) -> {
                     CompiledSQLExpression e = expressionsByColumnName.get(columnName);

--- a/herddb-core/src/test/java/herddb/core/RestartPendingTransactionTest.java
+++ b/herddb-core/src/test/java/herddb/core/RestartPendingTransactionTest.java
@@ -96,7 +96,7 @@ public class RestartPendingTransactionTest {
             manager.checkpoint();
 
             long tx = ((TransactionResult) manager.executeStatement(new BeginTransactionStatement("tblspace1"), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)).getTransactionId();
-            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2.data), new ConstValueRecordFunction(key3.data), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
+            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2), new ConstValueRecordFunction(key3), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
             manager.executeStatement(new CommitTransactionStatement("tblspace1", tx), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             // transaction which contains the update will be replayed at reboot
         }
@@ -209,10 +209,10 @@ public class RestartPendingTransactionTest {
             manager.executeStatement(new InsertStatement("tblspace1", table.name, new Record(key3, key3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             manager.checkpoint();
 
-            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2.data), new ConstValueRecordFunction(key3.data), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2), new ConstValueRecordFunction(key3), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             long tx2 = ((TransactionResult) manager.executeStatement(new BeginTransactionStatement("tblspace1"), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)).getTransactionId();
-            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2.data), new ConstValueRecordFunction(key3.data), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx2));
+            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2), new ConstValueRecordFunction(key3), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx2));
             manager.executeStatement(new CommitTransactionStatement("tblspace1", tx2), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             // transactions which contains the update will be replayed at reboot
         }
@@ -326,7 +326,7 @@ public class RestartPendingTransactionTest {
             long tx = ((TransactionResult) manager.executeStatement(new BeginTransactionStatement("tblspace1"), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)).getTransactionId();
             manager.executeStatement(new DeleteStatement("tblspace1", table.name, key2, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
             manager.executeStatement(new InsertStatement("tblspace1", table.name, new Record(key2, key2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
-            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2.data), new ConstValueRecordFunction(key3.data), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
+            manager.executeStatement(new UpdateStatement("tblspace1", table.name, new ConstValueRecordFunction(key2), new ConstValueRecordFunction(key3), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
             manager.executeStatement(new CommitTransactionStatement("tblspace1", tx), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             // transaction which contains the update will be replayed at reboot
         }

--- a/herddb-core/src/test/java/herddb/file/FileDataStorageManagerTest.java
+++ b/herddb-core/src/test/java/herddb/file/FileDataStorageManagerTest.java
@@ -54,7 +54,7 @@ public class FileDataStorageManagerTest {
     @Test
     public void testReadWriteIndexPage() throws Exception {
         try (FileDataStorageManager man = new FileDataStorageManager(folder.newFolder().toPath());) {
-            byte[] page = Bytes.from_int(1).data;
+            byte[] page = Bytes.intToByteArray(1);
             man.writeIndexPage("test1", "table1", 1L, (out) -> {
                 out.writeArray(page);
             });

--- a/herddb-core/src/test/java/herddb/server/BackupRestoreTest.java
+++ b/herddb-core/src/test/java/herddb/server/BackupRestoreTest.java
@@ -296,7 +296,7 @@ public class BackupRestoreTest {
             final Record update = RecordSerializer.makeRecord(table, "c", 2, "d", 22);
 
             manager.executeUpdate(new InsertStatement(TableSpace.DEFAULT, table.name, RecordSerializer.makeRecord(table, "c", 5, "d", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            manager.executeUpdate(new UpdateStatement(TableSpace.DEFAULT, table.name, new ConstValueRecordFunction(update.key.data), new ConstValueRecordFunction(update.value.data), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.executeUpdate(new UpdateStatement(TableSpace.DEFAULT, table.name, new ConstValueRecordFunction(update.key), new ConstValueRecordFunction(update.value), null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             /* Now we have a dirty page in the checkpoint */
             manager.checkpoint();

--- a/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
+++ b/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
@@ -39,7 +39,7 @@ public class BytesCompareJavaTest {
         byte[] array = new byte[suffix.getLength() + 1];
         array[0] = 8;
 
-        System.arraycopy(suffix.data, 0, array, 1, suffix.data.length);
+        System.arraycopy(suffix.getBuffer(), suffix.getOffset(), array, 1, suffix.getLength());
 
         Bytes low = Bytes.from_array(array);
 

--- a/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
+++ b/herddb-core/src/test/java/herddb/utils/BytesCompareJavaTest.java
@@ -36,7 +36,7 @@ public class BytesCompareJavaTest {
 
         Bytes suffix = Bytes.from_long(578687L);
 
-        byte[] array = new byte[suffix.data.length + 1];
+        byte[] array = new byte[suffix.getLength() + 1];
         array[0] = 8;
 
         System.arraycopy(suffix.data, 0, array, 1, suffix.data.length);

--- a/herddb-utils/src/main/java/herddb/utils/ByteBufUtils.java
+++ b/herddb-utils/src/main/java/herddb/utils/ByteBufUtils.java
@@ -38,6 +38,11 @@ public class ByteBufUtils {
         writeVInt(buffer, array.length);
         buffer.writeBytes(array);
     }
+    
+    public static final void writeArray(ByteBuf buffer, Bytes array) {
+        writeVInt(buffer, array.getLength());
+        buffer.writeBytes(array.getBuffer(), array.getOffset(), array.getLength());
+    }
 
     public static final void writeArray(ByteBuf buffer, byte[] array, int offset, int length) {
         writeVInt(buffer, length);

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -456,7 +456,6 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     public boolean startsWith(int length, byte[] prefix) {
-        //TODO: handle offset/length
         return Bytes.startsWith(this.buffer, this.offset, this.length, length, prefix);
     }
 

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -25,8 +25,6 @@ import java.util.Arrays;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.util.internal.PlatformDependent;
-import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * A wrapper for byte[], in order to use it as keys on HashMaps
@@ -37,6 +35,8 @@ import java.util.stream.Stream;
 public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public static final Bytes POSITIVE_INFINITY = new Bytes(new byte[0]);
+    
+    public static final Bytes EMPTY_ARRAY = new Bytes(new byte[0]);
 
     private static final boolean UNALIGNED = PlatformDependent.isUnaligned();
     private static final boolean HAS_UNSAFE = PlatformDependent.hasUnsafe();
@@ -60,14 +60,16 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         return value.length + CONSTANT_BYTE_SIZE;
     }
 
-    public final byte[] data;
+    private final byte[] buffer;
+    private final int offset;
+    private final int length;
     private int hashCode = -1;
 
     public Object deserialized;
 
     @Override
     public long getEstimatedSize() {
-        return data.length + CONSTANT_BYTE_SIZE;
+        return length + CONSTANT_BYTE_SIZE;
     }
 
     public static byte[] string_to_array(String s) {
@@ -120,6 +122,10 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         return new Bytes(data);
     }
     
+    public static Bytes from_array(byte[] data, int offset, int len) {
+        return new Bytes(data, offset, len);
+    }
+
     public static Bytes from_nullable_array(byte[] data) {
         if (data == null) {
             return null;
@@ -128,7 +134,13 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     public byte[] to_array() {
-        return data;
+        if (offset == 0 && buffer.length == length) {
+            return buffer;
+        } else {
+            byte[] copy = new byte[length];
+            System.arraycopy(buffer, offset, copy, 0, length);
+            return copy;
+        }
     }
 
     public static Bytes from_int(int value) {
@@ -154,19 +166,21 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     public long to_long() {
-        return toLong(data, 0);
+        assert length == 8;
+        return toLong(buffer, offset);
     }
-    
+
     public RawString to_RawString() {
-        return RawString.newUnpooledRawString(data, 0, data.length);
+        return RawString.newUnpooledRawString(buffer, offset, length);
     }
 
     public int to_int() {
-        return toInt(data, 0);
+        assert length == 4;
+        return toInt(buffer, offset);
     }
 
     public String to_string() {
-        return new String(data, 0, data.length, StandardCharsets.UTF_8);
+        return new String(buffer, offset, length, StandardCharsets.UTF_8);
     }
 
     public static String to_string(byte[] data) {
@@ -178,25 +192,36 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     public java.sql.Timestamp to_timestamp() {
-        return toTimestamp(data, 0);
+        assert length == 8;
+        return toTimestamp(buffer, offset);
     }
 
     public boolean to_boolean() {
-        return toBoolean(data, 0);
+        assert length == 1;
+        return toBoolean(buffer, offset);
     }
 
     public double to_double() {
-        return toDouble(data, 0);
+        assert length == 8;
+        return toDouble(buffer, offset);
     }
 
-    public Bytes(byte[] data) {
-        this.data = data;
+    private Bytes(byte[] data) {
+        this.buffer = data;
+        this.offset = 0;
+        this.length = buffer.length;
+    }
+
+    private Bytes(byte[] data, int offset, int length) {
+        this.buffer = data;
+        this.offset = offset;
+        this.length = length;
     }
 
     @Override
     public int hashCode() {
         if (hashCode == -1) {
-            this.hashCode = Arrays.hashCode(this.data);
+            this.hashCode = CompareBytesUtils.hashCode(buffer, offset, length);
         }
         return hashCode;
 
@@ -209,13 +234,14 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         }
         try {
             final Bytes other = (Bytes) obj;
-            if (data.length != other.data.length) {
+            if (length != other.length) {
                 return false;
             }
             if (other.hashCode() != this.hashCode()) {
                 return false;
             }
-            return CompareBytesUtils.arraysEquals(data, 0, data.length, other.data, 0, data.length);
+            return CompareBytesUtils.arraysEquals(buffer, offset, length,
+                    other.buffer, other.offset, other.length);
         } catch (ClassCastException otherClass) {
             return false;
         }
@@ -340,11 +366,14 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         } else if (o == POSITIVE_INFINITY) {
             return -1;
         }
-        return CompareBytesUtils.compare(this.data, o.data);
+        return CompareBytesUtils.compare(buffer, offset, offset + length, 
+                o.buffer, o.offset, o.offset + o.length);
     }
 
-    public static boolean startsWith(byte[] left, int len, byte[] right) {
-        for (int i = 0, j = 0; i < left.length && j < right.length && i < len; i++, j++) {
+    public static boolean startsWith(byte[] left, int offset, int bufferlen, int max, byte[] right) {
+        int endleft = offset + bufferlen;
+        int endmax = offset + max;
+        for (int i = offset, j = 0; i < endleft && j < right.length && i < endmax; i++, j++) {
             if (left[i] != right[j]) {
                 return false;
             }
@@ -352,31 +381,32 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         // equality
         return true;
     }
-    
+
     public int getLength() {
-        return data.length;
+        return length;
     }
-    
+
     public byte[] getBuffer() {
-        return data;
+        return buffer;
     }
-    
+
     public int getOffset() {
-        return 0;
+        return offset;
     }
 
     @Override
     public String toString() {
-        if (data == null) {
+        if (buffer == null) {
             return "null";
         }
         // ONLY FOR TESTS
-        return arraytohexstring(data);
+        return arraytohexstring(buffer, offset, length);
     }
 
-    public static String arraytohexstring(byte[] bytes) {
+    public static String arraytohexstring(byte[] buffer, int offset, int length) {
         StringBuilder string = new StringBuilder();
-        for (byte b : bytes) {
+        for (int i = offset; i < offset + length; i++) {
+            byte b = buffer[i];
             String hexString = Integer.toHexString(0x00FF & b);
             string.append(hexString.length() == 1 ? "0" + hexString : hexString);
         }
@@ -384,9 +414,9 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     }
 
     public ByteArrayCursor newCursor() {
-        return ByteArrayCursor.wrap(data);
+        return ByteArrayCursor.wrap(buffer, offset, length);
     }
-    
+
     /**
      * Returns the next {@code Bytes} instance.
      * <p>
@@ -401,10 +431,10 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
      */
     public Bytes next() {
 
-        final byte[] dst = new byte[data.length];
-        System.arraycopy(data, 0, dst, 0, data.length);
+        final byte[] dst = new byte[length];
+        System.arraycopy(buffer, offset, dst, 0, length);
 
-        int idx = data.length - 1;
+        int idx = length - 1;
 
         /*
          * We alter bytes from last in a backward fashion. We could have done directly a manual copy with
@@ -427,7 +457,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public boolean startsWith(int length, byte[] prefix) {
         //TODO: handle offset/length
-        return Bytes.startsWith(this.data, length, prefix);
+        return Bytes.startsWith(this.buffer, this.offset, this.length, length, prefix);
     }
 
 }

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.util.internal.PlatformDependent;
+import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * A wrapper for byte[], in order to use it as keys on HashMaps
@@ -117,6 +119,13 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     public static Bytes from_array(byte[] data) {
         return new Bytes(data);
     }
+    
+    public static Bytes from_nullable_array(byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        return new Bytes(data);
+    }
 
     public byte[] to_array() {
         return data;
@@ -146,6 +155,10 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public long to_long() {
         return toLong(data, 0);
+    }
+    
+    public RawString to_RawString() {
+        return RawString.newUnpooledRawString(data, 0, data.length);
     }
 
     public int to_int() {
@@ -339,6 +352,18 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         // equality
         return true;
     }
+    
+    public int getLength() {
+        return data.length;
+    }
+    
+    public byte[] getBuffer() {
+        return data;
+    }
+    
+    public int getOffset() {
+        return 0;
+    }
 
     @Override
     public String toString() {
@@ -358,6 +383,10 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         return string.toString();
     }
 
+    public ByteArrayCursor newCursor() {
+        return ByteArrayCursor.wrap(data);
+    }
+    
     /**
      * Returns the next {@code Bytes} instance.
      * <p>
@@ -394,6 +423,11 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
         return new Bytes(dst);
 
+    }
+
+    public boolean startsWith(int length, byte[] prefix) {
+        //TODO: handle offset/length
+        return Bytes.startsWith(this.data, length, prefix);
     }
 
 }

--- a/herddb-utils/src/main/java/herddb/utils/ExtendedDataInputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/ExtendedDataInputStream.java
@@ -216,6 +216,10 @@ public class ExtendedDataInputStream extends DataInputStream {
 
     private static final byte[] EMPTY_ARRAY = new byte[0];
 
+    public Bytes readBytes() throws IOException {
+        return Bytes.from_nullable_array(readArray());
+    }
+    
     public byte[] readArray() throws IOException {
         int len = readVInt();
         if (len == 0) {

--- a/herddb-utils/src/main/java/herddb/utils/ExtendedDataOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/ExtendedDataOutputStream.java
@@ -118,10 +118,23 @@ public final class ExtendedDataOutputStream extends DataOutputStream {
     public final void writeZLong(long l) throws IOException {
         writeSignedVLong((l >> 63) ^ (l << 1));
     }
+    
+    public void writeArray(Bytes data) throws IOException {
+        if (data == null) {
+            writeNullArray();
+        } else {
+            writeVInt(data.getLength());
+            write(data.getBuffer(), data.getOffset(), data.getLength());
+        }
+    }
 
+    public void writeNullArray() throws IOException {
+        writeVInt(-1);
+    }    
+    
     public void writeArray(byte[] data) throws IOException {
         if (data == null) {
-            writeVInt(-1);
+            writeNullArray();
         } else {
             writeVInt(data.length);
             write(data);

--- a/herddb-utils/src/main/java/herddb/utils/KeyValue.java
+++ b/herddb-utils/src/main/java/herddb/utils/KeyValue.java
@@ -29,10 +29,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings("EI2")
 public class KeyValue {
 
-    public final byte[] key;
-    public final byte[] value;
+    public final Bytes key;
+    public final Bytes value;
 
-    public KeyValue(byte[] key, byte[] value) {
+    public KeyValue(Bytes key, Bytes value) {
         this.key = key;
         this.value = value;
     }

--- a/herddb-utils/src/main/java/herddb/utils/XXHash64Utils.java
+++ b/herddb-utils/src/main/java/herddb/utils/XXHash64Utils.java
@@ -41,7 +41,7 @@ public class XXHash64Utils {
 
     public static byte[] digest(byte[] array, int offset, int len) {
         long hash = HASHER.hash(array, offset, len, DEFAULT_SEED);
-        byte[] digest = Bytes.from_long(hash).data;
+        byte[] digest = Bytes.longToByteArray(hash);
         return digest;
     }
 

--- a/herddb-utils/src/test/java/herddb/utils/BytesTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/BytesTest.java
@@ -45,7 +45,7 @@ public class BytesTest {
         byte[] array2 = "tesu".getBytes(StandardCharsets.UTF_8);
         System.out.println("a:" + bytes1.to_string());
         System.out.println("b:" + next.to_string());
-        assertArrayEquals(array2, next.data);
+        assertArrayEquals(array2, next.to_array());
     }
 
     @Test
@@ -57,7 +57,7 @@ public class BytesTest {
         Bytes bytes = Bytes.from_array(array);
         Bytes next = bytes.next();
 
-        assertArrayEquals(nextExpected, next.data);
+        assertArrayEquals(nextExpected, next.to_array());
     }
 
     /** Check that the change propagate to next byte if 255 (-1) */
@@ -70,7 +70,7 @@ public class BytesTest {
         Bytes bytes = Bytes.from_array(array);
         Bytes next = bytes.next();
 
-        assertArrayEquals(nextExpected, next.data);
+        assertArrayEquals(nextExpected, next.to_array());
     }
 
     /** Check that more than one byte is changed if needed */
@@ -83,7 +83,7 @@ public class BytesTest {
         Bytes bytes = Bytes.from_array(array);
         Bytes next = bytes.next();
 
-        assertArrayEquals(nextExpected, next.data);
+        assertArrayEquals(nextExpected, next.to_array());
     }
 
     /** Checks that prefix bytes aren't touched */
@@ -96,7 +96,7 @@ public class BytesTest {
         Bytes bytes = Bytes.from_array(array);
         Bytes next = bytes.next();
 
-        assertArrayEquals(nextExpected, next.data);
+        assertArrayEquals(nextExpected, next.to_array());
     }
 
     /** Checks that next fails if there is no more space */
@@ -117,11 +117,11 @@ public class BytesTest {
 
         Bytes bytes = Bytes.from_array(src);
 
-        assertArrayEquals(src, bytes.data);
+        assertArrayEquals(src, bytes.to_array());
 
         Bytes next = bytes.next();
 
-        assertEquals(bytes.data.length, next.data.length);
+        assertEquals(bytes.getLength(), next.getLength());
 
     }
 


### PR DESCRIPTION
- Encapsulate Bytes internal array, drop the only public constructor
- Let Bytes wrap a generic slice of a byte[], adding *offset* and *length* fields
- Use Bytes whenever possible, save resources by not creating temporary byte[] and saving memory copies on the hottest paths
- Prepare the code to be able to load data pages as a single byte[] and have key/values as slices on that buffer (this will boost loading of pages and save GC cycles)