### PR TITLE
Handle BLink fixed size evaluation, closes #341

### DIFF
--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -326,7 +326,20 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
     private static final class SizeEvaluatorImpl implements SizeEvaluator<Bytes, Long> {
 
         /**
-         * Siongleton INSTANCE
+         * <pre>
+         * java.lang.Long object internals:
+         *  OFFSET  SIZE   TYPE DESCRIPTION                               VALUE
+         *       0    12        (object header)                           N/A
+         *      12     4        (alignment/padding gap)
+         *      16     8   long Long.value                                N/A
+         * Instance size: 24 bytes
+         * Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
+         * </pre>
+         */
+        private static final long DATA_SIZE = 24L;
+
+        /**
+         * Singleton INSTANCE
          */
         public static final SizeEvaluator<Bytes, Long> INSTANCE = new SizeEvaluatorImpl();
 
@@ -342,24 +355,23 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
         }
 
         @Override
+        public boolean isValueSizeConstant() {
+            return true;
+        }
+
+        @Override
+        public long constantValueSize() throws UnsupportedOperationException {
+            return DATA_SIZE;
+        }
+
+        @Override
         public long evaluateValue(Long value) {
-            /**
-             * <pre>
-             * java.lang.Long object internals:
-             *  OFFSET  SIZE   TYPE DESCRIPTION                               VALUE
-             *       0    12        (object header)                           N/A
-             *      12     4        (alignment/padding gap)
-             *      16     8   long Long.value                                N/A
-             * Instance size: 24 bytes
-             * Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
-             * </pre>
-             */
-            return 24L;
+            return DATA_SIZE;
         }
 
         @Override
         public long evaluateAll(Bytes key, Long value) {
-            return key.getEstimatedSize() + 24L;
+            return key.getEstimatedSize() + DATA_SIZE;
         }
 
         @Override

--- a/herddb-utils/src/test/java/herddb/index/blink/BLinkConstantSizeTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/BLinkConstantSizeTest.java
@@ -1,0 +1,119 @@
+package herddb.index.blink;
+
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import herddb.core.RandomPageReplacementPolicy;
+import herddb.index.blink.BLink.SizeEvaluator;
+import herddb.index.blink.BLinkTest.DummyBLinkIndexDataStorage;
+
+/**
+ * Tests on {@link BLink} about constant size retrieved from {@link SizeEvaluator}
+ *
+ * @author diego.salvi
+ */
+public class BLinkConstantSizeTest {
+
+    /**
+     * Dynamic sizing
+     */
+    private static class DummySizeEvaluator implements SizeEvaluator<Long,Long> {
+
+        static final long KEY_CONSTANT_SIZE = 1;
+        static final long VALUE_CONSTANT_SIZE = 1;
+
+        @Override
+        public long evaluateKey(Long key) {
+            return KEY_CONSTANT_SIZE;
+        }
+
+        @Override
+        public long evaluateValue(Long value) {
+            return VALUE_CONSTANT_SIZE;
+        }
+
+        @Override
+        public long evaluateAll(Long key, Long value) {
+            return KEY_CONSTANT_SIZE + VALUE_CONSTANT_SIZE;
+        }
+
+        private static final Long POSITIVE_INF = Long.MAX_VALUE;
+
+        @Override
+        public Long getPosiviveInfinityKey() {
+            return POSITIVE_INF;
+        }
+
+    }
+
+    /**
+     * Constant sizing
+     */
+    private static final class DummyConstantSizeEvaluator extends DummySizeEvaluator {
+
+        @Override
+        public long evaluateKey(Long key) {
+            Assert.fail("Method evaluateKey souldn't be invoked");
+            return super.evaluateKey(key);
+        }
+
+        @Override
+        public long evaluateValue(Long value) {
+            Assert.fail("Method evaluateValue souldn't be invoked");
+            return super.evaluateKey(value);
+        }
+
+        @Override
+        public boolean isKeySizeConstant() {
+            return true;
+        }
+
+        @Override
+        public long constantKeySize() {
+            return KEY_CONSTANT_SIZE;
+        }
+
+        @Override
+        public boolean isValueSizeConstant() {
+            return true;
+        }
+
+        @Override
+        public long constantValueSize() {
+            return VALUE_CONSTANT_SIZE;
+        }
+
+    }
+
+    /**
+     * Check that 2 BLink generated with 2 different but equivalent {@link SizeEvaluator}s (one enforce
+     * constant sizing the other one enforce dynamic sizing) report the same size.
+     */
+    @Test
+    public void dynamicAndConstantSizeCheck() {
+
+        long maxSize = 2048L;
+
+        Function<SizeEvaluator<Long,Long>,Long> sizeEvaluation = (evaluator) -> {
+            try (BLink<Long, Long> blink = new BLink<>(maxSize, evaluator, new RandomPageReplacementPolicy(3), new DummyBLinkIndexDataStorage<>())) {
+                long size;
+                long data = 0;
+                while ((size = blink.getUsedMemory()) < maxSize) {
+                    final Long v = Long.valueOf(data++);
+                    blink.insert(v, v);
+                }
+
+                return size;
+            }
+        };
+
+
+        long dynamicSize = sizeEvaluation.apply(new DummySizeEvaluator());
+        long constantSize = sizeEvaluation.apply(new DummyConstantSizeEvaluator());
+
+        Assert.assertEquals(dynamicSize, constantSize);
+    }
+
+}

--- a/herddb-utils/src/test/java/herddb/index/blink/ConcurrentCheckpointBLinkTest.java
+++ b/herddb-utils/src/test/java/herddb/index/blink/ConcurrentCheckpointBLinkTest.java
@@ -527,9 +527,9 @@ public class ConcurrentCheckpointBLinkTest {
     @Test
     public void concurrentReadWithManyEmptyNodes() throws Exception {
 
-        int concurrentReaders = 16;
-        int concurrentWriters = 2;
-        int concurrentDeleters = 4;
+        int concurrentReaders = 4;
+        int concurrentWriters = 1;
+        int concurrentDeleters = 2;
 
         boolean debugCheckpointers = false;
         boolean debugReaders = false;


### PR DESCRIPTION
Refine BLink sizing handling with an explicit handling when key or value are known as constant size.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
