### PR TITLE
Fix KeyToPage used memory tracking

### DIFF
--- a/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
@@ -77,7 +77,13 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
     public boolean put(Bytes key, Long newPage, Long expectedPage) {
         if (expectedPage == null) {
             final Long opage = map.putIfAbsent(key, newPage);
-            return opage == null;
+
+            if (opage == null) {
+                keyAdded(key);
+                return true;
+            }
+
+            return false;
         } else {
             /*
              * We need to keep track if the update was really done. Reading computeIfPresent result won't
@@ -93,7 +99,12 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
                 return spage;
             });
 
-            return holder.value;
+            if (holder.value) {
+                keyAdded(key);
+                return true;
+            }
+
+            return false;
         }
 
     }

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -57,9 +57,7 @@ import herddb.storage.DataStorageManagerException;
 import herddb.storage.IndexStatus;
 import herddb.utils.ByteArrayCursor;
 import herddb.utils.Bytes;
-import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
-import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
 
 /**
@@ -231,7 +229,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
     @Override
     public long getUsedMemory() {
-        return 0;
+        return getTree().getUsedMemory();
     }
 
     @Override

--- a/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
@@ -26,6 +26,79 @@ public abstract class KeyToPageIndexTest {
 
     abstract KeyToPageIndex createIndex();
 
+
+    @Test
+    public void getUsedMemory() {
+
+        try (KeyToPageIndex index = createIndex()) {
+
+            final Bytes key = Bytes.from_int(1);
+
+            index.start(LogSequenceNumber.START_OF_TIME);
+
+            Assert.assertEquals(0, index.getUsedMemory());
+
+            /* Test put */
+            index.put(key, 1L);
+
+            Assert.assertTrue(index.getUsedMemory() > 0);
+
+            /* Test remove after put */
+            index.remove(key);
+
+            Assert.assertEquals(0, index.getUsedMemory());
+
+
+            /* Test put if */
+            index.put(key, 1L, null);
+
+            Assert.assertTrue(index.getUsedMemory() > 0);
+
+            /* Test remove after put if */
+            index.remove(key);
+
+            Assert.assertEquals(0, index.getUsedMemory());
+
+        }
+
+    }
+
+    @Test
+    public void size() {
+
+        try (KeyToPageIndex index = createIndex()) {
+
+            final Bytes key = Bytes.from_int(1);
+
+            index.start(LogSequenceNumber.START_OF_TIME);
+
+            Assert.assertEquals(0, index.size());
+
+            /* Test put */
+            index.put(key, 1L);
+
+            Assert.assertEquals(1, index.size());
+
+            /* Test remove after put */
+            index.remove(key);
+
+            Assert.assertEquals(0, index.size());
+
+
+            /* Test put if */
+            index.put(key, 1L, null);
+
+            Assert.assertEquals(1, index.size());
+
+            /* Test remove after put if */
+            index.remove(key);
+
+            Assert.assertEquals(0, index.size());
+
+        }
+
+    }
+
     /** This test failed with the error
      * <pre>
      * herddb.storage.DataStorageManagerException: pages are immutable


### PR DESCRIPTION
During #355 we found an issue on PK used memory tracking. This PR address that issue:
- track memory on put if too in ConcurrentMapKeyToPageIndex
- add tracking for BLink key to pages

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

