### PR TITLE
Remove shared references during checkpoint

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1443,7 +1443,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private void applyUpdate(Bytes key, Bytes value) throws DataStorageManagerException {
         // do not want to retain shared buffers as keys
         key = key.nonShared();
-        
+
         /*
          * New record to be updated, it will always updated if there aren't errors thus is simpler to create
          * the record now
@@ -1655,7 +1655,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private void applyInsert(Bytes key, Bytes value, boolean onTransaction) throws DataStorageManagerException {
         // don't want to keep strong references to shared buffers in the keyToPages
         key = key.nonShared();
-        
+
         if (table.auto_increment) {
             // the next auto_increment value MUST be greater than every other explict value
             long pk_logical_value;
@@ -1704,7 +1704,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             /* Try allocate a new page if no already done */
             insertionPageId = allocateLivePage(insertionPageId);
         }
-        
+
         /* Insert  the value on keyToPage */
         keyToPage.put(key, insertionPageId);
 
@@ -2078,7 +2078,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     }
 
                     /* Flush the page if it would exceed max page size */
-                    if (bufferPageSize + DataPage.estimateEntrySize(record) > maxLogicalPageSize) {
+                    final long recordSize = DataPage.estimateEntrySize(record);
+                    if (bufferPageSize + recordSize > maxLogicalPageSize) {
                         createImmutablePage(buffer, bufferPageSize);
                         flushedRecords += buffer.size();
                         bufferPageSize = 0;
@@ -2086,8 +2087,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         buffer = new HashMap<>(buffer.size());
                     }
 
-                    buffer.put(record.key, record);
-                    bufferPageSize += DataPage.estimateEntrySize(record);
+                    Record unshared = record.nonShared();
+                    buffer.put(unshared.key, unshared);
+                    bufferPageSize += recordSize;
                 }
 
                 /* Do not continue if we have used up all configured checkpoint time */
@@ -2129,7 +2131,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
                 for (Record record : records) {
                     /* Flush the page if it would exceed max page size */
-                    if (bufferPageSize + DataPage.estimateEntrySize(record) > maxLogicalPageSize) {
+                    final long recordSize = DataPage.estimateEntrySize(record);
+                    if (bufferPageSize + recordSize > maxLogicalPageSize) {
                         createImmutablePage(buffer, bufferPageSize);
                         flushedRecords += buffer.size();
                         bufferPageSize = 0;
@@ -2137,8 +2140,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         buffer = new HashMap<>(buffer.size());
                     }
 
-                    buffer.put(record.key, record);
-                    bufferPageSize += DataPage.estimateEntrySize(record);
+                    Record unshared = record.nonShared();
+                    buffer.put(unshared.key, unshared);
+                    bufferPageSize += recordSize;
                 }
 
                 final long now = System.currentTimeMillis();

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -797,10 +797,10 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         boolean add = true;
         final Iterator<Record> records = spareData.values().iterator();
         while (add && records.hasNext()) {
-            Record record = records.next();
+            Record record = records.next().nonShared();
             add = page.put(record);
             if (add) {
-                keyToPage.put(record.key.nonShared(), page.pageId);
+                keyToPage.put(record.key, page.pageId);
                 records.remove();
             }
         }

--- a/herddb-core/src/main/java/herddb/model/Record.java
+++ b/herddb-core/src/main/java/herddb/model/Record.java
@@ -84,9 +84,28 @@ public final class Record implements SizeAwareObject {
         this.cache = new WeakReference<>(cache);
     }
 
+    private Record(Bytes key, Bytes value, WeakReference<Map<String, Object>> cache) {
+        this.key = key;
+        this.value = value;
+        this.cache = cache;
+    }
+
     @Override
     public long getEstimatedSize() {
         return this.key.getEstimatedSize() + this.value.getEstimatedSize() + CONSTANT_BYTE_SIZE;
+    }
+
+    /**
+     * Ensure that this value is not retaining strong references to a shared buffer
+     * @return the record itself or a copy
+     */
+    public Record nonShared() {
+
+        if (key.isShared() || value.isShared()) {
+            return new Record(key.nonShared(), value.nonShared(), cache);
+        }
+
+        return this;
     }
 
     public final Map<String, Object> toBean(Table table) {

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -21,7 +21,6 @@ package herddb.utils;
 
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.util.internal.PlatformDependent;
@@ -35,7 +34,7 @@ import io.netty.util.internal.PlatformDependent;
 public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
 
     public static final Bytes POSITIVE_INFINITY = new Bytes(new byte[0]);
-    
+
     public static final Bytes EMPTY_ARRAY = new Bytes(new byte[0]);
 
     private static final boolean UNALIGNED = PlatformDependent.isUnaligned();
@@ -121,7 +120,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
     public static Bytes from_array(byte[] data) {
         return new Bytes(data);
     }
-    
+
     public static Bytes from_array(byte[] data, int offset, int len) {
         return new Bytes(data, offset, len);
     }
@@ -366,7 +365,7 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
         } else if (o == POSITIVE_INFINITY) {
             return -1;
         }
-        return CompareBytesUtils.compare(buffer, offset, offset + length, 
+        return CompareBytesUtils.compare(buffer, offset, offset + length,
                 o.buffer, o.offset, o.offset + o.length);
     }
 
@@ -464,12 +463,16 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
      * @return the buffer itself or a copy
      */
     public Bytes nonShared() {
-        if (this.offset == 0 && this.length == buffer.length) {
-            return this;
+        if (isShared()) {
+            byte[] array = new byte[this.length];
+            System.arraycopy(buffer, offset, array, 0, length);
+            return new Bytes(array, 0, length);
         }
-        byte[] array = new byte[this.length];
-        System.arraycopy(buffer, offset, array, 0, length);
-        return new Bytes(array, 0, length);
+        return this;
     }
-    
+
+    public boolean isShared() {
+        return this.offset !=0 || this.length != buffer.length;
+    }
+
 }


### PR DESCRIPTION
Checkpoint procedure preserved shared Bytes references (putting them even in keyToPage and in new pages during dirty page rebuild)