### PR TITLE
Fix concurrent unload and checkpoint flush on new pages

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -732,10 +732,15 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         final boolean flushed = flushNewPage(page, spareDataPage);
 
         if (!flushed) {
-            throw new IllegalStateException("Concurrently flushed a new page during checkpoint! Page " + page);
+            LOGGER.log(Level.INFO, "New page {0} already flushed in a concurrent thread", page.pageId);
         }
 
-        /* Replace the page in memory with his immutable version (faster modification checks) */
+        /*
+         * Replace the page in memory with his immutable version (faster modification checks). We can
+         * replace the page even if we didn't flush it (i.e.:flushed by some other thread) because we are
+         * running during a checkpoint and no other page write could happen (thus our page copy is fully
+         * equivalent to really flushed one)
+         */
         pages.put(page.pageId, page.toImmutable());
     }
 


### PR DESCRIPTION
This PR address an issue similar to #362 but on new pages.

The issue was never observed but is latent (discovered while developing #362).

This behaviour could generate a rare problem:
1. [Thread A] attempt checkpoint of new page P
2. [Thread B] needs to load a page and unload P flusing it to disk (is a newpage)
3. [Thread A] start P flush and find that was already flushed
4. [Thread A] fail with IllegalStateException("Concurrently flushed a new page during checkpoint! Page P");

Unfortunately I cannot reproduce the problem on a test (but was there waiting to bite)

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
