### PR TITLE
Clean up logs

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -556,7 +556,7 @@ public class TableSpaceManager {
             return tableManager.scan(statement, context, transaction, lockRequired, forWrite);
         } catch (StatementExecutionException error) {
             if (rollbackOnError) {
-                LOGGER.log(Level.SEVERE, tableSpaceName+" forcing rollback of implicit tx "+transactionContext.transactionId, error);
+                LOGGER.log(Level.FINE, tableSpaceName + " forcing rollback of implicit tx "+transactionContext.transactionId, error);
                 try {
                     rollbackTransaction(new RollbackTransactionStatement(tableSpaceName, transactionContext.transactionId), context).get();
                 } catch (ExecutionException err) {
@@ -1064,7 +1064,7 @@ public class TableSpaceManager {
                 }
                 long txId = capturedTx.get();
                 if (error != null && txId > 0) {
-                    LOGGER.log(Level.SEVERE, tableSpaceName+" force rollback of implicit transaction "+txId, error);
+                    LOGGER.log(Level.FINE, tableSpaceName + " force rollback of implicit transaction "+txId, error);
                     try {
                         rollbackTransaction(new RollbackTransactionStatement(tableSpaceName, txId), context)
                                 .get(); // block until rollback is complete
@@ -1140,8 +1140,8 @@ public class TableSpaceManager {
             long txId = transactionContext.transactionId;
             if (txId > 0) {
                 res = res.whenComplete((xx, error) -> {
-                    LOGGER.log(Level.SEVERE, tableSpaceName+" force rollback of implicit transaction "+txId, error);
                     if (error != null) {
+                        LOGGER.log(Level.FINE, tableSpaceName + " force rollback of implicit transaction "+txId, error);
                         try {
                             rollbackTransaction(new RollbackTransactionStatement(tableSpaceName, txId), context)
                                     .get(); // block until operation completes

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -412,8 +412,8 @@ public class CalcitePlanner implements AbstractSQLPlanner {
                 return result;
             }
             long delta = System.currentTimeMillis() - startTs;
-            LOG.log(Level.INFO, "schema " + defaultTableSpace + " not available yet, after waiting "
-                    + delta + "/" + WAIT_FOR_SCHEMA_UP_TIMEOUT + " ms");
+            LOG.log(Level.FINE, "schema {0} not available yet, after waiting {1}/{2} ms",
+                    new Object[]{defaultTableSpace, delta, WAIT_FOR_SCHEMA_UP_TIMEOUT});
             if (delta >= WAIT_FOR_SCHEMA_UP_TIMEOUT) {
                 return null;
             }
@@ -481,12 +481,8 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             SqlParseException, ValidationException, MetadataStorageManagerException {
         SchemaPlus subSchema = getSchemaForTableSpace(defaultTableSpace);
         if (subSchema == null) {
-            TableSpaceManager tableSpaceManager = manager.getTableSpaceManager(defaultTableSpace);
             clearCache();
-            throw new StatementExecutionException("internal error,"
-                    + "Calcite subSchema for " + defaultTableSpace + " is null,"
-                    + "tableSpaceManager is " + tableSpaceManager + ","
-                    + "maybe table space " + defaultTableSpace + " is not yet started on this node");
+            throw new StatementExecutionException("tablespace " + defaultTableSpace + " is not available");
         }
 
         final FrameworkConfig config = Frameworks.newConfigBuilder()

--- a/herddb-net/src/main/java/herddb/network/Channel.java
+++ b/herddb-net/src/main/java/herddb/network/Channel.java
@@ -94,7 +94,7 @@ public abstract class Channel implements AutoCloseable {
             throw new RuntimeException(err.getCause());
         } catch (TimeoutException timeoutException) {
             long _stop = System.currentTimeMillis();
-            TimeoutException err = new TimeoutException("Timed-out after waiting response for " + (_stop - _start) + " ms");
+            TimeoutException err = new TimeoutException("Request timedout (" + ((_stop - _start)/1000) + "s). Slow server or internal error");
             err.initCause(timeoutException);
             throw err;
         }


### PR DESCRIPTION
- Remove bad log line introduced in 0.11.5
- Make Calcite planner error more understandable (do no cite "calcite", that doesn't make sense for the users)
- Make "Timeout error" more understandable, it usually means that the server it broken, so the user must check server side logs