### PR TITLE
Add automatic retry when leader is not reachable

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -65,6 +65,12 @@ public class ClientConfiguration {
     
     public static final String PROPERTY_MAX_CONNECTIONS_PER_SERVER = "client.maxconnections.perserver";
     public static final int PROPERTY_MAX_CONNECTIONS_PER_SERVER_DEFAULT = 10;
+    
+    public static final String PROPERTY_MAX_OPERATION_RETRY_COUNT = "client.max.operation.retry.count";
+    public static final int PROPERTY_MAX_OPERATION_RETRY_COUNT_DEFAULT = 100;
+    
+    public static final String PROPERTY_OPERATION_RETRY_DELAY = "client.operation.retry.delay";
+    public static final int PROPERTY_OPERATION_RETRY_DELAY_DEFAULT = 1000;
 
     public static final String PROPERTY_ZOOKEEPER_ADDRESS = "client.zookeeper.address";
     public static final String PROPERTY_ZOOKEEPER_SESSIONTIMEOUT = "client.zookeeper.session.timeout";

--- a/herddb-core/src/main/java/herddb/client/impl/RetryRequestException.java
+++ b/herddb-core/src/main/java/herddb/client/impl/RetryRequestException.java
@@ -40,4 +40,8 @@ public class RetryRequestException extends HDBException {
         super(message, cause);
     }
 
+    public boolean isRequireMetadataRefresh() {
+        return false;
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/client/impl/UnreachableServerException.java
+++ b/herddb-core/src/main/java/herddb/client/impl/UnreachableServerException.java
@@ -20,21 +20,21 @@
 package herddb.client.impl;
 
 /**
- * a retry is needed. for instance in case of leadership change
+ * a retry is needed. the server is down, maybe this is a simple restart
  *
  * @author enrico.olivelli
  */
-public class LeaderChangedException extends RetryRequestException {
+public class UnreachableServerException extends RetryRequestException {
 
-    public LeaderChangedException(String message) {
+    public UnreachableServerException(String message) {
         super(message);
     }
 
-    public LeaderChangedException(Throwable cause) {
+    public UnreachableServerException(Throwable cause) {
         super(cause);
     }
 
-    public LeaderChangedException(String message, Throwable cause) {
+    public UnreachableServerException(String message, Throwable cause) {
         super(message, cause);
     }
 

--- a/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
@@ -27,7 +27,9 @@ import herddb.client.ScanResultSet;
 import herddb.core.DBManager;
 import herddb.core.TableSpaceManager;
 import herddb.core.TestUtils;
+
 import static herddb.core.TestUtils.scan;
+
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.TableSpace;
@@ -42,8 +44,11 @@ import java.util.List;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.test.TestStatsProvider;
 import org.junit.After;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -100,7 +105,9 @@ public class RetryOnLeaderChangedTest {
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
 
-                TestUtils.execute(server_1.getManager(), "CREATE TABLESPACE 'ttt','leader:" + server_2.getNodeId() + "','expectedreplicacount:2'", Collections.emptyList());
+                TestUtils.execute(server_1.getManager(),
+                        "CREATE TABLESPACE 'ttt','leader:" + server_2.getNodeId() + "','expectedreplicacount:2'",
+                        Collections.emptyList());
 
                 // wait for server_2 to wake up
                 for (int i = 0; i < 40; i++) {
@@ -114,7 +121,7 @@ public class RetryOnLeaderChangedTest {
                 assertTrue(server_2.getManager().getTableSpaceManager("ttt") != null
                         && server_2.getManager().getTableSpaceManager("ttt").isLeader());
 
-                // wait for server_1 to announce as follower                
+                // wait for server_1 to announce as follower
                 waitClusterStatus(server_1.getManager(), server_1.getNodeId(), "follower");
 
                 ClientConfiguration clientConfiguration = new ClientConfiguration();
@@ -128,13 +135,18 @@ public class RetryOnLeaderChangedTest {
                     try (HDBConnection connection = client1.openConnection();) {
 
                         // create table and insert data
-                        connection.executeUpdate(TableSpace.DEFAULT, "CREATE TABLE ttt.t1(k1 int primary key, n1 int)", TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
-                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(1,1)", TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
-                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(2,1)", TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
-                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(3,1)", TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "CREATE TABLE ttt.t1(k1 int primary key, n1 int)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(1,1)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(2,1)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(3,1)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
 
                         // use client2, so that it opens a connection to current leader
-                        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1", false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0);) {
+                        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1",
+                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0);) {
                             assertEquals(3, scan.consume().size());
                         }
 
@@ -142,7 +154,8 @@ public class RetryOnLeaderChangedTest {
                         switchLeader(server_1.getNodeId(), server_2.getNodeId(), server_1.getManager());
 
                         // perform operation
-                        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1", false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0);) {
+                        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1",
+                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0);) {
                             assertEquals(3, scan.consume().size());
                         }
                         // check the client handled "not leader error"
@@ -152,7 +165,8 @@ public class RetryOnLeaderChangedTest {
                         switchLeader(server_2.getNodeId(), server_1.getNodeId(), server_1.getManager());
 
                         // perform operation
-                        GetResult get = connection.executeGet(TableSpace.DEFAULT, "SELECT * FROM ttt.t1 where k1=1", TransactionContext.NOTRANSACTION_ID, false, Collections.emptyList());
+                        GetResult get = connection.executeGet(TableSpace.DEFAULT, "SELECT * FROM ttt.t1 where k1=1",
+                                TransactionContext.NOTRANSACTION_ID, false, Collections.emptyList());
                         assertTrue(get.isFound());
 
                         // check the client handled "not leader error"
@@ -163,7 +177,8 @@ public class RetryOnLeaderChangedTest {
 
                         // perform operation
                         assertEquals(1,
-                                connection.executeUpdate(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1", TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList()).updateCount);
+                                connection.executeUpdate(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1",
+                                        TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList()).updateCount);
 
                         // check the client handled "not leader error"
                         assertEquals(3, logger.scope("hdbclient").getCounter("leaderChangedErrors").get().intValue());
@@ -173,7 +188,9 @@ public class RetryOnLeaderChangedTest {
 
                         // perform operation
                         assertEquals(1,
-                                connection.executeUpdateAsync(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1", TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList()).get().updateCount);
+                                connection.executeUpdateAsync(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1",
+                                        TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList()).
+                                        get().updateCount);
 
                         // check the client handled "not leader error"
                         assertEquals(4, logger.scope("hdbclient").getCounter("leaderChangedErrors").get().intValue());
@@ -183,7 +200,9 @@ public class RetryOnLeaderChangedTest {
 
                         // perform operation
                         assertEquals(1,
-                                connection.executeUpdates(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1", TransactionContext.NOTRANSACTION_ID, false, false, Arrays.asList(Collections.emptyList())).get(0).updateCount);
+                                connection.executeUpdates(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1",
+                                        TransactionContext.NOTRANSACTION_ID, false, false, Arrays.asList(Collections.
+                                                emptyList())).get(0).updateCount);
 
                         // check the client handled "not leader error"
                         assertEquals(5, logger.scope("hdbclient").getCounter("leaderChangedErrors").get().intValue());
@@ -193,10 +212,168 @@ public class RetryOnLeaderChangedTest {
 
                         // perform operation
                         assertEquals(1,
-                                connection.executeUpdatesAsync(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1", TransactionContext.NOTRANSACTION_ID, false, false, Arrays.asList(Collections.emptyList())).get().get(0).updateCount);
+                                connection.executeUpdatesAsync(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=3 where k1=1",
+                                        TransactionContext.NOTRANSACTION_ID, false, false, Arrays.asList(Collections.
+                                                emptyList())).get().get(0).updateCount);
 
                         // check the client handled "not leader error"
                         assertEquals(6, logger.scope("hdbclient").getCounter("leaderChangedErrors").get().intValue());
+
+                    }
+
+                }
+
+            }
+
+        }
+    }
+
+    @Test
+    public void testKillLeaderDuringScan() throws Exception {
+        testKillLeader((connection) -> {
+            try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT,
+                    "SELECT * FROM ttt.t1", false, Collections.emptyList(),
+                    TransactionContext.NOTRANSACTION_ID, 0, 0);) {
+                assertEquals(3, scan.consume().size());
+            } catch (Exception err) {
+                throw new RuntimeException(err);
+            }
+        });
+    }
+    
+    @Test
+    public void testKillLeaderDuringUpdate() throws Exception {
+        testKillLeader((connection) -> {
+
+            try {
+                connection.executeUpdate(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=2",
+                        TransactionContext.NOTRANSACTION_ID, false, true, Collections.emptyList());
+            } catch (Exception err) {
+                throw new RuntimeException(err);
+            }
+        });
+    }
+    
+     @Test
+    public void testKillLeaderDuringUpdates() throws Exception {
+        testKillLeader((connection) -> {
+
+            try {
+                connection.executeUpdates(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=2",
+                        TransactionContext.NOTRANSACTION_ID, false, true, Arrays.asList(Collections.emptyList())).get(0);
+            } catch (Exception err) {
+                throw new RuntimeException(err);
+            }
+        });
+    }
+
+    @Test
+    public void testKillLeaderDuringAsyncUpdate() throws Exception {
+        testKillLeader((connection) -> {
+
+            try {
+                connection.executeUpdateAsync(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=2",
+                        TransactionContext.NOTRANSACTION_ID, false, true, Collections.emptyList()).get();
+            } catch (Exception err) {
+                throw new RuntimeException(err);
+            }
+        });
+    }
+
+    @Test
+    public void testKillLeaderDuringAsyncUpdates() throws Exception {
+        testKillLeader((connection) -> {
+
+            try {
+                connection.executeUpdatesAsync(TableSpace.DEFAULT, "UPDATE ttt.t1 set n1=2",
+                        TransactionContext.NOTRANSACTION_ID, false, true, Arrays.asList(Collections.emptyList()))
+                        .get().get(0);
+            } catch (Exception err) {
+                throw new RuntimeException(err);
+            }
+        });
+    }
+
+    private void testKillLeader(Consumer<HDBConnection> operation) throws Exception {
+
+        TestStatsProvider statsProvider = new TestStatsProvider();
+
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+                .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
+                .set(ServerConfiguration.PROPERTY_PORT, 7868);
+
+        try (Server server_1 = new Server(serverconfig_1)) {
+            server_1.start();
+            server_1.waitForStandaloneBoot();
+
+            try (Server server_2 = new Server(serverconfig_2)) {
+                server_2.start();
+
+                TestUtils.execute(server_1.getManager(),
+                        "CREATE TABLESPACE 'ttt','leader:" + server_2.getNodeId() + "','expectedreplicacount:2'",
+                        Collections.emptyList());
+
+                // wait for server_2 to wake up
+                for (int i = 0; i < 40; i++) {
+                    TableSpaceManager tableSpaceManager2 = server_2.getManager().getTableSpaceManager("ttt");
+                    if (tableSpaceManager2 != null
+                            && tableSpaceManager2.isLeader()) {
+                        break;
+                    }
+                    Thread.sleep(500);
+                }
+                assertTrue(server_2.getManager().getTableSpaceManager("ttt") != null
+                        && server_2.getManager().getTableSpaceManager("ttt").isLeader());
+
+                // wait for server_1 to announce as follower
+                waitClusterStatus(server_1.getManager(), server_1.getNodeId(), "follower");
+
+                ClientConfiguration clientConfiguration = new ClientConfiguration();
+                clientConfiguration.set(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_CLUSTER);
+                clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+                clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+                clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+                clientConfiguration.set(ClientConfiguration.PROPERTY_MAX_OPERATION_RETRY_COUNT, 1000);
+
+                StatsLogger logger = statsProvider.getStatsLogger("ds");
+                try (HDBClient client1 = new HDBClient(clientConfiguration, logger);) {
+                    try (HDBConnection connection = client1.openConnection();) {
+
+                        // create table and insert data
+                        connection.executeUpdate(TableSpace.DEFAULT, "CREATE TABLE ttt.t1(k1 int primary key, n1 int)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(1,1)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(2,1)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(3,1)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+
+                        // use client2, so that it opens a connection to current leader
+                        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1",
+                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0);) {
+                            assertEquals(3, scan.consume().size());
+                        }
+
+                        // change leader
+                        switchLeader(server_1.getNodeId(), null, server_1.getManager());
+
+                        // make server_2 (current leader) die
+                        server_2.close();
+
+                        // perform operation, it will eventually succeed, because
+                        // the client will automatically wait for the new leader to be up
+                        operation.accept(connection);
 
                     }
 
@@ -213,12 +390,18 @@ public class RetryOnLeaderChangedTest {
 
         // wait for server to announce as leader
         waitClusterStatus(matadataServer, newLeader, "leader");
-        waitClusterStatus(matadataServer, newFollower, "follower");
+        if (newFollower != null) {
+            // wait for server to announce as follower
+            waitClusterStatus(matadataServer, newFollower, "follower");
+        }
+
     }
 
     void waitClusterStatus(final DBManager matadataServer, String node, String expectedMode) throws DataScannerException, InterruptedException {
         for (int i = 0; i < 100; i++) {
-            try (DataScanner scan = scan(matadataServer, "SELECT * FROM SYSTABLESPACEREPLICASTATE where tablespace_name='ttt' and nodeId='" + node + "'", Collections.emptyList());) {
+            try (DataScanner scan = scan(matadataServer,
+                    "SELECT * FROM SYSTABLESPACEREPLICASTATE where tablespace_name='ttt' and nodeId='" + node + "'",
+                    Collections.emptyList());) {
                 List<DataAccessor> tuples = scan.consume();
                 assertEquals(1, tuples.size());
                 if (tuples.get(0).get("mode").equals(expectedMode)) {
@@ -228,4 +411,5 @@ public class RetryOnLeaderChangedTest {
             Thread.sleep(1000);
         }
     }
+
 }

--- a/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
@@ -20,6 +20,7 @@
 package herddb.jdbc;
 
 import herddb.client.ClientConfiguration;
+import herddb.client.ClientSideMetadataProviderException;
 import herddb.client.HDBClient;
 import herddb.client.HDBConnection;
 import herddb.client.HDBException;
@@ -164,7 +165,7 @@ public class BasicHerdDBDataSource implements javax.sql.DataSource, AutoCloseabl
         if (waitForTableSpaceTimeout > 0 && !waitForTableSpace.isEmpty()) {
             try (HDBConnection con = client.openConnection();) {
                 con.waitForTableSpace(waitForTableSpace, waitForTableSpaceTimeout);
-            } catch (HDBException err) {
+            } catch (HDBException | ClientSideMetadataProviderException err) {
                 throw new SQLException(err);
             }
         }

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBDataSource.java
@@ -20,7 +20,6 @@
 package herddb.jdbc;
 
 import java.sql.SQLException;
-import java.util.logging.Logger;
 
 /**
  * Generic DataSource for connecting to a remote HerdDB cluster


### PR DESCRIPTION
Add new configuration properties for automatic retrial in case of unreachable server.

This way we can deal cleanly with a leader that crashes and the follower takes control, the client will automatically wait for the cluster to be up and running.

This won't work very well for open transactions, that are deeemed to fail, because a leadership change rollbacks every open transaction, but this is the life.