### PR TITLE
Fix FileCommitLog max sync time configuration from 1 microsecond to 1 millisecond

### DIFF
--- a/herddb-core/src/main/java/herddb/file/FileCommitLog.java
+++ b/herddb-core/src/main/java/herddb/file/FileCommitLog.java
@@ -101,7 +101,7 @@ public class FileCommitLog extends CommitLog {
 
     private final int maxUnsyncedBatchSize;
     private final int maxUnsyncedBatchBytes;
-    private final int maxSyncTime;
+    private final long maxSyncTime;
     private final boolean requireSync;
     private final boolean enableO_DIRECT;
 
@@ -348,7 +348,7 @@ public class FileCommitLog extends CommitLog {
     ) {
         this.maxUnsyncedBatchSize = maxUnsynchedBatchSize;
         this.maxUnsyncedBatchBytes = maxUnsynchedBatchBytes;
-        this.maxSyncTime = maxSyncTime;
+        this.maxSyncTime = TimeUnit.MILLISECONDS.toNanos(maxSyncTime);
         this.requireSync = requireSync;
         this.enableO_DIRECT = enableO_DIRECT && OpenFileUtils.isO_DIRECT_Supported();
         this.onClose = onClose;
@@ -443,7 +443,7 @@ public class FileCommitLog extends CommitLog {
                 long unsyncedBytes = 0;
                 int unsyncedCount = 0;
                 while (!closed || !writeQueue.isEmpty()) {
-                    LogEntryHolderFuture entry = writeQueue.poll(maxSyncTime, TimeUnit.MICROSECONDS);
+                    LogEntryHolderFuture entry = writeQueue.poll(maxSyncTime, TimeUnit.NANOSECONDS);
                     boolean timedOut = false;
                     if (entry != null) {
                         if (entry.entry == null) {


### PR DESCRIPTION
txlog.synctimeout defaulted to 1 and in FileCommitLog was used as microseconds.

Modified to default to 1 millisecond. (Internally FileCommitLog will use nanoseconds to avoid conversions every time)

 - [ X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
