### PR TITLE
Fix/remove checkpoint double pk lookup closes #333

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -83,6 +83,32 @@ public class DataPage extends Page<TableManager> {
         pageLock = immutable ? null : new ReentrantReadWriteLock(false);
     }
 
+    /**
+     * Convert a {@link DataPage} to immutable.
+     * <p>
+     * Conversion can be done only after the page has been set as not writable.
+     * </p>
+     * <p>
+     * Checks on immutable pages are faster (they not have to check volatile writable flag and lock it
+     * before checking).
+     * </p>
+     *
+     * @return immutable data page version
+     */
+    DataPage toImmutable() {
+
+        if (immutable) {
+            throw new IllegalStateException("page " + pageId + " already is immutable!");
+        }
+
+        if (writable) {
+            throw new IllegalStateException("page " + pageId + " cannot be converted to immutable because still writable!");
+        }
+
+        return new DataPage(owner, pageId, maxSize, usedMemory.get(), data, true);
+
+    }
+
     Record remove(Bytes key) {
         if (immutable) {
             throw new IllegalStateException("page " + pageId + " is immutable!");

--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -131,6 +131,14 @@ public class DataPage extends Page<TableManager> {
         return true;
     }
 
+    void putNoMemoryHandle(Record record) {
+        if (immutable) {
+            throw new IllegalStateException("page " + pageId + " is immutable!");
+        }
+
+        data.put(record.key, record);
+    }
+
     boolean isEmpty() {
         return data.isEmpty();
     }

--- a/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
@@ -36,6 +36,7 @@ import herddb.model.TableContext;
 import herddb.sql.SQLRecordKeyFunction;
 import herddb.storage.DataStorageManagerException;
 import herddb.utils.Bytes;
+import herddb.utils.Holder;
 
 /**
  * Implementation of KeyToPageIndex which uses any ConcurrentMap
@@ -70,6 +71,31 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
         if (res == null) {
             keyAdded(key);
         }
+    }
+
+    @Override
+    public boolean put(Bytes key, Long newPage, Long expectedPage) {
+        if (expectedPage == null) {
+            final Long opage = map.putIfAbsent(key, newPage);
+            return opage == null;
+        } else {
+            /*
+             * We need to keep track if the update was really done. Reading computeIfPresent result won't
+             * suffice, it can be equal to newPage even if no replacement was done (the map contained already
+             * newPage mapping and expectedPage was different)
+             */
+            Holder<Boolean> holder = new Holder<>(Boolean.FALSE);
+            map.computeIfPresent(key, (skey, spage) -> {
+                if (spage.equals(expectedPage)) {
+                    holder.value = Boolean.TRUE;
+                    return newPage;
+                }
+                return spage;
+            });
+
+            return holder.value.booleanValue();
+        }
+
     }
 
     private void keyAdded(Bytes key) {

--- a/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
@@ -35,8 +35,8 @@ import herddb.model.StatementExecutionException;
 import herddb.model.TableContext;
 import herddb.sql.SQLRecordKeyFunction;
 import herddb.storage.DataStorageManagerException;
+import herddb.utils.BooleanHolder;
 import herddb.utils.Bytes;
-import herddb.utils.Holder;
 
 /**
  * Implementation of KeyToPageIndex which uses any ConcurrentMap
@@ -84,16 +84,16 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
              * suffice, it can be equal to newPage even if no replacement was done (the map contained already
              * newPage mapping and expectedPage was different)
              */
-            Holder<Boolean> holder = new Holder<>(Boolean.FALSE);
+            BooleanHolder holder = new BooleanHolder(false);
             map.computeIfPresent(key, (skey, spage) -> {
                 if (spage.equals(expectedPage)) {
-                    holder.value = Boolean.TRUE;
+                    holder.value = true;
                     return newPage;
                 }
                 return spage;
             });
 
-            return holder.value.booleanValue();
+            return holder.value;
         }
 
     }

