### PR TITLE
Add metrics checkpoint

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -137,7 +137,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     private final ServerConfiguration serverConfiguration;
     private ConnectionsInfoProvider connectionsInfoProvider;
     private long checkpointPeriod;
-    private final StatsLogger statsLogger;
+    private final StatsLogger mainStatsLogger;
 
     private long maxMemoryReference = ServerConfiguration.PROPERTY_MEMORY_LIMIT_REFERENCE_DEFAULT;
     private long maxLogicalPageSize = ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE_DEFAULT;
@@ -172,7 +172,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
     public DBManager(String nodeId, MetadataStorageManager metadataStorageManager, DataStorageManager dataStorageManager,
             CommitLogManager commitLogManager, Path tmpDirectory, herddb.network.ServerHostData hostData, ServerConfiguration configuration,
-            StatsLogger mainStatsLogger) {
+            StatsLogger statsLogger) {
         this.serverConfiguration = configuration;
         this.tmpDirectory = tmpDirectory;
         int asyncWorkerThreads = configuration.getInt(ServerConfiguration.PROPERTY_ASYNC_WORKER_THREADS,
@@ -182,12 +182,12 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         this.metadataStorageManager = metadataStorageManager;
         this.dataStorageManager = dataStorageManager;
         this.commitLogManager = commitLogManager;
-        if (mainStatsLogger == null) {
-            this.statsLogger = NullStatsLogger.INSTANCE;
+        if (statsLogger == null) {
+            this.mainStatsLogger = NullStatsLogger.INSTANCE;
         } else {
-            this.statsLogger = mainStatsLogger;
+            this.mainStatsLogger = statsLogger;
         }
-        this.runningStatements = new RunningStatementsStats(this.statsLogger);
+        this.runningStatements = new RunningStatementsStats(this.mainStatsLogger);
         this.nodeId = nodeId;
         this.virtualTableSpaceId = makeVirtualTableSpaceManagerId(nodeId);
         this.hostData = hostData != null ? hostData : new ServerHostData("localhost", 7000, "", false, new HashMap<>());
@@ -1310,7 +1310,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     }
 
     public StatsLogger getStatsLogger() {
-        return this.statsLogger;
+        return this.mainStatsLogger;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -137,6 +137,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     private final ServerConfiguration serverConfiguration;
     private ConnectionsInfoProvider connectionsInfoProvider;
     private long checkpointPeriod;
+    private final StatsLogger statsLogger;
 
     private long maxMemoryReference = ServerConfiguration.PROPERTY_MEMORY_LIMIT_REFERENCE_DEFAULT;
     private long maxLogicalPageSize = ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE_DEFAULT;
@@ -182,9 +183,11 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         this.dataStorageManager = dataStorageManager;
         this.commitLogManager = commitLogManager;
         if (mainStatsLogger == null) {
-            mainStatsLogger = NullStatsLogger.INSTANCE;
+            this.statsLogger = NullStatsLogger.INSTANCE;
+        } else {
+            this.statsLogger = mainStatsLogger;
         }
-        this.runningStatements = new RunningStatementsStats(mainStatsLogger);
+        this.runningStatements = new RunningStatementsStats(this.statsLogger);
         this.nodeId = nodeId;
         this.virtualTableSpaceId = makeVirtualTableSpaceManagerId(nodeId);
         this.hostData = hostData != null ? hostData : new ServerHostData("localhost", 7000, "", false, new HashMap<>());
@@ -1304,6 +1307,10 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
     public ServerSidePreparedStatementCache getPreparedStatementsCache() {
         return preparedStatementsCache;
+    }
+
+    public StatsLogger getStatsLogger() {
+        return this.statsLogger;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1541,7 +1541,6 @@ public class TableSpaceManager {
         }
 
         long _start = System.currentTimeMillis();
-        long _stop = 0;
         LogSequenceNumber logSequenceNumber = null;
         LogSequenceNumber _logSequenceNumber = null;
         Map<String, LogSequenceNumber> checkpointsTableNameSequenceNumber = new HashMap<>();
@@ -1611,14 +1610,12 @@ public class TableSpaceManager {
                     LOGGER.log(Level.SEVERE, "postcheckpoint error:" + error, error);
                 }
             }
-
-            _stop = System.currentTimeMillis();
-            LOGGER.log(Level.INFO, "{0} checkpoint finish {1} started ad {2}, finished at {3}, total time {4} ms",
-                    new Object[]{nodeId, tableSpaceName, logSequenceNumber, _logSequenceNumber, Long.toString(_stop - _start)});
-
             return new TableSpaceCheckpoint(logSequenceNumber, checkpointsTableNameSequenceNumber);
 
         } finally {
+            long _stop = System.currentTimeMillis();
+            LOGGER.log(Level.INFO, "{0} checkpoint finish {1} started ad {2}, finished at {3}, total time {4} ms",
+                    new Object[]{nodeId, tableSpaceName, logSequenceNumber, _logSequenceNumber, Long.toString(_stop - _start)});
             checkpointTimeStats.registerSuccessfulEvent(_stop, TimeUnit.MILLISECONDS);
         }
     }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;


### PR DESCRIPTION
Added statsLogger in the DbManager class to measure successful checkpoints. Sample metrics look like this -

# TYPE herd summary
herd{success="false",quantile="0.5"} NaN
herd{success="false",quantile="0.75"} NaN
herd{success="false",quantile="0.95"} NaN
herd{success="false",quantile="0.99"} NaN
herd{success="false",quantile="0.999"} NaN
herd{success="false",quantile="0.9999"} NaN
herd{success="false",quantile="1.0"} NaN
herd_count{success="false"} 0
herd_sum{success="false"} 0.0
herd{success="true",quantile="0.5"} NaN
herd{success="true",quantile="0.75"} NaN
herd{success="true",quantile="0.95"} NaN
herd{success="true",quantile="0.99"} NaN
herd{success="true",quantile="0.999"} NaN
herd{success="true",quantile="0.9999"} NaN
herd{success="true",quantile="1.0"} NaN
herd_count{success="true"} 1
herd_sum{success="true"} 1.550816699887E12