### PR TITLE
Improved empty pages checkpoint handling. Closes #356

### DIFF
--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -384,7 +384,14 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
          */
         private static final long VERSION_1 = 1L;
 
-        public static final long CURRENT_VERSION = VERSION_1;
+        /**
+         * Removed empty field in BLinkNodeMetadata
+         *
+         * @since 0.9.0
+         */
+        private static final long VERSION_2 = 2L;
+
+        public static final long CURRENT_VERSION = VERSION_2;
 
         private static final long NO_FLAGS = 0L;
 
@@ -419,8 +426,6 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
                     edos.writeVLong(node.id);
                     edos.writeVLong(node.storeId);
-
-                    edos.writeBoolean(node.empty);
 
                     edos.writeVInt(node.keys);
                     edos.writeVLong(node.bytes);
@@ -458,7 +463,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                  */
                 boolean recalculateSize = version == VERSION_0;
 
-                /* flags for future implementations, actually unused (exists from version 1)*/
+                /* flags for future implementations, actually unused (exists from version 1) */
                 @SuppressWarnings("unused")
                 long flags = version > VERSION_0 ? edis.readVLong() : NO_FLAGS;
 
@@ -489,41 +494,107 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                         throw new IOException("Wrong block type " + block);
                     }
 
-                    final boolean leaf = edis.readBoolean();
+                    BLinkNodeMetadata<Bytes> node;
 
-                    long id = edis.readVLong();
-                    long storeId = edis.readVLong();
+                    if (version == VERSION_2) {
+                        node = readV2(edis, recalculateSize);
 
-                    boolean empty = edis.readBoolean();
+                    } else if (version == VERSION_1) {
+                        node = readV1(edis, recalculateSize);
 
-                    int keys = edis.readVInt();
-                    long bytes = edis.readVLong();
+                    } else if (version == VERSION_0) {
+                        node = readV0(edis, recalculateSize);
 
-                    if (recalculateSize) {
-                        /* Set size to unknown to force node size recalculation */
-                        bytes = BLink.UNKNOWN_SIZE;
-                    }
-
-                    long outlink = edis.readZLong();
-                    long rightlink = edis.readZLong();
-
-                    boolean hasInf = edis.readBoolean();
-
-                    Bytes rightsep;
-                    if (hasInf) {
-                        rightsep = Bytes.POSITIVE_INFINITY;
                     } else {
-                        rightsep = edis.readBytesNoCopy();
+                        throw new IllegalArgumentException("Unknown BLink node metadata version " + version);
                     }
-
-                    BLinkNodeMetadata<Bytes> node
-                        = new BLinkNodeMetadata<>(leaf, id, storeId, empty, keys, bytes, outlink, rightlink, rightsep);
 
                     nodes.add(node);
                 }
 
                 return new BLinkMetadata<>(nextID, fast, fastheight, top, topheight, first, values, nodes);
             }
