### PR TITLE
Read/Write to ZooKeeper in CLI cluster management commands

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -141,14 +141,19 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
 
     @Override
     @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED")
-    public synchronized void start() throws MetadataStorageManagerException {
+    public void start() throws MetadataStorageManagerException {
+        start(true);
+    }
+    public synchronized void start(boolean formatIfNeeded) throws MetadataStorageManagerException {   
         if (started) {
             return;
         }
         LOGGER.log(Level.SEVERE, "start, zkAddress " + zkAddress + ", zkSessionTimeout:" + zkSessionTimeout + ", basePath:" + basePath);
         try {
             restartZooKeeper();
-            ensureRoot();
+            if (formatIfNeeded) {
+                ensureRoot();
+            }
             started = true;
         } catch (IOException | InterruptedException | KeeperException err) {
             throw new MetadataStorageManagerException(err);


### PR DESCRIPTION
With this change the CLI will read and write direclty to/from ZooKeeper, this way the operator can manage the cluster without having the need of an up and running server in the cluster.