### PR TITLE
Fix wrong page assertion during checkpoint

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DataPage.java
+++ b/herddb-core/src/main/java/herddb/core/DataPage.java
@@ -19,15 +19,14 @@
  */
 package herddb.core;
 
+import herddb.model.Record;
+import herddb.utils.Bytes;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import herddb.model.Record;
-import herddb.utils.Bytes;
 
 /**
  * A page of data loaded in memory
@@ -237,8 +236,20 @@ public final class DataPage extends Page<TableManager> {
         return pageId == other.pageId;
     }
 
+    /**
+     * Page deep equality. It checks every record in the page.
+     */
+    boolean deepEquals(DataPage other) {
+        if (!equals(other)) {
+            return false;
+        }
+        return data.equals(other.data);
+    }
+
     void flushRecordsCache() {
         data.values().forEach(r -> r.clearCache());
     }
+
+
 
 }


### PR DESCRIPTION
During checkpoint and page compaction (cleanAndCompactPages) there is an erroneous assertion (leftover of older implementations when checkpoint was blocking even read only procedures) about in memory page (check that in memory page object reference doesn't change).

Changed the assertion to:
* allow concurrent page unload (removed page == null): pages can be unloaded due to page policy replacement requests (even for other tables and tablespaces)
* in case of page object reference change (removed page != old page) execute a deep page eguality to check page records: this cover a really rare case of page unload and reload during checkpoint, to be safe we will ensure that in memory data used for checkpoint match data reloaded from disk. This is an extremely improbable case so time spent in page check should be negligible.

I couldn't create and ad hoc test to check the error (it happened in a production environment) because the pattern is the next:
* get a page to _clean and compact_
* check if page is in memory
* * if page not is in memory temp load the page and do work (this branch doesn't have a page to check and cannot create the assertion check problem)
* * **if page is in memory use it to do compaction**
* **concurrently unload compacting page**
* **remove page from page replacement policy**
* page compaction ends
* attempt to unload the _rebuilt_ page
* unload fails because it wasn't in memory anymore

Concurrent page reload is even more improbable because it require a page unload due to page replacement policy and then a page load due to a concurrent get. Such unload and reload must be done between page retrieval for checkpoint and page replacement policy removal (after remove it cannot be unloaded any more by normal means)

Other additions
* added an exception message for an existing data inconsistency check
* added a log message for changed assertion check (there was only the exception)

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
