### PR TITLE
Add missing use of server.zookeeper.path

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -19,6 +19,24 @@
  */
 package herddb.cluster;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.log.LogNotAvailableException;
 import herddb.metadata.MetadataStorageManager;
@@ -29,22 +47,6 @@ import herddb.model.TableSpace;
 import herddb.model.TableSpaceAlreadyExistsException;
 import herddb.model.TableSpaceDoesNotExistException;
 import herddb.model.TableSpaceReplicaState;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.ZooKeeper;
-import org.apache.zookeeper.data.Stat;
 
 /**
  * Metadata storage manager over Zookeeper
@@ -84,6 +86,10 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
 
     public int getZkSessionTimeout() {
         return zkSessionTimeout;
+    }
+
+    public String getLedgersPath() {
+        return ledgersPath;
     }
 
     private synchronized void restartZooKeeper() throws IOException, InterruptedException {
@@ -428,7 +434,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
     @Override
     public List<NodeMetadata> listNodes() throws MetadataStorageManagerException {
         try {
-            List<String> children = ensureZooKeeper().getChildren(nodesPath, mainWatcher, null);            
+            List<String> children = ensureZooKeeper().getChildren(nodesPath, mainWatcher, null);
             List<NodeMetadata> result = new ArrayList<>();
             for (String child : children) {
                 NodeMetadata nodeMetadata = getNode(child);

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -237,7 +237,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 LOGGER.log(Level.INFO, "Use this JDBC URL to connect to this server: {0}", new Object[]{jdbcUrl});
                 break;
             case ServerConfiguration.PROPERTY_MODE_CLUSTER:
-                this.embeddedBookie = new EmbeddedBookie(baseDirectory, configuration, statsLogger);
+                this.embeddedBookie = new EmbeddedBookie(baseDirectory, configuration, (ZookeeperMetadataStorageManager) this.metadataStorageManager, statsLogger);
                 jdbcUrl = "jdbc:herddb:zookeeper:" + configuration.getString(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS_DEFAULT) + configuration.getString(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, ServerConfiguration.PROPERTY_ZOOKEEPER_PATH_DEFAULT);
                 LOGGER.log(Level.INFO, "Use this JDBC URL to connect to this HerdDB cluster: {0}", new Object[]{jdbcUrl});
                 break;

--- a/herddb-core/src/test/java/herddb/core/ReplicatedLogtestcase.java
+++ b/herddb-core/src/test/java/herddb/core/ReplicatedLogtestcase.java
@@ -19,8 +19,10 @@
  */
 package herddb.core;
 
+import java.io.File;
 import java.nio.file.Path;
 
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,8 +33,6 @@ import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.file.FileDataStorageManager;
 import herddb.server.ServerConfiguration;
 import herddb.utils.ZKTestEnv;
-import java.io.File;
-import org.apache.bookkeeper.stats.NullStatsLogger;
 
 /**
  * Tests using multiple nodes
@@ -62,7 +62,7 @@ public abstract class ReplicatedLogtestcase {
         File nodeDirectory = new File(folder.getRoot(), nodeId + "");
         nodeDirectory.mkdirs();
         Path path = nodeDirectory.toPath();
-        ZookeeperMetadataStorageManager metadataStorageManager = new ZookeeperMetadataStorageManager(testEnv.getAddress(), testEnv.getTimeout(), "/tests");
+        ZookeeperMetadataStorageManager metadataStorageManager = new ZookeeperMetadataStorageManager(testEnv.getAddress(), testEnv.getTimeout(), testEnv.getPath());
         BookkeeperCommitLogManager commitLogManager = new BookkeeperCommitLogManager(metadataStorageManager, new ServerConfiguration(), new NullStatsLogger());
         FileDataStorageManager dataStorageManager = new FileDataStorageManager(path);
         System.setErr(System.out);

--- a/herddb-core/src/test/java/herddb/core/SimpleClusterTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleClusterTest.java
@@ -26,8 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import herddb.utils.Holder;
-
+import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -50,8 +49,8 @@ import herddb.storage.DataStorageManager;
 import herddb.storage.FullTableScanConsumer;
 import herddb.storage.TableStatus;
 import herddb.utils.Bytes;
+import herddb.utils.Holder;
 import herddb.utils.ZKTestEnv;
-import org.apache.bookkeeper.stats.NullStatsLogger;
 
 /**
  *
@@ -79,7 +78,7 @@ public class SimpleClusterTest extends BaseTestcase {
 
     @Override
     protected MetadataStorageManager makeMetadataStorageManager() throws Exception {
-        return new ZookeeperMetadataStorageManager(testEnv.getAddress(), testEnv.getTimeout(), "/tests");
+        return new ZookeeperMetadataStorageManager(testEnv.getAddress(), testEnv.getTimeout(), testEnv.getPath());
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/server/BookkeeperFailuresTest.java
+++ b/herddb-core/src/test/java/herddb/server/BookkeeperFailuresTest.java
@@ -19,11 +19,31 @@
  */
 package herddb.server;
 
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.codec.RecordSerializer;
 import herddb.core.ActivatorRunRequest;
 import herddb.core.TableSpaceManager;
