### PR TITLE
Make BookKeeper ledgers path configurable and let HerdDBEmbeddedDataSource to start in cluster mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 jobs:
   include:
   - stage: test
-    jdk: openjdk11
+    jdk: oraclejdk11
     script: mvn verify -Pjenkins -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false jacoco:report coveralls:report
 
 branches:

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
@@ -65,7 +65,8 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
         config.setThrottleValue(0);
         config.setZkServers(metadataStorageManager.getZkAddress());
         config.setZkTimeout(metadataStorageManager.getZkSessionTimeout());
-        config.setZkLedgersRootPath(metadataStorageManager.getLedgersPath());
+        config.setZkLedgersRootPath(serverConfiguration.getString(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH,
+                ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT));
         config.setEnableParallelRecoveryRead(true);
         config.setEnableDigestTypeAutodetection(true);
 

--- a/herddb-core/src/main/java/herddb/cluster/EmbeddedBookie.java
+++ b/herddb-core/src/main/java/herddb/cluster/EmbeddedBookie.java
@@ -57,7 +57,6 @@ public class EmbeddedBookie implements AutoCloseable {
 
     private BookieServer bookieServer;
 
-
     public EmbeddedBookie(Path baseDirectory, ServerConfiguration configuration, ZookeeperMetadataStorageManager metadataManager) {
         this(baseDirectory, configuration, metadataManager, null);
     }
@@ -73,7 +72,7 @@ public class EmbeddedBookie implements AutoCloseable {
         org.apache.bookkeeper.conf.ServerConfiguration conf = new org.apache.bookkeeper.conf.ServerConfiguration();
         conf.setZkTimeout(metadataManager.getZkSessionTimeout());
         conf.setZkServers(metadataManager.getZkAddress());
-        conf.setZkLedgersRootPath(metadataManager.getLedgersPath());
+        conf.setZkLedgersRootPath(configuration.getString(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH, ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT));
         conf.setStatisticsEnabled(true);
         int port = configuration.getInt(ServerConfiguration.PROPERTY_BOOKKEEPER_BOOKIE_PORT, ServerConfiguration.PROPERTY_BOOKKEEPER_BOOKIE_PORT_DEFAULT);
 
@@ -119,7 +118,7 @@ public class EmbeddedBookie implements AutoCloseable {
             }
         }
         long _start = System.currentTimeMillis();
-        LOG.severe("Booting Apache Bookkeeper on port " + port);
+        LOG.severe("Booting Apache Bookkeeper on port " + port + ",  base directory: " + bookie_dir);
 
         Files.createDirectories(bookie_dir);
         dumpBookieConfiguration(bookie_dir, conf);

--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -86,11 +86,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
 
     public int getZkSessionTimeout() {
         return zkSessionTimeout;
-    }
-
-    public String getLedgersPath() {
-        return ledgersPath;
-    }
+    }   
 
     private synchronized void restartZooKeeper() throws IOException, InterruptedException {
         ZooKeeper old = zooKeeper;

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -122,6 +122,9 @@ public final class ServerConfiguration {
 
     public static final String PROPERTY_BOOKKEEPER_BOOKIE_PORT = "server.bookkeeper.port";
     public static final int PROPERTY_BOOKKEEPER_BOOKIE_PORT_DEFAULT = 3181;
+    
+    public static final String PROPERTY_BOOKKEEPER_LEDGERS_PATH = "server.bookkeeper.ledgers.path";
+    public static final String PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT = "/ledgers";
 
     public static final String PROPERTY_BOOKKEEPER_ENSEMBLE = "server.bookkeeper.ensemble.size";
     public static final int PROPERTY_BOOKKEEPER_ENSEMBLE_DEFAULT = 1;

--- a/herddb-core/src/test/java/herddb/server/BookkeeperFailuresTest.java
+++ b/herddb-core/src/test/java/herddb/server/BookkeeperFailuresTest.java
@@ -86,7 +86,7 @@ public class BookkeeperFailuresTest {
     private BookKeeper createBookKeeper() throws Exception {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         clientConfiguration.setZkServers(testEnv.getAddress());
-        clientConfiguration.setZkLedgersRootPath(testEnv.getPath() + "/ledgers");
+        clientConfiguration.setZkLedgersRootPath(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT);
         return BookKeeper.forConfig(clientConfiguration).build();
     }
 

--- a/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
@@ -72,7 +72,7 @@ public class ZKTestEnv implements AutoCloseable {
 
         Path targetDir = path.resolve("bookie_data");
         conf.setZkServers("localhost:1282");
-        conf.setZkLedgersRootPath(getPath() + "/ledgers");
+        conf.setZkLedgersRootPath(herddb.server.ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT);
         conf.setLedgerDirNames(new String[]{targetDir.toAbsolutePath().toString()});
         conf.setJournalDirName(targetDir.toAbsolutePath().toString());
         conf.setFlushInterval(10000);

--- a/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
@@ -49,12 +49,12 @@ public class ZKTestEnv implements AutoCloseable {
             throw new Exception("bookie already started");
         }
         ServerConfiguration conf = new ServerConfiguration();
-        conf.setBookiePort(5621);
+        conf.setBookiePort(0);
         conf.setUseHostNameAsBookieID(true);
 
         Path targetDir = path.resolve("bookie_data");
         conf.setZkServers("localhost:1282");
-        conf.setZkLedgersRootPath(getPath() + "/ledgers");
+        conf.setZkLedgersRootPath("/ledgers");
         conf.setLedgerDirNames(new String[]{targetDir.toAbsolutePath().toString()});
         conf.setJournalDirName(targetDir.toAbsolutePath().toString());
         conf.setFlushInterval(10000);


### PR DESCRIPTION
- Make BookKeeper ledgers path configurable
- Separate BK zookeeper namespace from HerdDB default one
- Simplify the boot of in clustermode using HerdDBEmbeddedDataSource