+
+        }
+
+
+        /**
+         * Read node metadata V2
+         */
+        public BLinkNodeMetadata<Bytes> readV2(ByteArrayCursor cursor, boolean recalculateSize) throws IOException {
+
+            final boolean leaf = cursor.readBoolean();
+
+            long id = cursor.readVLong();
+            long storeId = cursor.readVLong();
+
+            int keys = cursor.readVInt();
+            long bytes = cursor.readVLong();
+
+            if (recalculateSize) {
+                /* Set size to unknown to force node size recalculation */
+                bytes = BLink.UNKNOWN_SIZE;
+            }
+
+            long outlink = cursor.readZLong();
+            long rightlink = cursor.readZLong();
+
+            boolean hasInf = cursor.readBoolean();
+
+            Bytes rightsep;
+            if (hasInf) {
+                rightsep = Bytes.POSITIVE_INFINITY;
+            } else {
+                rightsep = cursor.readBytesNoCopy();
+            }
+
+            return new BLinkNodeMetadata<>(leaf, id, storeId, keys, bytes, outlink, rightlink, rightsep);
+
+        }
+
+        /**
+         * Read node metadata V1
+         */
+        public BLinkNodeMetadata<Bytes> readV1(ByteArrayCursor cursor, boolean recalculateSize) throws IOException {
+            /* Actually node metadata v0 and v1 are identical, this method exists only to be more explicit */
+            return readV0(cursor,recalculateSize);
+        }
+
+        /**
+         * Read node metadata V0
+         */
+        public BLinkNodeMetadata<Bytes> readV0(ByteArrayCursor cursor, boolean recalculateSize) throws IOException {
+
+            final boolean leaf = cursor.readBoolean();
+
+            long id = cursor.readVLong();
+            long storeId = cursor.readVLong();
+
+            /* Boolean read, we don't need "empty" flag anymore but still exists in this version */
+            @SuppressWarnings("unused")
+            boolean empty = cursor.readBoolean();
+
+            int keys = cursor.readVInt();
+            long bytes = cursor.readVLong();
+
+            if (recalculateSize) {
+                /* Set size to unknown to force node size recalculation */
+                bytes = BLink.UNKNOWN_SIZE;
+            }
+
+            long outlink = cursor.readZLong();
+            long rightlink = cursor.readZLong();
+
+            boolean hasInf = cursor.readBoolean();
+
+            Bytes rightsep;
+            if (hasInf) {
+                rightsep = Bytes.POSITIVE_INFINITY;
+            } else {
+                rightsep = cursor.readBytesNoCopy();
+            }
+
+            return new BLinkNodeMetadata<>(leaf, id, storeId, keys, bytes, outlink, rightlink, rightsep);
 
         }
     }

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -545,7 +545,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             if (hasInf) {
                 rightsep = Bytes.POSITIVE_INFINITY;
             } else {
-                rightsep = cursor.readBytesNoCopy();
+                rightsep = cursor.readBytes();
             }
 
             return new BLinkNodeMetadata<>(leaf, id, storeId, keys, bytes, outlink, rightlink, rightsep);
@@ -591,7 +591,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             if (hasInf) {
                 rightsep = Bytes.POSITIVE_INFINITY;
             } else {
-                rightsep = cursor.readBytesNoCopy();
+                rightsep = cursor.readBytes();
             }
 
             return new BLinkNodeMetadata<>(leaf, id, storeId, keys, bytes, outlink, rightlink, rightsep);
