### PR TITLE
Fix BLink old metadata read for Spotbugs

### DIFF
--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -583,8 +583,7 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             long storeId = cursor.readVLong();
 
             /* Boolean read, we don't need "empty" flag anymore but still exists in this version */
-            @SuppressWarnings("unused")
-            boolean empty = cursor.readBoolean();
+            cursor.readBoolean();
 
             int keys = cursor.readVInt();
             long bytes = cursor.readVLong();


### PR DESCRIPTION
Fix a Spotbugs false positive on node metadata read for olter metadata versions. A boolean flag isn't anymore used but still is in such metadata format and must be read but then it shouldn't be used


 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