-import static herddb.core.TestUtils.scan;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
 import herddb.model.StatementEvaluationContext;
@@ -37,23 +57,6 @@ import herddb.model.commands.CommitTransactionStatement;
 import herddb.model.commands.CreateTableStatement;
 import herddb.model.commands.InsertStatement;
 import herddb.utils.ZKTestEnv;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.BookKeeperAdmin;
-import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.api.LedgerMetadata;
-import org.apache.bookkeeper.conf.ClientConfiguration;
-import org.junit.After;
-import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /**
  * We are going to fence forcibly a ledger during the normal execution
@@ -83,6 +86,7 @@ public class BookkeeperFailuresTest {
     private BookKeeper createBookKeeper() throws Exception {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         clientConfiguration.setZkServers(testEnv.getAddress());
+        clientConfiguration.setZkLedgersRootPath(testEnv.getPath() + "/ledgers");
         return BookKeeper.forConfig(clientConfiguration).build();
     }
 

--- a/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
@@ -20,12 +20,14 @@
 package herddb.utils;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
+
 import org.apache.bookkeeper.client.BookKeeperAdmin;
-import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.ZooDefs;
 
 public class ZKTestEnv implements AutoCloseable {
 
@@ -39,25 +41,53 @@ public class ZKTestEnv implements AutoCloseable {
     }
 
     public void startBookie() throws Exception {
+        startBookie(true);
+    }
+
+    public void startBookie(boolean format) throws Exception {
+        if (bookie != null) {
+            throw new Exception("bookie already started");
+        }
         ServerConfiguration conf = new ServerConfiguration();
         conf.setBookiePort(5621);
         conf.setUseHostNameAsBookieID(true);
 
         Path targetDir = path.resolve("bookie_data");
         conf.setZkServers("localhost:1282");
+        conf.setZkLedgersRootPath(getPath() + "/ledgers");
         conf.setLedgerDirNames(new String[]{targetDir.toAbsolutePath().toString()});
-        conf.setJournalDirName(targetDir.toAbsolutePath().toString());        
+        conf.setJournalDirName(targetDir.toAbsolutePath().toString());
         conf.setFlushInterval(10000);
         conf.setGcWaitTime(5);
         conf.setJournalFlushWhenQueueEmpty(true);
 //        conf.setJournalBufferedEntriesThreshold(1);
         conf.setAutoRecoveryDaemonEnabled(false);
         conf.setEnableLocalTransport(true);
+        conf.setJournalSyncData(false);
 
         conf.setAllowLoopback(true);
-        conf.setProperty("journalMaxGroupWaitMSec", 10); // default 200ms            
+        conf.setProperty("journalMaxGroupWaitMSec", 10); // default 200ms
 
-        BookKeeperAdmin.format(conf, false, true);
+
+        try (ZooKeeperClient zkc = ZooKeeperClient
+                .newBuilder()
+                .connectString("localhost:1282")
+                .sessionTimeoutMs(10000)
+                .build()){
+
+            boolean rootExists = zkc.exists(getPath(), false) != null;
+
+            if (!rootExists) {
+                zkc.create(getPath(), new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            }
+
+        }
+
+        if (format) {
+            BookKeeperAdmin.initNewCluster(conf);
+            BookKeeperAdmin.format(conf, false, true);
+        }
+
         this.bookie = new BookieServer(conf);
         this.bookie.start();
     }


### PR DESCRIPTION
Poperty server.zookeeper.path was ignored in BookKeeperBlobManager

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

