### PR TITLE
Use Context Class Loader for default serializer

### DIFF
--- a/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
+++ b/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
@@ -34,6 +34,7 @@ import herddb.model.commands.CreateTableStatement;
 import herddb.network.ServerHostData;
 import herddb.server.ServerConfiguration;
 import herddb.utils.Bytes;
+import herddb.utils.ContextClassLoaderAwareObjectInputStream;
 import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -76,7 +77,7 @@ public final class CollectionsManager implements AutoCloseable {
         public Object deserialize(Bytes bytes) throws Exception {
             SimpleByteArrayInputStream oo = new SimpleByteArrayInputStream(bytes.getBuffer(), bytes.getOffset(),
                     bytes.getLength());
-            try (ObjectInputStream ooo = new ObjectInputStream(oo)) {
+            try (ObjectInputStream ooo = new ContextClassLoaderAwareObjectInputStream(oo)) {
                 return ooo.readUnshared();
             }
         }
@@ -123,15 +124,15 @@ public final class CollectionsManager implements AutoCloseable {
         // here we are not using network or async commit logs....
         // so it is better to perform every operation on the same thread
         configuration.set(ServerConfiguration.PROPERTY_ASYNC_WORKER_THREADS, -1);
-        
+
         // no SQL planner
-        configuration.set(ServerConfiguration.PROPERTY_PLANNER_TYPE, ServerConfiguration.PLANNER_TYPE_NONE);        
-        
+        configuration.set(ServerConfiguration.PROPERTY_PLANNER_TYPE, ServerConfiguration.PLANNER_TYPE_NONE);
+
         // disable JMX, not useful in this case
         configuration.set(ServerConfiguration.PROPERTY_JMX_ENABLE, false);
-        
+
         if (additionalConfiguration != null) {
-            additionalConfiguration.forEach((k,v)-> {
+            additionalConfiguration.forEach((k, v) -> {
                 configuration.set(k.toString(), v);
             });
         }
@@ -194,7 +195,7 @@ public final class CollectionsManager implements AutoCloseable {
             this.configuration = configuration;
             return this;
         }
-        
+
         /**
          * Max memory to use. This is an upper bound to the amount of memory directly referenced by the
          * CollectionsManager. The system will automatically swap to disk data in order to respect this limit.

--- a/herddb-utils/src/main/java/herddb/utils/ContextClassLoaderAwareObjectInputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/ContextClassLoaderAwareObjectInputStream.java
@@ -1,0 +1,48 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+/**
+ * Specialized ObjectInputStream that looks for class definitions first from the ContextClassLoader. The default
+ * beheaviour of ObjectInputStream is weird, it uses something like jdk.internal.misc.VM.latestUserDefinedLoader().
+ */
+public final class ContextClassLoaderAwareObjectInputStream extends ObjectInputStream {
+
+    public ContextClassLoaderAwareObjectInputStream(InputStream in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc)
+            throws IOException, ClassNotFoundException {
+        try {
+            return Class.forName(desc.getName(), false,
+                    Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException ex) {
+            return super.resolveClass(desc);
+        }
+
+    }
+}


### PR DESCRIPTION
By default ObjectInputStream does not take into consideration the Thread Context Class Loader and this may lead to unespected beheaviour in clients of the Collections Framework.
With this change the default value deserializer will use the  Thread Context Class Loader