--- a/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
@@ -70,6 +70,17 @@ public interface KeyToPageIndex extends AutoCloseable {
 
     public void put(Bytes key, Long currentPage);
 
+    /**
+     * Attempt to put a new value in the index. The mapping will be update only if current mapping
+     * matches given expected one (provide null if no mapping is expected).
+     * <p>
+     * I current mapping differs it will be left untouched
+     * </p>
+     *
+     * @return {@code false} if the put wasn't executed
+     */
+    public boolean put(Bytes key, Long newPage, Long expectedPage);
+
     public boolean containsKey(Bytes key);
 
     public Long get(Bytes key);

--- a/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
@@ -74,7 +74,7 @@ public interface KeyToPageIndex extends AutoCloseable {
      * Attempt to put a new value in the index. The mapping will be update only if current mapping
      * matches given expected one (provide null if no mapping is expected).
      * <p>
-     * I current mapping differs it will be left untouched
+     * If current mapping differs it will be left untouched
      * </p>
      *
      * @return {@code false} if the put wasn't executed

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -125,6 +125,11 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
     }
 
     @Override
+    public boolean put(Bytes key, Long newPage, Long expectedPage) {
+        return getTree().insert(key, newPage, expectedPage);
+    }
+
+    @Override
     public boolean containsKey(Bytes key) {
         return getTree().search(key) != null;
     }

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -293,10 +293,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
             throw new DataStorageManagerException(ex);
         }
 
-        Bytes prev = indexpages.putIfAbsent(tableSpace + "." + indexName + "_" + pageId, page_wrapper);
-        if (prev != null) {
-            throw new DataStorageManagerException("pages are immutable");
-        }
+        indexpages.put(tableSpace + "." + indexName + "_" + pageId, page_wrapper);
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
@@ -17,7 +17,7 @@ import herddb.storage.DataStorageManagerException;
 import herddb.utils.Bytes;
 
 /**
- * Suite di test base per {@link  BLinkKeyToPageIndex}
+ * Base test suite for {@link  BLinkKeyToPageIndex}
  *
  * @author diego.salvi
  */

