### PR TITLE
Added checkpoint cleanup time limit

### DIFF
--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -168,6 +168,17 @@ public final class ServerConfiguration {
 
     /**
      * Maximum target time in milliseconds to spend during standard checkpoint
+     * operations on clening dirty pages. Is should be less than the
+     * maximum checkpoint duration configured by
+     * {@link #PROPERTY_CHECKPOINT_DURATION}. If set to -1 checkpoints won't
+     * have a time limit. Regardless his value at least one page will be
+     * compacted for each checkpoint. By default, the value is 1000 ms.
+     */
+    public static final String PROPERTY_CLEANUP_DURATION = "server.checkpoint.cleanup";
+    public static final long PROPERTY_CLEANUP_DURATION_DEFAULT = 1000L;
+
+    /**
+     * Maximum target time in milliseconds to spend during standard checkpoint
      * operations on compacting smaller pages. Is should be less than the
      * maximum checkpoint duration configured by
      * {@link #PROPERTY_CHECKPOINT_DURATION}. If set to -1 checkpoints won't

--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -102,6 +102,12 @@ server.bookkeeper.port=-1
 # wider dirty page threshold.
 #server.checkpoint.duration=
 
+# Maximum target time in milliseconds to spend during standard checkpoint operations on clening dirty
+# pages. Is should be less than the maximum checkpoint duration configured by
+# # "server.checkpoint.duration". If set to -1 checkpoints won't have a time limit. Regardless his
+# value at least one page will be cleaned for each checkpoint.
+#server.checkpoint.cleanup=
+
 # Maximum target time in milliseconds to spend during standard checkpoint operations on compacting
 # smaller pages. Is should be less than the maximum checkpoint duration configured by
 # "server.checkpoint.duration". If set to -1 checkpoints won't have a time limit. Regardless his


### PR DESCRIPTION
Added a new configuration property `server.checkpoint.cleanup` to limit time spent in checkpoint to cleaning dirty pages.

This configuration could address issue #330 

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

