### PR TITLE
Use LongPoll for tailing read on BookKeeper

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -538,7 +538,9 @@ public class BookkeeperCommitLog extends CommitLog {
 
                 if (currentLedger.isClosed() && currentLedger.getLastAddConfirmed()
                         == nextEntryToRead - 1) {
-                    LOGGER.info(tableSpaceDescription() + " ledger " + currentLedger.getId() + " is closed and we have fully read it");
+                    if (LOGGER.isLoggable(Level.FINER)) {
+                        LOGGER.finer(tableSpaceDescription() + " ledger " + currentLedger.getId() + " is closed and we have fully read it");
+                    }
                 } else {
                     if (LOGGER.isLoggable(Level.FINER)) {
                         LOGGER.finer(tableSpaceDescription() + " seekToNextLedger keep current handle " + currentLedger.getId() + " nextEntry " + nextEntryToRead);
@@ -686,7 +688,7 @@ public class BookkeeperCommitLog extends CommitLog {
         } catch (EOFException | org.apache.bookkeeper.client.api.BKException err) {
             LOGGER.log(Level.SEVERE, tableSpaceDescription() + " internal error", err);
             throw new LogNotAvailableException(err);
-        } catch (InterruptedException err) {            
+        } catch (InterruptedException err) {
             LOGGER.log(Level.SEVERE, tableSpaceDescription() + " internal error", err);
             Thread.currentThread().interrupt();
             throw new LogNotAvailableException(err);

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -943,17 +943,11 @@ public class TableSpaceManager {
         public void run() {
             try (CommitLog.FollowerContext context = log.startFollowing(actualLogSequenceNumber)) {
                 while (!isLeader() && !closed) {
-                    log.followTheLeader(actualLogSequenceNumber, new BiConsumer< LogSequenceNumber, LogEntry>() {
-                        @Override
-                        public void accept(LogSequenceNumber num, LogEntry u
-                        ) {
-                            try {
-                                apply(new CommitLogResult(num, false, true), u, false);
-                                LOGGER.info("followed "+u+" at "+num+" now ALSN "+actualLogSequenceNumber);
-                                
-                            } catch (Throwable t) {
-                                throw new RuntimeException(t);
-                            }
+                    log.followTheLeader(actualLogSequenceNumber, (LogSequenceNumber num, LogEntry u) -> {
+                        try {
+                            apply(new CommitLogResult(num, false, true), u, false);
+                        } catch (Throwable t) {
+                            throw new RuntimeException(t);
                         }
                     }, context );
                 }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -713,7 +713,7 @@ public class TableSpaceManager {
         Set<String> tablesToDo = new HashSet<>(tablesNeedingCheckPoint);
         tablesNeedingCheckPoint.clear();
         for (String table : tablesToDo) {
-            LOGGER.log(Level.SEVERE, "Forcing local checkpoint table " + this.tableSpaceName + "." + table);
+            LOGGER.log(Level.INFO, "Forcing local checkpoint table " + this.tableSpaceName + "." + table);
             AbstractTableManager tableManager = tables.get(table);
             if (tableManager != null) {
                 try {

--- a/herddb-core/src/main/java/herddb/file/FileCommitLog.java
+++ b/herddb-core/src/main/java/herddb/file/FileCommitLog.java
@@ -638,11 +638,6 @@ public class FileCommitLog extends CommitLog {
     }
 
     @Override
-    public void followTheLeader(LogSequenceNumber skipPast, BiConsumer<LogSequenceNumber, LogEntry> consumer) throws LogNotAvailableException {
-        // we are always the leader!
-    }
-
-    @Override
     public void recovery(LogSequenceNumber snapshotSequenceNumber, BiConsumer<LogSequenceNumber, LogEntry> consumer, boolean fencing) throws LogNotAvailableException {
         LOGGER.log(Level.INFO, "recovery {1}, snapshotSequenceNumber: {0}", new Object[]{snapshotSequenceNumber, tableSpaceName});
         // no lock is needed, we are at boot time

--- a/herddb-core/src/main/java/herddb/log/CommitLog.java
+++ b/herddb-core/src/main/java/herddb/log/CommitLog.java
@@ -44,7 +44,21 @@ public abstract class CommitLog implements AutoCloseable {
 
     public abstract void recovery(LogSequenceNumber snapshotSequenceNumber, BiConsumer<LogSequenceNumber, LogEntry> consumer, boolean fencing) throws LogNotAvailableException;
 
-    public abstract void followTheLeader(LogSequenceNumber skipPast, BiConsumer<LogSequenceNumber, LogEntry> consumer) throws LogNotAvailableException;
+    public static interface FollowerContext extends AutoCloseable {
+
+        @Override
+        public default void close() {
+        }
+    }
+
+    public <T extends FollowerContext> T startFollowing(LogSequenceNumber lastPosition) {
+        return null;
+    }
+
+    public void followTheLeader(LogSequenceNumber skipPast, BiConsumer<LogSequenceNumber, LogEntry> consumer,
+            FollowerContext context) throws LogNotAvailableException {
+            // useful only on cluster
+    }
 
     public abstract LogSequenceNumber getLastSequenceNumber();
 

--- a/herddb-core/src/main/java/herddb/mem/MemoryCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryCommitLogManager.java
@@ -91,10 +91,6 @@ public class MemoryCommitLogManager extends CommitLogManager {
             }
 
             @Override
-            public void followTheLeader(LogSequenceNumber skipPast, BiConsumer<LogSequenceNumber, LogEntry> consumer) throws LogNotAvailableException {
-            }
-
-            @Override
             public void startWriting() throws LogNotAvailableException {
             }
 

--- a/herddb-core/src/test/java/herddb/cluster/BackupRestoreTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/BackupRestoreTest.java
@@ -17,7 +17,7 @@
  under the License.
 
  */
-package herddb.server;
+package herddb.cluster;
 
 import static org.junit.Assert.assertEquals;
 
@@ -54,6 +54,8 @@ import herddb.model.commands.CreateTableStatement;
 import herddb.model.commands.DeleteStatement;
 import herddb.model.commands.InsertStatement;
 import herddb.model.commands.UpdateStatement;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
 import herddb.utils.Bytes;
 import herddb.utils.ZKTestEnv;
 

--- a/herddb-core/src/test/java/herddb/cluster/BookkeeperFailuresTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/BookkeeperFailuresTest.java
@@ -17,7 +17,7 @@
  under the License.
 
  */
-package herddb.server;
+package herddb.cluster;
 
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
@@ -56,6 +56,8 @@ import herddb.model.TransactionContext;
 import herddb.model.commands.CommitTransactionStatement;
 import herddb.model.commands.CreateTableStatement;
 import herddb.model.commands.InsertStatement;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
 import herddb.utils.ZKTestEnv;
 
 /**

--- a/herddb-core/src/test/java/herddb/cluster/MultiServerCreateTableSpaceWaitTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/MultiServerCreateTableSpaceWaitTest.java
@@ -17,7 +17,7 @@
  under the License.
 
  */
-package herddb.server;
+package herddb.cluster;
 
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
@@ -36,6 +36,8 @@ import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
 import herddb.model.Table;
 import herddb.model.Tuple;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
 import herddb.utils.DataAccessor;
 import herddb.utils.ZKTestEnv;
 

--- a/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
@@ -17,7 +17,7 @@
  under the License.
 
  */
-package herddb.server;
+package herddb.cluster;
 
 import herddb.cluster.BookkeeperCommitLog;
 import static org.junit.Assert.assertEquals;
@@ -37,7 +37,6 @@ import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.codec.RecordSerializer;
 import herddb.core.AbstractTableManager;
 import herddb.core.TableSpaceManager;
-import herddb.log.CommitLog;
 import herddb.log.LogSequenceNumber;
 import herddb.model.ColumnTypes;
 import herddb.model.DMLStatementExecutionResult;
@@ -54,6 +53,8 @@ import herddb.model.commands.CreateTableStatement;
 import herddb.model.commands.GetStatement;
 import herddb.model.commands.InsertStatement;
 import herddb.model.commands.ScanStatement;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import herddb.utils.ZKTestEnv;

--- a/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
@@ -17,7 +17,7 @@
  under the License.
 
  */
-package herddb.server;
+package herddb.cluster;
 
 import herddb.client.ClientConfiguration;
 import herddb.client.GetResult;
@@ -32,6 +32,8 @@ import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.TableSpace;
 import herddb.model.TransactionContext;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
 import herddb.utils.DataAccessor;
 import herddb.utils.ZKTestEnv;
 import java.util.Arrays;

--- a/herddb-core/src/test/java/herddb/cluster/TablespaceReplicasStateTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/TablespaceReplicasStateTest.java
@@ -17,7 +17,7 @@
  under the License.
 
  */
-package herddb.server;
+package herddb.cluster;
 
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
@@ -43,6 +43,8 @@ import herddb.model.TransactionContext;
 import herddb.model.Tuple;
 import herddb.model.commands.AlterTableSpaceStatement;
 import herddb.model.commands.CreateTableStatement;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
 import herddb.utils.DataAccessor;
 import herddb.utils.ZKTestEnv;
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <libs.netty4>4.1.34.Final</libs.netty4>
-        <libs.netty4ssl>2.0.23.Final</libs.netty4ssl>
+        <libs.netty4>4.1.36.Final</libs.netty4>
+        <libs.netty4ssl>2.0.25.Final</libs.netty4ssl>
         <libs.calcite>1.17.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
         <libs.jackson.mapper>1.9.11</libs.jackson.mapper>
@@ -422,12 +422,12 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.0</version>
+                        <version>2.22.2</version>
                         <configuration>                                     
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
                             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
-                            <argLine> -Xmx2G -XX:+UseG1GC -Djava.io.tmpdir=${project.build.directory}</argLine>
+                            <argLine>-Dio.netty.tryReflectionSetAccessible=true -Xmx2G -XX:+UseG1GC -Djava.io.tmpdir=${project.build.directory}</argLine>
                             <trimStackTrace>false</trimStackTrace>
                         </configuration>
                     </plugin>            

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <libs.slf4j>1.7.21</libs.slf4j>
         <libs.commonscollections>3.2.1</libs.commonscollections>        
         <libs.lz4>1.3.0</libs.lz4>
-        <libs.bookkeeper>4.9.0</libs.bookkeeper>
+        <libs.bookkeeper>4.9.1</libs.bookkeeper>
         <libs.jersey>2.26</libs.jersey>
         <libs.jcipi-annotations>1.0</libs.jcipi-annotations> 
         <libs.spotbugsannotations>3.1.8</libs.spotbugsannotations>


### PR DESCRIPTION
Since BookKeeper 4.5 there is the long-poll read feature, see https://issues.apache.org/jira/browse/BOOKKEEPER-670.

This change introduces long-pool reads and refactors the Follower.

Summary of changes:
- change CommitLog interface and introduce FollowerContext (introduce default methods for implementations that do not support 'tailing')
- move the Follower code to new BookKeeper API (LedgerHandle > ReadHandle)
- keep the current ReadHandle open, this save lots of resources on ZK (each ReadHandle is a watch,
and opening a ledger means queries on ZK and on Bookies)
- do not read continuously the "actual ledgers list" from ZK
- use Long-Poll reads of BookKeeper
- clean up logger usage
- move tests related to replication to a better package name
- upgrade to Netty latest and greatest
- upgrade BookKeeper to 4.9.1

This is only the first patch in the set.
The next patch will focus on using less threads on the Follower in order to be able to "follow" more and more tablespaces with the same resources.

After this patch I can see real improvements on the memory usage of both the bookies and the followers. There is less garbage in general and fewer ZK calls.