--- a/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
@@ -1,0 +1,144 @@
+package herddb.index;
+
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import herddb.core.AbstractIndexManager;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.log.LogSequenceNumber;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.model.TableContext;
+import herddb.storage.DataStorageManagerException;
+import herddb.utils.Bytes;
+
+/**
+ * Suite di test base per {@link  BLinkKeyToPageIndex}
+ *
+ * @author diego.salvi
+ */
+public class BLinkKeyToPageIndexTest extends KeyToPageIndexTest {
+
+    @Override
+    KeyToPageIndex createIndex() {
+
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), (128L << 10));
+        MemoryDataStorageManager ds = new MemoryDataStorageManager();
+        BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
+
+        return new ResourceCloseKeyToPageIndex(idx,ds);
+
+    }
+
+    private final class ResourceCloseKeyToPageIndex implements KeyToPageIndex {
+
+        KeyToPageIndex delegate;
+        AutoCloseable[] closeables;
+
+        public ResourceCloseKeyToPageIndex(KeyToPageIndex index, AutoCloseable... closeables) {
+            this.delegate = index;
+            this.closeables = closeables;
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+
+            IllegalStateException exception = null;
+            for(AutoCloseable closeable : closeables) {
+                try {
+                    closeable.close();
+                } catch (Exception e) {
+                    if (exception == null) {
+                        exception = new IllegalStateException("Failed to properly close resources", e);
+                    } else {
+                        exception.addSuppressed(e);
+                    }
+                }
+            }
+
+            if (exception != null) {
+                throw exception;
+            }
+        }
+
+        @Override
+        public long getUsedMemory() {
+            return delegate.getUsedMemory();
+        }
+
+        @Override
+        public boolean requireLoadAtStartup() {
+            return delegate.requireLoadAtStartup();
+        }
+
+        @Override
+        public long size() {
+            return delegate.size();
+        }
+
+        @Override
+        public void start(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+            delegate.start(sequenceNumber);
+        }
+
+        @Override
+        public List<PostCheckpointAction> checkpoint(LogSequenceNumber sequenceNumber, boolean pin)
+                throws DataStorageManagerException {
+            return delegate.checkpoint(sequenceNumber, pin);
+        }
+
+        @Override
+        public void unpinCheckpoint(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+            delegate.unpinCheckpoint(sequenceNumber);
+        }
+
+        @Override
+        public void truncate() {
+            delegate.truncate();
+        }
+
+        @Override
+        public Stream<Entry<Bytes, Long>> scanner(IndexOperation operation, StatementEvaluationContext context,
+                                                  TableContext tableContext, AbstractIndexManager index)
+                throws DataStorageManagerException, StatementExecutionException {
+            return delegate.scanner(operation, context, tableContext, index);
+        }
+
+        @Override
+        public void put(Bytes key, Long currentPage) {
+            delegate.put(key, currentPage);
+        }
+
+        @Override
+        public boolean put(Bytes key, Long newPage, Long expectedPage) {
+            return delegate.put(key, newPage, expectedPage);
+        }
+
+        @Override
+        public boolean containsKey(Bytes key) {
+            return delegate.containsKey(key);
+        }
+
+        @Override
+        public Long get(Bytes key) {
+            return delegate.get(key);
+        }
+
+        @Override
+        public Long remove(Bytes key) {
+            return delegate.remove(key);
+        }
+
+        @Override
+        public boolean isSortedAscending() {
+            return delegate.isSortedAscending();
+        }
+
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/index/ConcurrentMapKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/ConcurrentMapKeyToPageIndexTest.java
@@ -3,7 +3,7 @@ package herddb.index;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Suite di test base per {@link  ConcurrentMapKeyToPageIndex}
+ * Base test suite for {@link  ConcurrentMapKeyToPageIndex}
  *
  * @author diego.salvi
  */

--- a/herddb-core/src/test/java/herddb/index/ConcurrentMapKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/ConcurrentMapKeyToPageIndexTest.java
@@ -1,0 +1,19 @@
+package herddb.index;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Suite di test base per {@link  ConcurrentMapKeyToPageIndex}
+ *
+ * @author diego.salvi
+ */
+public class ConcurrentMapKeyToPageIndexTest extends KeyToPageIndexTest {
+
+    @Override
+    KeyToPageIndex createIndex() {
+
+        return new ConcurrentMapKeyToPageIndex(new ConcurrentHashMap<>());
+
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
@@ -1,0 +1,42 @@
+package herddb.index;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import herddb.log.LogSequenceNumber;
+import herddb.utils.Bytes;
+
+/**
+ * Suite di test base per {@link KeyToPageIndex}
+ *
+ * @author diego.salvi
+ */
+public abstract class KeyToPageIndexTest {
+
+    abstract KeyToPageIndex createIndex();
+
+    @Test
+    public void putIf() {
+
+        int entries = 100;
+
+        try (KeyToPageIndex index = createIndex()) {
+
+            index.start(LogSequenceNumber.START_OF_TIME);
+
+            for(int i = 0; i < entries; ++i) {
+                index.put(Bytes.from_int(i), 1L);
+            }
+
+            for(int i = 0; i < entries; ++i) {
+                Assert.assertTrue(index.put(Bytes.from_int(i), 2L, 1L));
+            }
+
+            for(int i = 0; i < entries; ++i) {
+                Assert.assertFalse(index.put(Bytes.from_int(i), 3L, 1L));
+                index.put(Bytes.from_int(i), 3L, 1L);
+            }
+        }
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
@@ -7,7 +7,7 @@ import herddb.log.LogSequenceNumber;
 import herddb.utils.Bytes;
 
 /**
- * Suite di test base per {@link KeyToPageIndex}
+ * Base test suite for {@link KeyToPageIndex}
  *
  * @author diego.salvi
  */

--- a/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
@@ -1,5 +1,15 @@
 package herddb.index;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -14,6 +24,42 @@ import herddb.utils.Bytes;
 public abstract class KeyToPageIndexTest {
 
     abstract KeyToPageIndex createIndex();
+
+    /** This test failed with the error
+     * <pre>
+     * herddb.storage.DataStorageManagerException: pages are immutable
+     * at herddb.mem.MemoryDataStorageManager.writeIndexPage(MemoryDataStorageManager.java:298)
+     * at herddb.index.blink.BLinkKeyToPageIndex$BLinkIndexDataStorageImpl.createPage(BLinkKeyToPageIndex.java:620)
+     * at herddb.index.blink.BLinkKeyToPageIndex$BLinkIndexDataStorageImpl.overwriteNodePage(BLinkKeyToPageIndex.java:605)
+     * at herddb.index.blink.BLink$Node.writeNodePage(BLink.java:2661)
+     * at herddb.index.blink.BLink$Node.writePage(BLink.java:2646)
+     * at herddb.index.blink.BLink$Node.flush(BLink.java:2541)
+     * at herddb.index.blink.BLink$Node.unload(BLink.java:2493)
+     * at herddb.index.blink.BLink.unload(BLink.java:342)
+     * at herddb.index.blink.BLink.normalize(BLink.java:894)
+     * at herddb.index.blink.BLink.insert(BLink.java:620)</pre>
+     *
+     * At least BLink must handles pages overwrite
+     */
+    @Test
+    public void massivePut() {
+
+        int entries = 100000;
+
+        try (KeyToPageIndex index = createIndex()) {
+
+            index.start(LogSequenceNumber.START_OF_TIME);
+
+            for(int i = 0; i < entries; ++i) {
+                index.put(Bytes.from_int(i), 1L);
+            }
+
+            for(int i = 0; i < entries; ++i) {
+                Assert.assertEquals(index.get(Bytes.from_int(i)),Long.valueOf(1L));
+            }
+        }
+
+    }
 
     @Test
     public void putIf() {
@@ -37,6 +83,160 @@ public abstract class KeyToPageIndexTest {
                 index.put(Bytes.from_int(i), 3L, 1L);
             }
         }
+    }
+
+    @Test
+    public void concurrentPutIf() throws InterruptedException, ExecutionException, TimeoutException {
+
+        int jobs = 10000;
+        int parallelJobs = 10;
+
+        ExecutorService executor = Executors.newFixedThreadPool(parallelJobs * ConcurrentPutIfTask.THREADS_PER_JOB);
+
+        try (KeyToPageIndex index = createIndex()) {
+
+            index.start(LogSequenceNumber.START_OF_TIME);
+
+            for (int i = 0; i < jobs; ++i) {
+                index.put(Bytes.from_int(i), 0L);
+            }
+
+            CompletableFuture<?>[] futures = new CompletableFuture<?>[jobs];
+
+            for (int i = 0; i < jobs; ++i) {
+                futures[i] = ConcurrentPutIfTask.submitJob(executor, index, Bytes.from_int(i), 1L, 0L);
+            }
+
+            CompletableFuture.allOf(futures).get(10, TimeUnit.SECONDS);
+
+        } finally {
+
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.DAYS);
+        }
+
+    }
+
+    private static final class ConcurrentPutIfTask implements Callable<Long> {
+
+        public static final CompletableFuture<?> submitJob(ExecutorService service, KeyToPageIndex index, Bytes key, Long newPage, Long expectedPage) {
+
+            final ConcurrentPutIfTask[] tasks = createTasks(index, key, newPage, expectedPage);
+
+            @SuppressWarnings("unchecked")
+            final CompletableFuture<Long>[] futures = new CompletableFuture[tasks.length];
+
+            for (int i = 0; i < tasks.length; ++i) {
+                futures[i] = CompletableFuture.supplyAsync(tasks[i]::call, service);
+            }
+
+            return CompletableFuture.allOf(futures);
+
+        }
+
+        private static final ConcurrentPutIfTask[] createTasks(KeyToPageIndex index, Bytes key, Long newPage, Long expectedPage) {
+
+            CyclicBarrier barrier = new CyclicBarrier(3);
+            CyclicBarrier barrier2 = new CyclicBarrier(3);
+            AtomicInteger counter = new AtomicInteger(0);
+
+            return new ConcurrentPutIfTask[] {
+                    new ConcurrentPutIfTask(index, key, newPage, expectedPage, barrier, barrier2, counter),
+                    new ConcurrentPutIfTask(index, key, newPage, expectedPage, barrier, barrier2, counter),
+                    new ConcurrentPutIfTask(index, key, newPage, expectedPage, barrier, barrier2, counter)
+                    };
+
+        }
+
+        public static final int THREADS_PER_JOB = 3;
+
+
+        private final KeyToPageIndex index;
+
+        private final Bytes key;
+        private final Long newPage;
+        private final Long expectedPage;
+
+        private final CyclicBarrier barrier;
+        private final CyclicBarrier barrier2;
+        private final AtomicInteger counter;
+
+        public ConcurrentPutIfTask(KeyToPageIndex index, Bytes key, Long newPage, Long expectedPage, CyclicBarrier barrier, CyclicBarrier barrier2, AtomicInteger counter) {
+            super();
+            this.index = index;
+            this.key = key;
+            this.newPage = newPage;
+            this.expectedPage = expectedPage;
+            this.barrier = barrier;
+            this.barrier2 = barrier2;
+            this.counter = counter;
+        }
+
+        @Override
+        public Long call() throws RuntimeException {
+
+            awaitOnBarrier(barrier);
+
+            boolean put = index.put(key, newPage, expectedPage);
+
+            if (put) {
+                counter.incrementAndGet();
+            }
+
+            awaitOnBarrier(barrier2);
+
+            Long page = index.get(key);
+
+            Assert.assertEquals("Wrong page in PK index", newPage, page);
+            Assert.assertEquals("Expected just one modification in PK index", 1, counter.get());
+
+            return page;
+
+//            return 0L;
+
+        }
+//
+//        private void awaitOnBarrier() {
+//            try {
+//                barrier.await(10, TimeUnit.SECONDS);
+//            } catch (TimeoutException e) {
+//                System.out.println(key.to_int() + " " + e);
+//                e.printStackTrace();
+//                fail("Too many time blocked on waiting");
+//            } catch (InterruptedException e) {
+//                System.out.println(key.to_int() + " " + e);
+//                e.printStackTrace();
+//                /* Interrupting */
+//                return;
+//            } catch (BrokenBarrierException e) {
+//                System.out.println(key.to_int() + " " + e);
+//                e.printStackTrace();
+//                fail("Barrier broken while waiting");
+//            }
+//        }
+
+        private void awaitOnBarrier(CyclicBarrier barrier) throws RuntimeException {
+            try {
+                barrier.await();
+//                barrier.await(10, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+//                System.out.println(key.to_int() + " " + e);
+//                e.printStackTrace();
+//                fail("Too many time blocked on waiting");
+//            } catch (InterruptedException e) {
+//                System.out.println(key.to_int() + " " + e);
+//                e.printStackTrace();
+//                /* Interrupting */
+//                return;
+//            } catch (BrokenBarrierException e) {
+//                System.out.println(key.to_int() + " " + e);
+//                e.printStackTrace();
+//                fail("Barrier broken while waiting");
+//            }
+        }
+
     }
 
 }

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -56,6 +56,7 @@ import herddb.core.Page;
 import herddb.core.Page.Metadata;
 import herddb.core.PageReplacementPolicy;
 import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
+import herddb.utils.BooleanHolder;
 import herddb.utils.Holder;
 
 /**
@@ -2079,7 +2080,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                 size += owner.evaluator.evaluateAll(key, value) + ENTRY_CONSTANT_SIZE;
                 return null;
             } else {
-                /* TODO: this could be avoided if we can ensure that every value will have the same size */
+                /* TODO: this could be avoided if we can ensure that every value will have the same size (GitHub #341) */
                 size += owner.evaluator.evaluateValue(value) - owner.evaluator.evaluateValue(old);
                 return old;
             }
@@ -2109,12 +2110,11 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                      * suffice, it can be equal to newPage even if no replacement was done (the map contained already
                      * newPage mapping and expectedPage was different)
                      */
-                    Holder<Boolean> replaced = new Holder<>(Boolean.FALSE);
+                    BooleanHolder replaced = new BooleanHolder(false);
                     Holder<Y> hold = new Holder<>();
-                    final boolean o;
                     map.computeIfPresent(key, (skey, svalue) -> {
                         if (svalue.equals(expected)) {
-                            replaced.value = Boolean.TRUE;
+                            replaced.value = true;
                             /* Cast to Y: is a leaf */
                             hold.value = (Y) svalue;
                             return value;
@@ -2124,7 +2124,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                     });
 
                     /* If we didn't find expected mapping abort replacement */
-                    if (!replaced.value.booleanValue()) {
+                    if (!replaced.value) {
                         return false;
                     }
 
@@ -2144,7 +2144,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                 ++keys;
                 size += owner.evaluator.evaluateAll(key, value) + ENTRY_CONSTANT_SIZE;
             } else {
-                /* TODO: this could be avoided if we can ensure that every value will have the same size */
+                /* TODO: this could be avoided if we can ensure that every value will have the same size (GitHub #341) */
                 size += owner.evaluator.evaluateValue(value) - owner.evaluator.evaluateValue(old);
             }
 


### PR DESCRIPTION
This pull requext resolve #333

A new method on KeyToPageIndex has been added to update index values ONLY if current value is as expected parameter (like atomic compare and set). Such method is used during dirty page rebuild to avoid a double lookup (1st to known is current record is "old" and a 2nd one to update the page reference).

To be able to udpate page reference, page id "generation" has been moved in checkpoint code and there maintained.

**This patch must be merged after #338 (is build on top of it)**

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

