### PR TITLE
Speed up PK writes

### DIFF
--- a/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
@@ -34,9 +34,9 @@ import java.util.Arrays;
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class VisibleByteArrayOutputStream extends OutputStream {
 
-    protected byte buf[];
+    private byte buf[];
 
-    protected int count;
+    private int count;
 
     public VisibleByteArrayOutputStream() {
         this(32);
@@ -59,8 +59,8 @@ public class VisibleByteArrayOutputStream extends OutputStream {
     private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
     /**
-     * Increases the capacity to ensure that it can hold at least the number of elements specified by the minimum
-     * capacity argument.
+     * Increases the capacity to ensure that it can hold at least the number of
+     * elements specified by the minimum capacity argument.
      *
      * @param minCapacity the desired minimum capacity
      */
@@ -83,8 +83,8 @@ public class VisibleByteArrayOutputStream extends OutputStream {
             throw new OutOfMemoryError();
         }
         return (minCapacity > MAX_ARRAY_SIZE)
-            ? Integer.MAX_VALUE
-            : MAX_ARRAY_SIZE;
+                ? Integer.MAX_VALUE
+                : MAX_ARRAY_SIZE;
     }
 
     @Override
@@ -97,7 +97,7 @@ public class VisibleByteArrayOutputStream extends OutputStream {
     @Override
     public void write(byte b[], int off, int len) {
         if ((off < 0) || (off > b.length) || (len < 0)
-            || ((off + len) - b.length > 0)) {
+                || ((off + len) - b.length > 0)) {
             throw new IndexOutOfBoundsException();
         }
         ensureCapacity(count + len);

--- a/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
@@ -34,9 +34,9 @@ import java.util.Arrays;
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class VisibleByteArrayOutputStream extends OutputStream {
 
-    private byte buf[];
+    byte buf[];
 
-    private int count;
+    int count;
 
     public VisibleByteArrayOutputStream() {
         this(32);


### PR DESCRIPTION
During benchmarks with low-memory we are observing that reads and writes of the BLink are the bottleneck (as expected).
We can work on saving memory copies in order to acheive better performances.

Summary of changes:
- during page writes allocate a byte[] buffer, write data and perform hash inside the buffer, then write to next layer
- this new temporary buffer is recyclable

Please note that the recyclable buffer pool is private to the FileDataStorageManager, because it will hold always buffers of the same size (bounded by the maximum page size).
If we provide a genertic RecyclableByteArrayOutputStream we will eventually end up with a lot of churn