### PR TITLE
Fix/checkpoint isolate methods

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -33,7 +33,7 @@ import herddb.utils.Bytes;
  * @author enrico.olivelli
  * @author diego.salvi
  */
-public class DataPage extends Page<TableManager> {
+public final class DataPage extends Page<TableManager> {
 
     /**
      * Constant entry size take in account map entry nodes:
@@ -56,7 +56,7 @@ public class DataPage extends Page<TableManager> {
     public final long maxSize;
     public final boolean immutable;
 
-    public Map<Bytes, Record> data;
+    public final Map<Bytes, Record> data;
 
     public final AtomicLong usedMemory;
 
@@ -71,7 +71,7 @@ public class DataPage extends Page<TableManager> {
      */
     public boolean writable;
 
-    public DataPage(TableManager owner, long pageId, long maxSize, long estimatedSize, Map<Bytes, Record> data, boolean immutable) {
+    DataPage(TableManager owner, long pageId, long maxSize, long estimatedSize, Map<Bytes, Record> data, boolean immutable) {
         super(owner, pageId);
         this.maxSize = maxSize;
         this.immutable = immutable;

--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -164,6 +164,13 @@ public class DataPage extends Page<TableManager> {
 
         data.put(record.key, record);
     }
+    
+    void removeNoMemoryHandle(Record record) {
+        if (immutable) {
+            throw new IllegalStateException("page " + pageId + " is immutable!");
+        }
+        data.remove(record.key);
+    }
 
     boolean isEmpty() {
         return data.isEmpty();

--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -26,7 +26,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import herddb.model.Record;
 import herddb.utils.Bytes;
-import java.util.Collections;
+import java.util.Collection;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -58,7 +59,7 @@ public final class DataPage extends Page<TableManager> {
     public final long maxSize;
     public final boolean immutable;
 
-    public final Map<Bytes, Record> data;
+    private final Map<Bytes, Record> data;
     // this is only for debug. NOT TO be COMMITTED
     public final CopyOnWriteArrayList<Bytes> debugSeenKeys = new CopyOnWriteArrayList<>();
 
@@ -159,6 +160,14 @@ public final class DataPage extends Page<TableManager> {
     int size() {
         return data.size();
     }
+       
+    Collection<Record> getRecordsForFlush() {
+        return data.values();
+    }
+    
+    Set<Bytes> getKeysForDebug() {
+        return data.keySet();
+    }
 
     long getUsedMemory() {
         return usedMemory.get();
@@ -196,6 +205,10 @@ public final class DataPage extends Page<TableManager> {
         }
         DataPage other = (DataPage) obj;
         return pageId == other.pageId;
+    }
+
+    void flushRecordsCache() {
+        data.values().forEach(r -> r.clearCache());
     }
 
 }

--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -87,33 +87,7 @@ public final class DataPage extends Page<TableManager> {
 
         pageLock = immutable ? null : new ReentrantReadWriteLock(false);
     }
-
-    /**
-     * Convert a {@link DataPage} to immutable.
-     * <p>
-     * Conversion can be done only after the page has been set as not writable.
-     * </p>
-     * <p>
-     * Checks on immutable pages are faster (they not have to check volatile
-     * writable flag and lock it before checking).
-     * </p>
-     *
-     * @return immutable data page version
-     */
-    DataPage toImmutable() {
-
-        if (immutable) {
-            throw new IllegalStateException("page " + pageId + " already is immutable!");
-        }
-
-        if (writable) {
-            throw new IllegalStateException("page " + pageId + " cannot be converted to immutable because still writable!");
-        }
-
-        return new DataPage(owner, pageId, maxSize, usedMemory.get(), Collections.unmodifiableMap(data), true);
-
-    }
-
+    
     Record remove(Bytes key) {
         if (immutable) {
             throw new IllegalStateException("page " + pageId + " is immutable!");

--- a/herddb-core/src/main/java/herddb/core/PageSet.java
+++ b/herddb-core/src/main/java/herddb/core/PageSet.java
@@ -55,7 +55,7 @@ public final class PageSet {
         public DataPageMetaData(DataPage page) {
             super();
             this.size = page.getUsedMemory();
-            this.avgRecordSize = size / page.data.size();
+            this.avgRecordSize = size / page.size();
             this.dirt = new LongAdder();
         }
 

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -719,7 +719,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         final long used = flushNewPage(page, spareData);
 
         /* Replace the page in memory with his immutable version (faster modification checks) */
-        page = page.toImmutable();
         pages.put(page.pageId, page);
 
         /*
@@ -886,8 +885,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
 
             if (keepPageInMemory) {
-                /* If we must keep the page in memory we "covert" the page to immutable */
-                page = page.toImmutable();
                 pages.put(page.pageId, page);
 
                 /* And we load to page replacement polcy */

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3104,7 +3104,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
             pageId = relocatedPageId;
             if (maxTrials-- == 0) {
-                throw new DataStorageManagerException("inconsistency! table " + table.name + " no record in memory for " + key + " page " + pageId + ", activePages " + pageSet.getActivePages() + " after many trials");
+                if (dataPage != null) {
+                    Collection<Bytes> keysForDebug = dataPage.data.keySet(); // this may in an inconsistent state
+                    throw new DataStorageManagerException("inconsistency! table " + table.name + " no record in memory for " + key + " page " + pageId + ", activePages " + pageSet.getActivePages() + ", dataPage "+dataPage+", dataPageKeys ="+keysForDebug+" after many trials");
+                } else {
+                    throw new DataStorageManagerException("inconsistency! table " + table.name + " no record in memory for " + key + " page " + pageId + ", activePages " + pageSet.getActivePages() + ", dataPage = null after many trials");
+                }
             }
         }
     }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1988,7 +1988,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private DataPage buildImmutableDataPage(long pageId, List<Record> page) {
-        Map<Bytes, Record> newPageMap = new HashMap<>(page.size());
+        Map<Bytes, Record> newPageMap = new ConcurrentHashMap<>(page.size());
         long estimatedPageSize = 0;
         for (Record r : page) {
             newPageMap.put(r.key, r);

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -2373,7 +2373,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         bufferPageSize += recordSize;
                     } else {
                         throw new IllegalStateException("Record "+unshared.key+" was moved out from page "+weighted.pageId
-                                    +" by a thread other then the checkpoint one");
+                                    +" by a thread other than the checkpoint one, keyToPage says: "+keyToPage.get(unshared.key)+
+                                " I was expecting "+weighted.pageId);
                     }
                 }
 

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -827,13 +827,13 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     records.remove();
                 }
             }
+
+            long spareUsedMemory = page.getUsedMemory() - usedMemory;
+
+            /* Fix spare page data removing used memory */
+            stealingDataPage.setUsedMemory(buildingPageMemory - spareUsedMemory);
         }
 
-
-        long spareUsedMemory = page.getUsedMemory() - usedMemory;
-
-        /* Fix spare page data removing used memory */
-        stealingDataPage.setUsedMemory(buildingPageMemory - spareUsedMemory);
 
         LOGGER.log(Level.FINER, "flushNewPage table {0}, pageId={1} with {2} records, {3} logical page size",
                 new Object[]{table.name, page.pageId, page.size(), page.getUsedMemory()});

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -803,11 +803,12 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             lock.unlock();
         }
 
-        final long usedMemory = page.getUsedMemory();
-        final long buildingPageMemory = page.getUsedMemory();
-
         // Try to steal records from another temporary page
         if (stealingDataPage != null) {
+            /* Save current memory size */
+            final long usedMemory = page.getUsedMemory();
+            final long buildingPageMemory = stealingDataPage.getUsedMemory();
+
             /* Flag to enable spare data addition to currently flushed page */
             boolean add = true;
             final Iterator<Record> records = stealingDataPage.getRecordsForFlush().iterator();

--- a/herddb-core/src/test/java/herddb/core/CheckpointTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointTest.java
@@ -318,10 +318,10 @@ public class CheckpointTest {
             assertNotNull(page);
 
             /* 2 records in page */
-            assertEquals(2, page.data.size());
+            assertEquals(2, page.size());
 
             /* No more space for other records */
-            long avgRecordSize = page.getUsedMemory() / page.data.size();
+            long avgRecordSize = page.getUsedMemory() / page.size();
             assertTrue(page.getUsedMemory() + avgRecordSize > pageSize);
 
             /* Dirty a page with few data */
@@ -407,10 +407,10 @@ public class CheckpointTest {
             assertNotNull(page);
 
             /* 2 records in page */
-            assertEquals(2, page.data.size());
+            assertEquals(2, page.size());
 
             /* No more space for other records */
-            long avgRecordSize = page.getUsedMemory() / page.data.size();
+            long avgRecordSize = page.getUsedMemory() / page.size();
             assertTrue(page.getUsedMemory() + avgRecordSize > pageSize);
 
             /* Dirty a page with few data */
@@ -496,10 +496,10 @@ public class CheckpointTest {
             assertNotNull(page);
 
             /* 1 records in page */
-            assertEquals(1, page.data.size());
+            assertEquals(1, page.size());
 
             /* No more space for other records */
-            long avgRecordSize = page.getUsedMemory() / page.data.size();
+            long avgRecordSize = page.getUsedMemory() / page.size();
             assertTrue(page.getUsedMemory() + avgRecordSize > pageSize);
 
             /* No more space in page BUT consider the page as small (little hacky) */
@@ -588,10 +588,10 @@ public class CheckpointTest {
             assertNotNull(page);
 
             /* 1 records in page */
-            assertEquals(1, page.data.size());
+            assertEquals(1, page.size());
 
             /* No more space for other records */
-            long avgRecordSize = page.getUsedMemory() / page.data.size();
+            long avgRecordSize = page.getUsedMemory() / page.size();
             assertTrue(page.getUsedMemory() + avgRecordSize > pageSize);
 
             /* No more space in page BUT consider the page as small (little hacky) */

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -2112,7 +2112,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                      */
                     BooleanHolder replaced = new BooleanHolder(false);
                     Holder<Y> hold = new Holder<>();
-                    map.compute(key, (skey, currentValue) -> {
+                    map.computeIfPresent(key, (skey, currentValue) -> {
                         if (expected.equals(currentValue)) {
                             replaced.value = true;
                             /* Cast to Y: is a leaf */

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -2112,15 +2112,15 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                      */
                     BooleanHolder replaced = new BooleanHolder(false);
                     Holder<Y> hold = new Holder<>();
-                    map.computeIfPresent(key, (skey, svalue) -> {
-                        if (svalue.equals(expected)) {
+                    map.compute(key, (skey, currentValue) -> {
+                        if (currentValue.equals(expected)) {
                             replaced.value = true;
                             /* Cast to Y: is a leaf */
-                            hold.value = (Y) svalue;
+                            hold.value = (Y) currentValue;
                             return value;
                         }
 
-                        return svalue;
+                        return currentValue;
                     });
 
                     /* If we didn't find expected mapping abort replacement */

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -2113,7 +2113,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                     BooleanHolder replaced = new BooleanHolder(false);
                     Holder<Y> hold = new Holder<>();
                     map.compute(key, (skey, currentValue) -> {
-                        if (currentValue.equals(expected)) {
+                        if (expected.equals(currentValue)) {
                             replaced.value = true;
                             /* Cast to Y: is a leaf */
                             hold.value = (Y) currentValue;


### PR DESCRIPTION
This PR starts from Enrico's fix/fix-checkpoint branch keeping all his improvements and isolating the main handling block of checkpoint into a separate method.

In addition:
* now dirty small pages handling is separated from dirty pages handling (thus a "small" and dirty page can be cleaned up without waiting forever that any other page has been cleaned up)
* added more DataPage isolation with a new metod to force used memory (without direct access to internal atomic long, cosmetic)
* fully handled "buildingPage" data size (who add or remove data from building page now handles page memory count too thus at the end of method execution buildPage data must match buildingPage usedMemory count with no other external count)


 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

