### PR TITLE
Upgrade to BookKeeper 4.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <libs.slf4j>1.7.21</libs.slf4j>
         <libs.commonscollections>3.2.1</libs.commonscollections>        
         <libs.lz4>1.3.0</libs.lz4>
-        <libs.bookkeeper>4.9.1</libs.bookkeeper>
+        <libs.bookkeeper>4.9.2</libs.bookkeeper>
         <libs.jersey>2.26</libs.jersey>
         <libs.jcipi-annotations>1.0</libs.jcipi-annotations> 
         <libs.spotbugsannotations>3.1.8</libs.spotbugsannotations>


### PR DESCRIPTION
Upgrade to BookKeeper 4.9.2, that comes with important fixes around Long-Poll
https://github.com/apache/bookkeeper/issues?q=label%3Arelease%2F4.9.2

