### PR TITLE
Upgrade calcite version to 1.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <libs.netty4>4.1.36.Final</libs.netty4>
         <libs.netty4ssl>2.0.25.Final</libs.netty4ssl>
-        <libs.calcite>1.17.0</libs.calcite>
+        <libs.calcite>1.19.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
         <libs.jackson.mapper>1.9.11</libs.jackson.mapper>
         <libs.zookeeper>3.5.5</libs.zookeeper>


### PR DESCRIPTION
This PR deals with upgrading herddb to use calcite 1.19. We initially tried upgrading to 1.20 but ran into lot of problems. There is an additional PR out there which consists changes needed for upgrading to 1.20. 