@@ -636,7 +636,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
                     switch (block) {
 
                         case NODE_PAGE_KEY_VALUE_BLOCK:
-                            map.put(in.readBytesNoCopy(),
+                            map.put(in.readBytes(),
                                 in.readVLong());
                             break;
 

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -419,11 +419,11 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                     }
 
                     /*
-                     * Remove the node from nodes knowledge: it is a safe operation, if a node is empty it will not used
-                     * anymore and it has just an outlink from a possibly real node. If there is a concurrent traversal
-                     * it will continue anyway (nodes reachable though links). Nodes memory is needed only for page
-                     * unload and close and truncate operations (the page was just unloaded and close and truncate will
-                     * deal with remaining "live" nodes).
+                     * Remove the node from nodes knowledge: it is a safe operation, if a node is empty it will not be
+                     * used anymore and it has just an outlink from a possibly real node. If there is a concurrent
+                     * traversal it will continue anyway (nodes reachable through links). Nodes memory is needed only
+                     * for page unload and close and truncate operations (the page was just unloaded and close and
+                     * truncate will deal with remaining "live" nodes).
                      */
                     nodes.remove(node.pageId);
 

--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -411,7 +411,22 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                  * Do not checkpoint empty nodes. They aren't needed at all and because no modification
                  * operations is occurring currently seen empty node aren't referenced by anyone.
                  */
-                if (node.empty) {
+                if (node.empty()) {
+
+                    /* If the node existed in policy remove it and unload */
+                    if (policy.remove(node)) {
+                        node.unload(false, false);
+                    }
+
+                    /*
+                     * Remove the node from nodes knowledge: it is a safe operation, if a node is empty it will not used
+                     * anymore and it has just an outlink from a possibly real node. If there is a concurrent traversal
+                     * it will continue anyway (nodes reachable though links). Nodes memory is needed only for page
+                     * unload and close and truncate operations (the page was just unloaded and close and truncate will
+                     * deal with remaining "live" nodes).
+                     */
+                    nodes.remove(node.pageId);
+
                     continue;
                 }
             } finally {
@@ -1695,8 +1710,6 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
 
         Node<X, Y> rightlink;
 
-        boolean empty;
-
         boolean loaded;
 
         volatile boolean dirty;
@@ -1709,8 +1722,6 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
             this.flushId = BLinkIndexDataStorage.NEW_PAGE;
 
             this.leaf = leaf;
-
-            this.empty = false;
 
             this.rightsep = rightsep;
 
@@ -1750,8 +1761,6 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
 
             this.leaf = metadata.leaf;
 
-            this.empty = metadata.empty;
-
             this.rightsep = metadata.rightsep;
 
             this.lock = new ReentrantReadWriteLock(false);
@@ -1771,7 +1780,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
         /* *** FOR BOTH LEAVES AND NODES *** */
         /* ********************************* */
         boolean empty() {
-            return empty;
+            return outlink != null;
         }
 
         boolean too_sparse() {
@@ -1836,8 +1845,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
 
                     dirty = true;
 
-                    // r is marked empty
-                    right.empty = true;
+                    // let JVM reclaim map memory
                     right.map.clear();
                     right.map = newNodeMap();
 
@@ -1894,6 +1902,18 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
 
             // If l is a leaf, its separator is set to the largest key in it
             rightsep = right.rightsep;
+
+            /*
+             * Right data page not needed anymore, unload it NOW. Removing from policy now has 2 benefits:
+             *
+             * 1) open space for real data pages on policy as soon as possible
+             *
+             * 2) avoid an unloading racing condition while checkpointing (concurrent unload attempt on pages
+             * unfortunately already removed from nodes knowledge)
+             */
+            if (owner.policy.remove(right)) {
+                right.unload(false, false);
+            }
 
             // the previous value of the rightmost separator in l is returned.
             return half_merge;
@@ -2667,7 +2687,6 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
                         leaf,
                         pageId,
                         storeId,
-                        empty,
                         keys,
                         size,
                         outlink == null ? BLinkNodeMetadata.NO_LINK : outlink.pageId,
@@ -2787,7 +2806,6 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
         public String toString() {
             return "Node [id=" + pageId
                     + ", leaf=" + leaf
-                    + ", empty=" + empty
                     + ", nkeys=" + keys
                     + ", size=" + size
                     + ", outlink=" + (outlink == null ? null : outlink.pageId)

--- a/herddb-utils/src/main/java/herddb/index/blink/BLinkMetadata.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLinkMetadata.java
@@ -96,8 +96,6 @@ public final class BLinkMetadata<K> {
         final long id;
         final long storeId;
 
-        final boolean empty;
-
         final int keys;
         final long bytes;
 
@@ -106,12 +104,11 @@ public final class BLinkMetadata<K> {
 
         final K rightsep;
 
-        public BLinkNodeMetadata(boolean leaf, long id, long storeId, boolean empty, int keys, long size, long outlink, long rightlink, K rightsep) {
+        public BLinkNodeMetadata(boolean leaf, long id, long storeId, int keys, long size, long outlink, long rightlink, K rightsep) {
             super();
             this.leaf = leaf;
             this.id = id;
             this.storeId = storeId;
-            this.empty = empty;
             this.keys = keys;
             this.bytes = size;
             this.outlink = outlink;
@@ -124,7 +121,6 @@ public final class BLinkMetadata<K> {
             return "BLinkNodeMetadata [leaf=" + leaf +
                     ", id=" + id +
                     ", storeId=" + storeId +
-                    ", empty=" + empty +
                     ", keys=" + keys +
                     ", size=" + bytes +
                     ", outlink=" + outlink +

--- a/herddb-utils/src/test/java/herddb/index/blink/BLinkTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/BLinkTest.java
@@ -42,7 +42,6 @@ import herddb.core.RandomPageReplacementPolicy;
 import herddb.index.blink.BLink.SizeEvaluator;
 import herddb.index.blink.BLinkMetadata.BLinkNodeMetadata;
 import herddb.utils.Holder;
-import herddb.utils.SizeAwareObject;
 import herddb.utils.Sized;
 
 /**
@@ -52,7 +51,7 @@ import herddb.utils.Sized;
  */
 public class BLinkTest {
 
-    static final class DummyBLinkIndexDataStorage<K extends Comparable<K> & SizeAwareObject, V> implements BLinkIndexDataStorage<K, V> {
+    static final class DummyBLinkIndexDataStorage<K extends Comparable<K>, V> implements BLinkIndexDataStorage<K, V> {
 
         AtomicLong newPageId = new AtomicLong();
         AtomicLong swapIn = new AtomicLong();
@@ -224,7 +223,6 @@ public class BLinkTest {
                     node.leaf,
                     node.id,
                     node.storeId,
-                    node.empty,
                     node.keys,
                     BLink.UNKNOWN_SIZE,
                     node.outlink,

--- a/herddb-utils/src/test/java/herddb/index/blink/ConcurrentCheckpointBLinkTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/ConcurrentCheckpointBLinkTest.java
@@ -1,0 +1,640 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.index.blink;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.StampedLock;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import herddb.core.ClockProPolicy;
+import herddb.index.blink.BLink.SizeEvaluator;
+
+/**
+ * Tests on concurcurrent checkpoint
+ */
+public class ConcurrentCheckpointBLinkTest {
+
+    static final class LongSizeEvaluator implements SizeEvaluator<Long, Long> {
+
+        public static final SizeEvaluator<Long, Long> INSTANCE = new LongSizeEvaluator();
+
+        @Override
+        public long evaluateKey(Long key) {
+            return Long.BYTES;
+        }
+
+        @Override
+        public long evaluateValue(Long value) {
+            return Long.BYTES;
+        }
+
+        @Override
+        public long evaluateAll(Long key, Long value) {
+            return evaluateKey(key) + evaluateValue(value);
+        }
+
+        private static final Long INFINITY = Long.valueOf(Long.MAX_VALUE);
+
+        @Override
+        public Long getPosiviveInfinityKey() {
+            return INFINITY;
+        }
+
+    }
+
+    private static final class Reporter {
+
+        private final long intervalMS;
+
+        private long start = -1L;
+        private long nextReport = -1L;
+
+        public Reporter(long interval, TimeUnit unit) {
+            super();
+            this.intervalMS = unit.toMillis(interval);
+        }
+
+        public void start() {
+            start = System.currentTimeMillis();
+            nextReport = start + intervalMS;
+        }
+
+        public Timings report() {
+
+            long now = System.currentTimeMillis();
+
+            if (now >= nextReport) {
+                long elapsed = now  - (nextReport - intervalMS);
+                nextReport = now + intervalMS;
+
+                return new Timings(now - start, elapsed);
+            }
+
+            return null;
+
+        }
+
+    }
+
+    public static final class Timings {
+
+        private final long totalTime;
+        private final long reportTime;
+
+        public Timings(long totalTime, long reportTime) {
+            super();
+            this.totalTime = totalTime;
+            this.reportTime = reportTime;
+        }
+
+        public long getTotalTime() {
+            return totalTime;
+        }
+        public long getReportTime() {
+            return reportTime;
+        }
+
+    }
+
+    /** Insert new data booking "blocks" */
+    private static final class Writer implements Callable<Long> {
+
+        private final BLink<Long, Long> blink;
+        private final boolean debug;
+        private final AtomicLong nextKeyBlock;
+        private final long keyBlocks;
+        private final long keyBlockSize;
+        private final long startKey;
+        private final BlockingQueue<Long> insertedBlocks;
+        private final StampedLock checkpointLock;
+        private final CyclicBarrier startBarrier;
+
+        private final Reporter reporter;
+
+        public Writer(BLink<Long, Long> blink, boolean debug, AtomicLong nextKeyBlock, long keyBlocks, long keyBlockSize,
+                      long startKey, BlockingQueue<Long> insertedBlocks, StampedLock checkpointLock,
+                      CyclicBarrier startBarrier) {
+            super();
+            this.blink = blink;
+            this.debug = debug;
+            this.nextKeyBlock = nextKeyBlock;
+            this.keyBlocks = keyBlocks;
+            this.keyBlockSize = keyBlockSize;
+            this.startKey = startKey;
+            this.insertedBlocks = insertedBlocks;
+            this.checkpointLock = checkpointLock;
+            this.startBarrier = startBarrier;
+            this.reporter = new Reporter(1, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public Long call() throws Exception {
+
+            /* Await other thread startup */
+            startBarrier.await(10, TimeUnit.SECONDS);
+
+            long tid = Thread.currentThread().getId();
+
+            long inserted = 0;
+            long keyBlock;
+
+            reporter.start();
+
+            try {
+                while ((keyBlock = nextKeyBlock.getAndIncrement()) < keyBlocks) {
+
+                    long startBlockKey = keyBlock * keyBlockSize + startKey;
+                    long maxBlockKey = startBlockKey + keyBlockSize;
+
+                    if (debug) {
+                        System.out.printf("[TID %3d] Write   from %3d to %3d block %3d\n", tid, startBlockKey, maxBlockKey, keyBlock);
+                    }
+
+                    for(long key = startBlockKey; key < maxBlockKey; ++key) {
+
+                        long stamp = checkpointLock.readLockInterruptibly();
+                        try {
+
+                            Long lkey = Long.valueOf(key);
+                            blink.insert(lkey, lkey);
+
+                            ++inserted;
+
+                            Timings timings = reporter.report();
+                            if (timings != null) {
+                                System.out.printf("[TID %3d] Inserted     %8d in %7d ms (%4d ms)\n", tid, inserted, timings.getTotalTime(), timings.getReportTime());
+                            }
+
+                            if (Thread.interrupted()) {
+                                throw new InterruptedException();
+                            }
+
+                        } finally {
+                            checkpointLock.unlockRead(stamp);
+                        }
+                    }
+
+                    insertedBlocks.add(keyBlock);
+
+                }
+
+            } catch (InterruptedException e) {
+
+                return inserted;
+
+            } catch (Exception e) {
+
+                /*
+                 * Fast print exception (still show the exception even if the future.get won't be invoked due to
+                 * some deadlock)
+                 */
+                e.printStackTrace();
+                throw e;
+
+            }
+
+            return inserted;
+        }
+
+    }
+
+    /** Delete data "blocks" */
+    private static final class Deleter implements Callable<Long> {
+
+        private final BLink<Long, Long> blink;
+        private final boolean debug;
+        private final AtomicLong deletingBlocks;
+        private final AtomicLong deletedBlocks;
+        private final long keyBlocks;
+        private final long keyBlockSize;
+        private final long startKey;
+        private final BlockingQueue<Long> insertedBlocks;
+        private final StampedLock checkpointLock;
+        private final CyclicBarrier startBarrier;
+
+        private final Reporter reporter;
+
+        public Deleter(BLink<Long, Long> blink, boolean debug, AtomicLong deletingBlocks, AtomicLong deletedBlocks, long keyBlocks,
+                       long keyBlockSize, long startKey, BlockingQueue<Long> insertedBlocks, StampedLock checkpointLock,
+                       CyclicBarrier startBarrier) {
+            super();
+            this.blink = blink;
+            this.debug = debug;
+            this.deletingBlocks = deletingBlocks;
+            this.deletedBlocks = deletedBlocks;
+            this.keyBlocks = keyBlocks;
+            this.keyBlockSize = keyBlockSize;
+            this.startKey = startKey;
+            this.insertedBlocks = insertedBlocks;
+            this.checkpointLock = checkpointLock;
+            this.startBarrier = startBarrier;
+            this.reporter = new Reporter(1, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public Long call() throws Exception {
+
+            /* Await other thread startup */
+            startBarrier.await(10, TimeUnit.SECONDS);
+
+            long tid = Thread.currentThread().getId();
+
+            long deleted = 0;
+
+            reporter.start();
+
+            try {
+
+                while(deletingBlocks.getAndIncrement() < keyBlocks) {
+
+                    Long keyBlock = insertedBlocks.take();
+
+                    long startBlockKey = keyBlock * keyBlockSize + startKey;
+                    long maxBlockKey = startBlockKey + keyBlockSize;
+
+                    if (debug) {
+                        System.out.printf("[TID %3d] Delete  from %3d to %3d block %3d\n", tid, startBlockKey, maxBlockKey, keyBlock);
+                    }
+
+                    for(long key = startBlockKey; key < maxBlockKey; ++key) {
+
+                        long stamp = checkpointLock.readLockInterruptibly();
+                        try {
+
+                            blink.delete(Long.valueOf(key));
+
+                            ++deleted;
+
+                            Timings timings = reporter.report();
+                            if (timings != null) {
+                                System.out.printf("[TID %3d] Deleted      %8d in %7d ms (%4d ms)\n", tid, deleted, timings.getTotalTime(), timings.getReportTime());
+                            }
+
+                            if (Thread.interrupted()) {
+                                throw new InterruptedException();
+                            }
+
+                        } finally {
+                            checkpointLock.unlockRead(stamp);
+                        }
+                    }
+
+                    deletedBlocks.incrementAndGet();
+                }
+
+            } catch (InterruptedException e) {
+
+                return deleted;
+
+            } catch (Exception e) {
+
+                /*
+                 * Fast print exception (still show the exception even if the future.get won't be invoked due to
+                 * some deadlock)
+                 */
+                e.printStackTrace();
+                throw e;
+
+            }
+
+
+            return deleted;
+        }
+
+    }
+
+    /** Read data */
+    private static final class Reader implements Callable<Long> {
+
+        private final BLink<Long, Long> blink;
+        private final boolean debug;
+        private final AtomicBoolean stop;
+        private final AtomicLong insertedBlocks;
+        private final AtomicLong deletedBlocks;
+        private final long keyBlockSize;
+        private final long startKey;
+        private final CyclicBarrier startBarrier;
+
+        private final Reporter reporter;
+
+        public Reader(BLink<Long, Long> blink, boolean debug, AtomicBoolean stop, AtomicLong insertedBlocks, AtomicLong deletedBlocks, long keyBlockSize, long startKey, CyclicBarrier startBarrier) {
+            super();
+            this.blink = blink;
+            this.debug = debug;
+            this.stop = stop;
+            this.insertedBlocks = insertedBlocks;
+            this.deletedBlocks = deletedBlocks;
+            this.keyBlockSize = keyBlockSize;
+            this.startKey = startKey;
+            this.startBarrier = startBarrier;
+            this.reporter = new Reporter(1, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public Long call() throws Exception {
+
+            /* Await other thread startup */
+            startBarrier.await(10, TimeUnit.SECONDS);
+
+            long tid = Thread.currentThread().getId();
+
+            long searches = 0;
+
+            reporter.start();
+
+            try {
+
+                while(!stop.get()) {
+
+                    long maxInsertedBlock = insertedBlocks.get();
+                    long countDeletedBlock = deletedBlocks.get();
+
+                    long endSearchKey = maxInsertedBlock * keyBlockSize + startKey;
+                    long startSearchKey = countDeletedBlock * keyBlockSize + startKey;
+
+
+                    if (endSearchKey != startSearchKey) {
+
+                        if (debug) {
+                            System.out.printf("[TID %3d] Read    from %3d to %3d max inserted block %3d deleted blocks %3d\n", tid, startSearchKey, endSearchKey, maxInsertedBlock, countDeletedBlock);
+                        }
+
+                        if (Thread.interrupted()) {
+                            throw new InterruptedException();
+                        }
+
+                        for (long key = endSearchKey - 1L; key >= startSearchKey; --key) {
+
+                            Long lkey = Long.valueOf(key);
+                            Long found = blink.search(lkey);
+
+                            if (found != null) {
+                                Assert.assertEquals(lkey, found);
+                            }
+
+                            ++searches;
+
+                            Timings timings = reporter.report();
+                            if (timings != null) {
+                                System.out.printf("[TID %3d] Read         %8d in %7d ms (%4d ms)\n", tid, searches, timings.getTotalTime(), timings.getReportTime());
+                            }
+
+                        }
+                    }
+
+                    if (Thread.interrupted()) {
+                        return searches;
+                    }
+
+                }
+
+            } catch (Exception e) {
+
+                /*
+                 * Fast print exception (still show the exception even if the future.get won't be invoked due to
+                 * some deadlock)
+                 */
+                e.printStackTrace();
+                throw e;
+
+            }
+
+            return searches;
+        }
+
+    }
+
+    /** Checkpoint BLink */
+    private static final class Checkpointer implements Callable<Long> {
+
+        private final BLink<Long, Long> blink;
+        private final boolean debug;
+        private final AtomicBoolean stop;
+        private final StampedLock checkpointLock;
+        private final CyclicBarrier startBarrier;
+
+        private final Reporter reporter;
+
+        public Checkpointer(BLink<Long, Long> blink, boolean debug, AtomicBoolean stop, StampedLock checkpointLock, CyclicBarrier startBarrier) {
+            super();
+            this.blink = blink;
+            this.debug = debug;
+            this.stop = stop;
+            this.checkpointLock = checkpointLock;
+            this.startBarrier = startBarrier;
+            this.reporter = new Reporter(1, TimeUnit.SECONDS);
+        }
+
+        @Override
+        public Long call() throws Exception {
+
+            /* Await other thread startup */
+            startBarrier.await(10, TimeUnit.SECONDS);
+
+            long tid = Thread.currentThread().getId();
+
+            long checkpoints = 0;
+            long checkStart;
+
+            reporter.start();
+
+            while(!stop.get()) {
+
+                try {
+
+                    long stamp = checkpointLock.writeLockInterruptibly();
+                    try {
+
+                        if (debug) {
+                            System.out.printf("[TID %3d] Checkpoint   %3d\n", tid, checkpoints);
+                        }
+                        checkStart = System.currentTimeMillis();
+
+                        blink.checkpoint();
+                        ++checkpoints;
+
+                        if (debug) {
+                            System.out.printf("[TID %3d] Checkpoint   %3d in %3d ms\n", tid, checkpoints, System.currentTimeMillis() - checkStart);
+                        }
+
+                        Timings timings = reporter.report();
+                        if (timings != null) {
+                            System.out.printf("[TID %3d] Checkpointed %8d in %7d ms (%4d ms)\n", tid, checkpoints, timings.getTotalTime(), timings.getReportTime());
+                        }
+
+                        if (Thread.interrupted()) {
+                            throw new InterruptedException();
+                        }
+
+                    } finally {
+                        checkpointLock.unlockWrite(stamp);
+                    }
+
+                    Thread.yield();
+
+                } catch (InterruptedException e) {
+
+                    return checkpoints;
+
+                } catch (Exception e) {
+
+                    /*
+                     * Fast print exception (still show the exception even if the future.get won't be invoked due to
+                     * some deadlock)
+                     */
+                    e.printStackTrace();
+                    throw e;
+
+                }
+            }
+
+            return checkpoints;
+        }
+
+    }
+
+    /** Execute a checkpoint on an index with many empty nodes */
+    @Test
+    public void concurrentReadWithManyEmptyNodes() throws Exception {
+
+        int concurrentReaders = 16;
+        int concurrentWriters = 2;
+        int concurrentDeleters = 4;
+
+        boolean debugCheckpointers = false;
+        boolean debugReaders = false;
+        boolean debugWriters = false;
+        boolean debugDeleters = false;
+
+        long minKey = 0;
+        long maxKey = 50000;
+
+        long blockKeySize = 100;
+
+
+        Assert.assertTrue(minKey < maxKey);
+        Assert.assertTrue(maxKey < LongSizeEvaluator.INSTANCE.getPosiviveInfinityKey());
+
+        long insertableKeys = maxKey - minKey;
+
+        /* Check that all blocks have equal size */
+        Assert.assertEquals(0, insertableKeys % blockKeySize);
+
+        long keyBlocks = insertableKeys / blockKeySize;
+
+        /* Check there are enough blocks  */
+        Assert.assertTrue(keyBlocks >= concurrentWriters);
+        Assert.assertTrue(keyBlocks >= concurrentDeleters);
+
+
+        ExecutorService executor = null;
+        BLinkTest.DummyBLinkIndexDataStorage<Long, Long> storage = new BLinkTest.DummyBLinkIndexDataStorage<>();
+        try (BLink<Long, Long> blink = new BLink<>(2048L, LongSizeEvaluator.INSTANCE, new ClockProPolicy(30), storage)) {
+
+            AtomicLong nextKeyBlock = new AtomicLong(0);
+            AtomicLong deletingKeyBlock = new AtomicLong(0);
+            AtomicLong deletedKeyBlock = new AtomicLong(0);
+            AtomicBoolean stop = new AtomicBoolean(false);
+
+            int threads = concurrentReaders + concurrentWriters + concurrentDeleters + 1 /* checkpoint */;
+
+            executor = Executors.newFixedThreadPool(threads);
+
+            StampedLock checkpointLock = new StampedLock();
+            CyclicBarrier startBarrier = new CyclicBarrier(threads + 1);
+            BlockingQueue<Long> insertedBlocks = new LinkedBlockingQueue<>();
+
+            Future<Long> checkpoint = executor.submit(new Checkpointer(blink, debugCheckpointers, stop, checkpointLock, startBarrier));
+
+            List<Future<Long>> writes = new ArrayList<>();
+            for (int i = 0; i < concurrentWriters; ++i) {
+                writes.add(executor.submit(new Writer(blink, debugWriters, nextKeyBlock, keyBlocks, blockKeySize, minKey,
+                        insertedBlocks, checkpointLock, startBarrier)));
+            }
+
+            List<Future<Long>> deletes = new ArrayList<>();
+            for (int i = 0; i < concurrentDeleters; ++i) {
+                deletes.add(executor.submit(new Deleter(blink, debugDeleters, deletingKeyBlock, deletedKeyBlock, keyBlocks,
+                        blockKeySize, minKey, insertedBlocks, checkpointLock, startBarrier)));
+            }
+
+            List<Future<Long>> reads = new ArrayList<>();
+            for (int i = 0; i < concurrentReaders; ++i) {
+                reads.add(executor.submit(
+                        new Reader(blink, debugReaders, stop, nextKeyBlock, deletedKeyBlock, blockKeySize, minKey, startBarrier)));
+            }
+
+            int nwrites = 0;
+            int ndeletes = 0;
+            int nreads = 0;
+
+            try {
+
+                /* Await other thread startup */
+                startBarrier.await(10, TimeUnit.SECONDS);
+
+                for (Future<Long> f : writes) {
+                    nwrites += f.get();
+                }
+
+                for (Future<Long> f : deletes) {
+                    ndeletes += f.get();
+                }
+
+            } finally {
+                stop.set(true);
+            }
+
+
+            for (Future<Long> f : reads) {
+                nreads += f.get();
+            }
+
+            long nckeckpoints = checkpoint.get();
+
+            System.out.println("Swapins:     " + storage.swapIn);
+            System.out.println("Inserts:     " + nwrites);
+            System.out.println("Reads:       " + nreads);
+            System.out.println("Deletes:     " + ndeletes);
+            System.out.println("Checkpoints: " + nckeckpoints);
+
+        } finally {
+
+            if (executor != null) {
+                executor.shutdownNow();
+            }
+
+        }
+
+    }
+}

--- a/herddb-utils/src/test/java/herddb/index/blink/ConcurrentCheckpointBLinkTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/ConcurrentCheckpointBLinkTest.java
@@ -537,7 +537,7 @@ public class ConcurrentCheckpointBLinkTest {
         boolean debugDeleters = false;
 
         long minKey = 0;
-        long maxKey = 50000;
+        long maxKey = 25000;
 
         long blockKeySize = 100;
 


### PR DESCRIPTION
- Improved empty pages checkpoint handling
- removed unused metadata (due to modified empty page handling)
- added mass concurrency delete, checkpoint, read test

[X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
