### PR TITLE
Use slices of data read from disk

### DIFF
--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -103,14 +103,14 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
                     }
                     int size = in.readVInt();
                     for (int i = 0; i < size; i++) {
-                        byte[] indexKey = in.readArray();
+                        Bytes indexKey = in.readBytesNoCopy();
                         int entrySize = in.readVInt();
                         List<Bytes> value = new ArrayList<>(entrySize);
                         for (int kk = 0; kk < entrySize; kk++) {
-                            byte[] tableKey = in.readArray();
-                            value.add(Bytes.from_array(tableKey));
+                            Bytes tableKey = in.readBytesNoCopy();
+                            value.add(tableKey);
                         }
-                        deserialized.put(Bytes.from_array(indexKey), value);
+                        deserialized.put(indexKey, value);
                     }
 
                     return deserialized;

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -55,6 +55,7 @@ import herddb.sql.SQLRecordKeyFunction;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
+import herddb.utils.ByteArrayCursor;
 import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
@@ -444,8 +445,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
         @SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE", justification = "flags still not used but it must be forcefully read")
         public BLinkMetadata<Bytes> read(byte[] data) throws IOException {
 
-            try (SimpleByteArrayInputStream bis = new SimpleByteArrayInputStream(data);
-                ExtendedDataInputStream edis = new ExtendedDataInputStream(bis)) {
+            try (ByteArrayCursor edis = ByteArrayCursor.wrap(data)) {
 
                 long version = edis.readVLong();
 
@@ -510,7 +510,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                     if (hasInf) {
                         rightsep = Bytes.POSITIVE_INFINITY;
                     } else {
-                        rightsep = Bytes.from_array(edis.readArray());
+                        rightsep = edis.readBytesNoCopy();
                     }
 
                     BLinkNodeMetadata<Bytes> node
@@ -562,7 +562,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                     switch (block) {
 
                         case NODE_PAGE_KEY_VALUE_BLOCK:
-                            map.put(Bytes.from_array(in.readArray()),
+                            map.put(in.readBytesNoCopy(),
                                 in.readVLong());
                             break;
 

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -128,9 +128,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
         if (page == null) {
             throw new DataStorageManagerException("No such page: " + tableSpace + "." + indexName + " page " + pageId);
         }
-        //TODO: do not perform copy
-        try (SimpleByteArrayInputStream in = new SimpleByteArrayInputStream(page.to_array());
-            ExtendedDataInputStream ein = new ExtendedDataInputStream(in)) {
+        try (ByteArrayCursor ein = page.newCursor()) {
             return reader.read(ein);
         } catch (IOException e) {
             throw new DataStorageManagerException(e);

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -37,6 +37,7 @@ import herddb.model.Index;
 import herddb.model.Record;
 import herddb.model.Table;
 import herddb.model.Transaction;
+import herddb.utils.ByteArrayCursor;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
 import java.util.logging.Level;
@@ -65,7 +66,7 @@ public abstract class DataStorageManager implements AutoCloseable {
     @FunctionalInterface
     public static interface DataReader<X> {
 
-        public X read(ExtendedDataInputStream in) throws IOException;
+        public X read(ByteArrayCursor in) throws IOException;
     }
 
     public abstract <X> X readIndexPage(String tableSpace, String uuid, Long pageId, DataReader<X> reader)

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -240,8 +240,8 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
             if (other.hashCode() != this.hashCode()) {
                 return false;
             }
-            return CompareBytesUtils.arraysEquals(buffer, offset, length,
-                    other.buffer, other.offset, other.length);
+            return CompareBytesUtils.arraysEquals(buffer, offset, offset + length,
+                    other.buffer, other.offset, other.offset + other.length);
         } catch (ClassCastException otherClass) {
             return false;
         }

--- a/herddb-utils/src/main/java/herddb/utils/XXHash64Utils.java
+++ b/herddb-utils/src/main/java/herddb/utils/XXHash64Utils.java
@@ -45,6 +45,10 @@ public class XXHash64Utils {
         return digest;
     }
 
+    public static long hash(byte[] array, int offset, int len) {
+        return HASHER.hash(array, offset, len, DEFAULT_SEED);
+    }
+
     public static boolean verifyBlockWithFooter(byte[] array, int offset, int len) {
         byte[] expectedFooter = Arrays.copyOfRange(array, len - HASH_LEN, len);
         long expectedHash = HASHER.hash(array, offset, len - HASH_LEN, DEFAULT_SEED);


### PR DESCRIPTION
With this patch data read from disk (data and indexes) won't be splitted into many small byte[], this should save resources and GC pressure.
The trade off is that we will be rataining hard refs to the whole byte array until we have at least one reference to a portion of an Record inside the data page