### PR TITLE
Fix/wrong checkpoint recovery

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1324,6 +1324,20 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             forceFlushTableData = true;
         }
 
+        if (!transaction.lastSequenceNumber.after(bootSequenceNumber)) {
+            if (recovery) {
+                LOGGER.log(Level.FINER,
+                        "ignoring transaction {0} commit on recovery, {1}.{2} data is newer: transaction {3}, table {4}",
+                        new Object[] { transaction.transactionId, table.tablespace, table.name,
+                                transaction.lastSequenceNumber, bootSequenceNumber });
+                return;
+            } else {
+                throw new DataStorageManagerException("corrupted commit log " + table.tablespace + "." + table.name
+                        + " data is newer than transaction " + transaction.transactionId + " transaction "
+                        + transaction.lastSequenceNumber + " table " + bootSequenceNumber);
+            }
+        }
+
         boolean lockAcquired;
         try {
             lockAcquired = checkpointLock.asReadLock().tryLock(CHECKPOINT_LOCK_READ_TIMEOUT, SECONDS);
@@ -1800,7 +1814,10 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         }
 
         /* Insert  the value on keyToPage */
-        keyToPage.put(key, insertionPageId);
+        if (!keyToPage.put(key, insertionPageId, null)) {
+            throw new IllegalStateException(
+                    "corrupted transaction log: key " + key + " is already present in table " + table.name);
+        }
 
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.log(Level.FINEST, "Inserted key " + key + " into page " + insertionPageId);
@@ -3186,4 +3203,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     private static final Comparator<Map.Entry<Bytes, Long>> SORTED_PAGE_ACCESS_COMPARATOR = (a, b) -> {
         return a.getValue().compareTo(b.getValue());
     };
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("TableManager [table=").append(table).append("]");
+        return builder.toString();
+    }
 }

--- a/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
@@ -20,8 +20,14 @@
 package herddb.core.system;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
 
 import herddb.core.AbstractTableManager;
 import herddb.core.MaterializedRecordSet;
@@ -48,11 +54,6 @@ import herddb.model.commands.ScanStatement;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.FullTableScanConsumer;
 import herddb.utils.SQLRecordPredicateFunctions;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.StreamSupport;
-import org.apache.bookkeeper.common.concurrent.FutureUtils;
 
 /**
  * System tables
@@ -273,4 +274,10 @@ public abstract class AbstractSystemTableManager implements AbstractTableManager
         return null;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(getClass().getSimpleName()).append(" [table=").append(table).append("]");
+        return builder.toString();
+    }
 }

--- a/herddb-core/src/main/java/herddb/file/FileCommitLog.java
+++ b/herddb-core/src/main/java/herddb/file/FileCommitLog.java
@@ -241,6 +241,14 @@ public class FileCommitLog extends CommitLog {
             this.entry = entry;
         }
 
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("LogEntryWithSequenceNumber [logSequenceNumber=").append(logSequenceNumber)
+                    .append(", entry=").append(entry).append("]");
+            return builder.toString();
+        }
+
     }
 
     public static class CommitFileReader implements AutoCloseable {

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -19,12 +19,11 @@
  */
 package herddb.model;
 
-import com.google.common.collect.ImmutableSet;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -32,8 +31,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableSet;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.model.commands.AlterTableStatement;
@@ -41,9 +44,6 @@ import herddb.sql.expressions.BindableTableScanColumnNameResolver;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.SimpleByteArrayInputStream;
-import java.util.Comparator;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Table definition
@@ -345,6 +345,13 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
 
     public Column getColumn(int index) {
         return columns[index];
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Table [name=").append(name).append(", tablespace=").append(tablespace).append("]");
+        return sb.toString();
     }
 
     public static class Builder {

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -21,13 +21,14 @@ package herddb.model;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import org.apache.commons.collections.map.HashedMap;
 
@@ -42,9 +43,6 @@ import herddb.utils.ILocalLockManager;
 import herddb.utils.LockHandle;
 import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
-import java.util.Collection;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * A Transaction, that is a series of Statement which must be executed with ACID
@@ -116,6 +114,7 @@ public class Transaction {
 
     private boolean updateLastSequenceNumber(CommitLogResult writeResult) throws LogNotAvailableException {
         if (writeResult.deferred) {
+            deferredWrites.add(writeResult);
             return false;
         }
         LogSequenceNumber sequenceNumber = writeResult.getLogSequenceNumber();
@@ -123,7 +122,6 @@ public class Transaction {
             return true;
         }
         this.lastSequenceNumber = sequenceNumber;
-        deferredWrites.add(writeResult);
         return false;
     }
 
@@ -509,7 +507,7 @@ public class Transaction {
                 || (newTables != null && newTables.containsKey(name));
     }
 
-    public void synch() throws LogNotAvailableException {
+    public void sync() throws LogNotAvailableException {
         // wait for all writes to be synch to log
         for (CommitLogResult result : deferredWrites) {
             LogSequenceNumber number = result.getLogSequenceNumber();
@@ -517,6 +515,16 @@ public class Transaction {
                 lastSequenceNumber = number;
             }
         }
+    }
+
+    public void sync(LogSequenceNumber sequenceNumber) throws LogNotAvailableException {
+        sync();
+
+        /* Check that given transaction position isn't smaller than last seen sequence number */
+        if (lastSequenceNumber != null && !sequenceNumber.after(lastSequenceNumber)) {
+            throw new IllegalStateException("Corrupted transaction, syncing on a position smaller than transaction last sequence number");
+        }
+        lastSequenceNumber = sequenceNumber;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -507,6 +507,7 @@ public class Transaction {
                 || (newTables != null && newTables.containsKey(name));
     }
 
+    /* Visible for testing */
     public void sync() throws LogNotAvailableException {
         // wait for all writes to be synch to log
         for (CommitLogResult result : deferredWrites) {

--- a/herddb-core/src/test/java/herddb/server/BookkeeperFailuresTest.java
+++ b/herddb-core/src/test/java/herddb/server/BookkeeperFailuresTest.java
@@ -382,7 +382,7 @@ public class BookkeeperFailuresTest {
 
             Transaction transaction = tableSpaceManager.getTransactions().stream().filter(t -> t.transactionId == transactionId).findFirst().get();
             // Transaction will synch, so every addEntry will be acked, but will not be "confirmed" yet
-            transaction.synch();
+            transaction.sync();
 
             try (DataScanner scan = scan(server.getManager(), "select * from t1", Collections.emptyList(), new TransactionContext(transactionId));) {
                 assertEquals(3, scan.consume().size());


### PR DESCRIPTION
Changes:
* added a check to evaluate if inserted record is really new (it breaks some test, especially RestartTest.recoverTableCreatedInTransaction)
* added a check to skip transaction apply if table booted with newer data (log in recovery, failure otherwise)
* added some minor cosmetic toString method to simplify debugging

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

