### PR TITLE
Count activities on transactions and wait for every activity to complete before starting a rollback or commit

### DIFF
--- a/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
+++ b/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
@@ -21,7 +21,7 @@ package herddb.core;
 
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
-import herddb.model.Tuple;
+import herddb.model.Transaction;
 import herddb.utils.DataAccessor;
 import java.util.Iterator;
 
@@ -37,16 +37,23 @@ public class SimpleDataScanner extends DataScanner {
     private DataAccessor next;
     private boolean finished;
 
-    public SimpleDataScanner(long transactionId, MaterializedRecordSet recordSet) {
-        super(transactionId, recordSet.fieldNames, recordSet.columns);
+    public SimpleDataScanner(Transaction transaction, MaterializedRecordSet recordSet) {
+        super(transaction, recordSet.fieldNames, recordSet.columns);
         this.recordSet = recordSet;
         this.iterator = this.recordSet.iterator();
+        if (transaction != null) {
+            transaction.increaseRefcount();
+        }
     }
 
     @Override
     public void close() throws DataScannerException {
         finished = true;
-        recordSet.close();
+        try {
+            recordSet.close();
+        } finally {
+            super.close();
+        }
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/core/StreamDataScanner.java
+++ b/herddb-core/src/main/java/herddb/core/StreamDataScanner.java
@@ -22,6 +22,7 @@ package herddb.core;
 import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
+import herddb.model.Transaction;
 import herddb.utils.DataAccessor;
 import java.util.Iterator;
 import java.util.stream.Stream;
@@ -37,11 +38,14 @@ class StreamDataScanner extends DataScanner {
     private DataAccessor next;
 
     public StreamDataScanner(
-        long transactionId, String[] fieldNames, Column[] schema,
-        Stream<DataAccessor> wrapped) {
-        super(transactionId, fieldNames, schema);
+            Transaction transaction, String[] fieldNames, Column[] schema,
+            Stream<DataAccessor> wrapped) {
+        super(transaction, fieldNames, schema);
         this.wrapped = wrapped.iterator();
         fetchNext();
+        if (transaction != null) {
+            transaction.increaseRefcount();
+        }
     }
 
     @Override
@@ -66,7 +70,7 @@ class StreamDataScanner extends DataScanner {
 
     @Override
     public void close() throws DataScannerException {
-
+        super.close();
     }
 
 }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1746,11 +1746,15 @@ public class TableSpaceManager {
         if (tc == null) {
             throw new StatementExecutionException("no such transaction " + txId + " in tablespace " + tableSpaceName);
         }
+        int count = 0;
         while (tc.hasPendingActivities() && !closed) {
             LOGGER.log(Level.INFO, "Transaction {0} ({1}) has {2} pending activities",
                     new Object[]{txId, tableSpaceName, tc.getRefCount()});
             if (!ENABLE_PENDING_TRANSACTION_CHECK) {
                 break;
+            }
+            if (count++ >= 5) {
+                throw new StatementExecutionException("transaction " + txId + " in tablespace " + tableSpaceName+" has "+tc.getRefCount()+" pending activities");
             }
             try {
                 Thread.sleep(1000);

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -536,6 +536,9 @@ public class TableSpaceManager {
             }
         }
         Transaction transaction = transactions.get(transactionContext.transactionId);
+        if (transactionContext.transactionId > 0 && transaction == null) {
+            throw new StatementExecutionException("transaction " + transactionContext.transactionId + " does not exist on tablespace " + tableSpaceName);
+        }
         if (transaction != null && !transaction.tableSpace.equals(tableSpaceName)) {
             throw new StatementExecutionException("transaction " + transaction.transactionId + " is for tablespace " + transaction.tableSpace + ", not for " + tableSpaceName);
         }
@@ -556,7 +559,7 @@ public class TableSpaceManager {
             return tableManager.scan(statement, context, transaction, lockRequired, forWrite);
         } catch (StatementExecutionException error) {
             if (rollbackOnError) {
-                LOGGER.log(Level.FINE, tableSpaceName + " forcing rollback of implicit tx "+transactionContext.transactionId, error);
+                LOGGER.log(Level.FINE, tableSpaceName + " forcing rollback of implicit tx " + transactionContext.transactionId, error);
                 try {
                     rollbackTransaction(new RollbackTransactionStatement(tableSpaceName, transactionContext.transactionId), context).get();
                 } catch (ExecutionException err) {
@@ -704,7 +707,7 @@ public class TableSpaceManager {
         }
 
     }
-  
+
     void processAbandonedTransactions() {
         long now = System.currentTimeMillis();
         long timeout = dbmanager.getAbandonedTransactionsTimeout();
@@ -729,7 +732,7 @@ public class TableSpaceManager {
             }
         }
     }
-    
+
     void runLocalTableCheckPoints() {
         Set<String> tablesToDo = new HashSet<>(tablesNeedingCheckPoint);
         tablesNeedingCheckPoint.clear();
@@ -970,7 +973,7 @@ public class TableSpaceManager {
                         } catch (Throwable t) {
                             throw new RuntimeException(t);
                         }
-                    }, context );
+                    }, context);
                 }
             } catch (Throwable t) {
                 LOGGER.log(Level.SEVERE, "follower error " + tableSpaceName, t);
@@ -1064,19 +1067,19 @@ public class TableSpaceManager {
                 }
                 long txId = capturedTx.get();
                 if (error != null && txId > 0) {
-                    LOGGER.log(Level.FINE, tableSpaceName + " force rollback of implicit transaction "+txId, error);
+                    LOGGER.log(Level.FINE, tableSpaceName + " force rollback of implicit transaction " + txId, error);
                     try {
                         rollbackTransaction(new RollbackTransactionStatement(tableSpaceName, txId), context)
                                 .get(); // block until rollback is complete
                     } catch (InterruptedException ex) {
-                        LOGGER.log(Level.SEVERE, tableSpaceName+" Cannot rollback implicit tx " + txId, ex);
+                        LOGGER.log(Level.SEVERE, tableSpaceName + " Cannot rollback implicit tx " + txId, ex);
                         Thread.currentThread().interrupt();
                         error.addSuppressed(ex);
                     } catch (ExecutionException ex) {
-                        LOGGER.log(Level.SEVERE, tableSpaceName+" Cannot rollback implicit tx " + txId, ex.getCause());
+                        LOGGER.log(Level.SEVERE, tableSpaceName + " Cannot rollback implicit tx " + txId, ex.getCause());
                         error.addSuppressed(ex.getCause());
                     } catch (Throwable t) {
-                        LOGGER.log(Level.SEVERE, tableSpaceName+" Cannot rollback  implicittx " + txId, t);
+                        LOGGER.log(Level.SEVERE, tableSpaceName + " Cannot rollback  implicittx " + txId, t);
                         error.addSuppressed(t);
                     }
                 }
@@ -1102,6 +1105,7 @@ public class TableSpaceManager {
         }
         if (transaction != null) {
             transaction.touch();
+            transaction.increaseRefcount();
         }
         CompletableFuture<StatementExecutionResult> res;
         try {
@@ -1136,12 +1140,17 @@ public class TableSpaceManager {
         } catch (StatementExecutionException error) {
             res = FutureUtils.exception(error);
         }
+        if (transaction != null) {
+            res = res.whenComplete((a,b) -> {
+                transaction.decreaseRefCount();
+            });
+        }
         if (rollbackOnError) {
             long txId = transactionContext.transactionId;
             if (txId > 0) {
                 res = res.whenComplete((xx, error) -> {
                     if (error != null) {
-                        LOGGER.log(Level.FINE, tableSpaceName + " force rollback of implicit transaction "+txId, error);
+                        LOGGER.log(Level.FINE, tableSpaceName + " force rollback of implicit transaction " + txId, error);
                         try {
                             rollbackTransaction(new RollbackTransactionStatement(tableSpaceName, txId), context)
                                     .get(); // block until operation completes
@@ -1565,7 +1574,7 @@ public class TableSpaceManager {
     TableSpaceCheckpoint checkpoint(boolean full, boolean pin, boolean alreadLocked) throws DataStorageManagerException, LogNotAvailableException {
         if (virtual) {
             return null;
-        }        
+        }
 
         long _start = System.currentTimeMillis();
         LogSequenceNumber logSequenceNumber = null;
@@ -1574,7 +1583,6 @@ public class TableSpaceManager {
 
         try {
             List<PostCheckpointAction> actions = new ArrayList<>();
-
 
             long lockStamp = 0;
             if (!alreadLocked) {
@@ -1674,6 +1682,7 @@ public class TableSpaceManager {
 
     private CompletableFuture<StatementExecutionResult> rollbackTransaction(RollbackTransactionStatement statement, StatementEvaluationContext context) throws StatementExecutionException {
         long txId = statement.getTransactionId();
+        validateTransactionBeforeTxCommand(txId);
         LogEntry entry = LogEntryFactory.rollbackTransaction(txId);
         long lockStamp = context.getTableSpaceLock();
         boolean lockAcquired = false;
@@ -1682,17 +1691,13 @@ public class TableSpaceManager {
             context.setTableSpaceLock(lockStamp);
             lockAcquired = true;
         }
-        CompletableFuture<StatementExecutionResult> res;
-        Transaction tx = transactions.get(txId);
-        if (tx == null) {
-            res = FutureUtils.exception(new StatementExecutionException("no such transaction " + statement.getTransactionId()));
-        } else {
-            CommitLogResult pos = log.log(entry, true);
-            res = pos.logSequenceNumber.thenApplyAsync((lsn) -> {
-                apply(pos, entry, false);
-                return new TransactionResult(txId, TransactionResult.OutcomeType.ROLLBACK);
-            }, callbacksExecutor);
-        }
+
+        CommitLogResult pos = log.log(entry, true);
+        CompletableFuture<StatementExecutionResult> res = pos.logSequenceNumber.thenApplyAsync((lsn) -> {
+            apply(pos, entry, false);
+            return new TransactionResult(txId, TransactionResult.OutcomeType.ROLLBACK);
+        }, callbacksExecutor);
+
         if (lockAcquired) {
             res = releaseReadLock(res, lockStamp, statement)
                     .thenApply(s -> {
@@ -1705,6 +1710,8 @@ public class TableSpaceManager {
 
     private CompletableFuture<StatementExecutionResult> commitTransaction(CommitTransactionStatement statement, StatementEvaluationContext context) throws StatementExecutionException {
         long txId = statement.getTransactionId();
+
+        validateTransactionBeforeTxCommand(txId);
         LogEntry entry = LogEntryFactory.commitTransaction(txId);
         long lockStamp = context.getTableSpaceLock();
         boolean lockAcquired = false;
@@ -1728,6 +1735,27 @@ public class TableSpaceManager {
         return res;
     }
 
+    private void validateTransactionBeforeTxCommand(long txId) throws StatementExecutionException {
+        Transaction tc = transactions.get(txId);
+        if (tc == null) {
+            throw new StatementExecutionException("no such transaction " + txId + " in tablespace " + tableSpaceName);
+        }
+        while (tc.hasPendingActivities() && !closed) {
+            LOGGER.log(Level.INFO, "Transaction {0} ({1}) has {2} pending activities",
+                    new Object[]{txId, tableSpaceName, tc.getRefCount()});
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new StatementExecutionException("Error while waiting for pending actities of transaction " + txId + " in " + tableSpaceName,
+                        ex);
+            }
+        }
+        if (closed) {
+            throw new StatementExecutionException("tablespace closed during commit of transaction " + txId + " in tablespace " + tableSpaceName);
+        }
+    }
+
     private CompletableFuture<StatementExecutionResult> releaseReadLock(
             CompletableFuture<StatementExecutionResult> promise, long lockStamp, Object description) {
         return promise.whenComplete((r, error) -> {
@@ -1747,7 +1775,10 @@ public class TableSpaceManager {
         return leader;
     }
 
-    Transaction getTransaction(long transactionId) {
+    public Transaction getTransaction(long transactionId) {
+        if (transactionId <= 0) {
+            return null;
+        }
         return transactions.get(transactionId);
     }
 

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1753,9 +1753,6 @@ public class TableSpaceManager {
             if (!ENABLE_PENDING_TRANSACTION_CHECK) {
                 break;
             }
-            if (count++ >= 5) {
-                throw new StatementExecutionException("transaction " + txId + " in tablespace " + tableSpaceName+" has "+tc.getRefCount()+" pending activities");
-            }
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException ex) {

--- a/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
@@ -256,7 +256,7 @@ public abstract class AbstractSystemTableManager implements AbstractTableManager
         recordSet.sort(statement.getComparator());
         recordSet.applyLimits(statement.getLimits(), context);
         recordSet.applyProjection(statement.getProjection(), context);
-        return new SimpleDataScanner(transaction != null ? transaction.transactionId : 0, recordSet);
+        return new SimpleDataScanner(transaction, recordSet);
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/DataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/DataScanner.java
@@ -39,13 +39,16 @@ public abstract class DataScanner implements AutoCloseable {
 
     private final Column[] schema;
     private final String[] fieldNames;
-    public long transactionId;
+    public Transaction transaction; // no final
 
-    public DataScanner(long transactionId, String[] fieldNames, Column[] schema) {
+    public DataScanner(Transaction transaction, String[] fieldNames, Column[] schema) {
         this.schema = schema;
-        this.transactionId = transactionId;
+        this.transaction = transaction;
         this.fieldNames = fieldNames != null ? fieldNames : Column.buildFieldNamesList(schema);
+    }
 
+    public Transaction getTransaction() {
+        return transaction;
     }
 
     public String[] getFieldNames() {
@@ -53,7 +56,7 @@ public abstract class DataScanner implements AutoCloseable {
     }
 
     public long getTransactionId() {
-        return transactionId;
+        return transaction != null ? transaction.transactionId : 0;
     }
 
     public Column[] getSchema() {
@@ -78,6 +81,9 @@ public abstract class DataScanner implements AutoCloseable {
 
     @Override
     public void close() throws DataScannerException {
+        if (transaction != null) {
+            transaction.decreaseRefCount();
+        }
     }
 
     /**

--- a/herddb-core/src/main/java/herddb/model/DataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/DataScanner.java
@@ -96,6 +96,12 @@ public abstract class DataScanner implements AutoCloseable {
         forEach(records::add);
         return records;
     }
+    
+    public List<DataAccessor> consumeAndClose() throws DataScannerException {
+         List<DataAccessor> res = consume();
+         close();
+         return res;
+    }
 
     public List<DataAccessor> consume(int fetchSize) throws DataScannerException {
         List<DataAccessor> records = new ArrayList<>();

--- a/herddb-core/src/main/java/herddb/model/ExecutionPlan.java
+++ b/herddb-core/src/main/java/herddb/model/ExecutionPlan.java
@@ -32,30 +32,22 @@ public class ExecutionPlan {
     private final static AtomicLong ID = new AtomicLong();
     private final long id = ID.incrementAndGet();
     public final Statement mainStatement;
-    public final Aggregator mainAggregator;
-    public final ScanLimits limits;
-    public final TupleComparator comparator;
     // this is actually only for tests and debug
     public final PlannerOp originalRoot;
 
     private ExecutionPlan(Statement mainStatement,
-            Aggregator mainAggregator,
-            ScanLimits limits,
-            TupleComparator comparator,
             PlannerOp originalRoot) {
         this.mainStatement = mainStatement;
-        this.mainAggregator = mainAggregator;
-        this.limits = limits;
-        this.comparator = comparator;
+      
         this.originalRoot = originalRoot;
     }
 
     public static ExecutionPlan simple(Statement statement) {
-        return new ExecutionPlan(statement, null, null, null, null);
+        return new ExecutionPlan(statement,  null);
     }
 
     public static ExecutionPlan simple(Statement statement, PlannerOp root) {
-        return new ExecutionPlan(statement, null, null, null, root);
+        return new ExecutionPlan(statement,  root);
     }
 
     public void validateContext(StatementEvaluationContext context) throws StatementExecutionException {

--- a/herddb-core/src/main/java/herddb/model/LimitedDataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/LimitedDataScanner.java
@@ -36,7 +36,7 @@ public class LimitedDataScanner extends DataScanner {
     }
 
     public LimitedDataScanner(DataScanner wrapped, int maxRows, int offset, StatementEvaluationContext context) throws DataScannerException, StatementExecutionException {
-        super(wrapped.transactionId, wrapped.getFieldNames(), wrapped.getSchema());
+        super(wrapped.getTransaction(), wrapped.getFieldNames(), wrapped.getSchema());
         this.remaining = maxRows > 0 ? maxRows : -1;
         this.offset = offset;
         this.wrapped = wrapped;

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -89,6 +89,7 @@ public class Transaction {
      */
     public void increaseRefcount() {
         refCount.incrementAndGet();
+//        new Exception("START tx "+transactionId+" now "+refCount).printStackTrace();
     }
 
     public void decreaseRefCount() {
@@ -99,6 +100,7 @@ public class Transaction {
                     + "has {2} pending activities",
                     new Object[]{transactionId, tableSpace, res});
         }
+//         new Exception("END tsx "+transactionId+" now "+res).printStackTrace();
     }
     
     public boolean hasPendingActivities() {

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -43,6 +43,8 @@ import herddb.utils.ILocalLockManager;
 import herddb.utils.LockHandle;
 import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 
 /**
  * A Transaction, that is a series of Statement which must be executed with ACID
@@ -67,6 +69,8 @@ public class Transaction {
     private final List<CommitLogResult> deferredWrites = new ArrayList<>();
     public volatile long lastActivityTs = System.currentTimeMillis();
 
+    private AtomicInteger refCount = new AtomicInteger();
+
     public Transaction(long transactionId, String tableSpace, CommitLogResult lastSequenceNumber) {
         this.transactionId = transactionId;
         this.tableSpace = tableSpace;
@@ -76,6 +80,33 @@ public class Transaction {
         this.deletedRecords = new HashMap<>();
         this.lastSequenceNumber = lastSequenceNumber.deferred ? null : lastSequenceNumber.getLogSequenceNumber();
         this.localCreationTimestamp = System.currentTimeMillis();
+    }
+
+    /**
+     * Each time an operation works on the tranaction we register it, this way
+     * we are able to wait for every pending operation before completing the
+     * transaction with a rollback or commit.
+     */
+    public void increaseRefcount() {
+        refCount.incrementAndGet();
+    }
+
+    public void decreaseRefCount() {
+        int res = refCount.decrementAndGet();
+        if (res < 0) {
+            LOG.log(Level.SEVERE, "transaction {0} "
+                    + "on tablespace {1} "
+                    + "has {2} pending activities",
+                    new Object[]{transactionId, tableSpace, res});
+        }
+    }
+    
+    public boolean hasPendingActivities() {
+        return refCount.get() > 0;
+    }
+
+    public int getRefCount() {
+        return refCount.get();
     }
     
     public void touch() {
@@ -267,7 +298,7 @@ public class Transaction {
     @Override
     public String toString() {
         return "Transaction{" + "transactionId=" + transactionId + ", tableSpace=" + tableSpace
-                + ", locks=" + locks.size() + ", changedRecords=" + changedRecords.size()
+                + ", refcount "+refCount+", locks=" + locks.size() + ", changedRecords=" + changedRecords.size()
                 + ", newRecords=" + newRecords.size()
                 + ", deletedRecords=" + deletedRecords.size()
                 + ", newTables=" + newTables
@@ -534,7 +565,7 @@ public class Transaction {
         }
         lastSequenceNumber = sequenceNumber;
     }
-    
+
     public boolean isAbandoned(long timestamp) {
         return lastActivityTs < timestamp;
     }

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -69,7 +69,7 @@ public class Transaction {
     private final List<CommitLogResult> deferredWrites = new ArrayList<>();
     public volatile long lastActivityTs = System.currentTimeMillis();
 
-    private AtomicInteger refCount = new AtomicInteger();
+    private final AtomicInteger refCount = new AtomicInteger();
 
     public Transaction(long transactionId, String tableSpace, CommitLogResult lastSequenceNumber) {
         this.transactionId = transactionId;

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -269,6 +269,9 @@ public class AggregateOp implements PlannerOp {
         @Override
         public void close() throws DataScannerException {
             wrapped.close();
+            if (aggregatedScanner != null) {
+                aggregatedScanner.close();
+            }
         }
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -119,7 +119,7 @@ public class AggregateOp implements PlannerOp {
         public AggregatedDataScanner(DataScanner wrapped,
                 StatementEvaluationContext context,
                 RecordSetFactory recordSetFactory) throws StatementExecutionException {
-            super(wrapped.transactionId, fieldnames, columns);
+            super(wrapped.getTransaction(), fieldnames, columns);
             this.wrapped = wrapped;
             this.context = context;
             this.recordSetFactory = recordSetFactory;
@@ -205,7 +205,7 @@ public class AggregateOp implements PlannerOp {
                         results.add(tuple);
                     }
                     results.writeFinished();
-                    aggregatedScanner = new SimpleDataScanner(wrapped.transactionId, results);
+                    aggregatedScanner = new SimpleDataScanner(wrapped.getTransaction(), results);
                 } else {
                     Group group = createGroup();
                     AggregatedColumnCalculator[] columns = group.columns;
@@ -225,7 +225,7 @@ public class AggregateOp implements PlannerOp {
                             .createFixedSizeRecordSet(1, getFieldNames(), getSchema());
                     results.add(tuple);
                     results.writeFinished();
-                    aggregatedScanner = new SimpleDataScanner(wrapped.transactionId, results);
+                    aggregatedScanner = new SimpleDataScanner(wrapped.getTransaction(), results);
                 }
             } catch (StatementExecutionException err) {
                 throw new DataScannerException(err);

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -89,8 +89,8 @@ public class AggregateOp implements PlannerOp {
             StatementEvaluationContext context,
             boolean lockRequired, boolean forWrite) throws StatementExecutionException {
 
-        StatementExecutionResult input =
-                this.input.execute(tableSpaceManager, transactionContext, context, lockRequired, forWrite);
+        StatementExecutionResult input
+                = this.input.execute(tableSpaceManager, transactionContext, context, lockRequired, forWrite);
         ScanResult downstreamScanResult = (ScanResult) input;
         final DataScanner inputScanner = downstreamScanResult.dataScanner;
         AggregatedDataScanner filtered = new AggregatedDataScanner(inputScanner, context,

--- a/herddb-core/src/main/java/herddb/model/planner/EnumerableDataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/planner/EnumerableDataScanner.java
@@ -22,6 +22,7 @@ package herddb.model.planner;
 import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
+import herddb.model.Transaction;
 import herddb.utils.DataAccessor;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Enumerator;
@@ -37,9 +38,9 @@ public class EnumerableDataScanner extends DataScanner {
     private DataAccessor next;
 
     public EnumerableDataScanner(
-            long transactionId, String[] fieldNames, Column[] schema,
+            Transaction transaction, String[] fieldNames, Column[] schema,
             Enumerable<DataAccessor> wrapped) {
-        super(transactionId, fieldNames, schema);
+        super(transaction, fieldNames, schema);
         this.wrapped = wrapped.enumerator();
         fetchNext();
     }

--- a/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
@@ -96,7 +96,7 @@ public class FilterOp implements PlannerOp {
         DataAccessor next;
 
         FilteredDataScanner(DataScanner inputScanner, CompiledSQLExpression condition, StatementEvaluationContext context) throws DataScannerException {
-            super(inputScanner.transactionId, inputScanner.getFieldNames(), inputScanner.getSchema());
+            super(inputScanner.getTransaction(), inputScanner.getFieldNames(), inputScanner.getSchema());
             this.inputScanner = inputScanner;
             this.context = context;
             this.condition = condition;

--- a/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
@@ -111,7 +111,7 @@ public class JoinOp implements PlannerOp {
                         generateNullsOnLeft,
                         generateNullsOnRight
                 );
-        EnumerableDataScanner joinedScanner = new EnumerableDataScanner(resTransactionId, fieldNames, columns, result);
+        EnumerableDataScanner joinedScanner = new EnumerableDataScanner(resRight.dataScanner.getTransaction(), fieldNames, columns, result);
         return new ScanResult(resTransactionId, joinedScanner);
 
     }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -314,7 +314,7 @@ public class ProjectOp implements PlannerOp {
 
         public ProjectedDataScanner(DataScanner downstream, String[] fieldNames,
             Column[] schema, StatementEvaluationContext context) {
-            super(downstream.transactionId, fieldNames, schema);
+            super(downstream.getTransaction(), fieldNames, schema);
             this.downstream = downstream;
             this.context = context;
         }

--- a/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
@@ -75,7 +75,7 @@ public class SemiJoinOp implements PlannerOp {
                 JoinKey.keyExtractor(leftKeys),
                 JoinKey.keyExtractor(rightKeys)
         );
-        EnumerableDataScanner joinedScanner = new EnumerableDataScanner(resTransactionId, fieldNames, columns, result);
+        EnumerableDataScanner joinedScanner = new EnumerableDataScanner(resRight.dataScanner.getTransaction(), fieldNames, columns, result);
         return new ScanResult(resTransactionId, joinedScanner);
 
     }

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -85,7 +85,7 @@ public class SortOp implements PlannerOp, TupleComparator {
             }
             recordSet.writeFinished();
             recordSet.sort(this);
-            SimpleDataScanner result = new SimpleDataScanner(downstreamScanResult.transactionId, recordSet);
+            SimpleDataScanner result = new SimpleDataScanner(downstreamScanResult.dataScanner.getTransaction(), recordSet);
             return new ScanResult(downstreamScanResult.transactionId, result);
         } catch (DataScannerException ex) {
             throw new StatementExecutionException(ex);

--- a/herddb-core/src/main/java/herddb/model/planner/ThetaJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ThetaJoinOp.java
@@ -94,7 +94,7 @@ public class ThetaJoinOp implements PlannerOp {
                 generateNullsOnLeft,
                 generateNullsOnRight
         );
-        EnumerableDataScanner joinedScanner = new EnumerableDataScanner(resTransactionId, fieldNames, columns, result);
+        EnumerableDataScanner joinedScanner = new EnumerableDataScanner(resRight.dataScanner.getTransaction(), fieldNames, columns, result);
         return new ScanResult(resTransactionId, joinedScanner);
 
     }

--- a/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
@@ -79,7 +79,7 @@ public class UnionAllOp implements PlannerOp {
 
         public UnionAllDataScanner(DataScanner first, TableSpaceManager tableSpaceManager,
                 TransactionContext transactionContext, StatementEvaluationContext context, boolean lockRequired, boolean forWrite) throws DataScannerException {
-            super(first.transactionId, first.getFieldNames(), first.getSchema());
+            super(first.getTransaction(), first.getFieldNames(), first.getSchema());
             this.tableSpaceManager = tableSpaceManager;
             this.lockRequired = lockRequired;
             this.forWrite = forWrite;
@@ -100,7 +100,7 @@ public class UnionAllOp implements PlannerOp {
                         .get(index).execute(tableSpaceManager,
                                 transactionContext, context, lockRequired, forWrite);
                 transactionContext = new TransactionContext(execute.transactionId);
-                this.transactionId = execute.transactionId;
+                this.transaction = execute.dataScanner.getTransaction();
                 current = execute.dataScanner;
                 fetchNext();
             }

--- a/herddb-core/src/main/java/herddb/model/planner/ValuesOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ValuesOp.java
@@ -28,6 +28,7 @@ import herddb.model.ScanResult;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.model.StatementExecutionResult;
+import herddb.model.Transaction;
 import herddb.model.TransactionContext;
 import herddb.model.Tuple;
 import herddb.sql.expressions.CompiledSQLExpression;
@@ -65,7 +66,9 @@ public class ValuesOp implements PlannerOp {
             TransactionContext transactionContext,
             StatementEvaluationContext context, boolean lockRequired, boolean forWrite) throws StatementExecutionException {
         Iterator<List<CompiledSQLExpression>> it = tuples.iterator();
-        DataScanner res = new DataScanner(transactionContext.transactionId, fieldNames, columns) {
+        Transaction transaction = tableSpaceManager.getTransaction(transactionContext.transactionId);
+        
+        DataScanner res = new DataScanner(transaction, fieldNames, columns) {
             @Override
             public boolean hasNext() throws DataScannerException {
                 return it.hasNext();

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -319,7 +319,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         }
     }
 
-    private CommitLogManager buildCommitLogManager() {
+    protected CommitLogManager buildCommitLogManager() {
 
         switch (mode) {
             case ServerConfiguration.PROPERTY_MODE_LOCAL:

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -470,7 +470,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 if (!last) {
                     scanners.put(scannerId, scanner);
                 }
-                ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.transactionId);
+                ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.getTransactionId());
                 _channel.sendReplyMessage(message.messageId, result);
             } else {
                 ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "unsupported query type for scan " + query + ": PLAN is " + translatedQuery.plan);
@@ -507,7 +507,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                     last = true;
                 }
 //                        LOGGER.log(Level.SEVERE, "sending " + converted.size() + " records to scanner " + scannerId);
-                ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.transactionId);
+                ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.getTransactionId());
                 _channel.sendReplyMessage(message.messageId, result);
             } catch (DataScannerException err) {
                 ByteBuf error = composeErrorResponse(message.messageId, err);

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -472,6 +472,10 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 }
                 ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.getTransactionId());
                 _channel.sendReplyMessage(message.messageId, result);
+                if (last) {
+                    // no need to hold the scanner anymore
+                    scanner.close();
+                }
             } else {
                 ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "unsupported query type for scan " + query + ": PLAN is " + translatedQuery.plan);
                 _channel.sendReplyMessage(message.messageId, error);
@@ -509,6 +513,9 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
 //                        LOGGER.log(Level.SEVERE, "sending " + converted.size() + " records to scanner " + scannerId);
                 ByteBuf result = PduCodec.ResultSetChunk.write(message.messageId, tuplesList, last, dataScanner.getTransactionId());
                 _channel.sendReplyMessage(message.messageId, result);
+                if (last) {
+                    dataScanner.close();
+                }
             } catch (DataScannerException err) {
                 ByteBuf error = composeErrorResponse(message.messageId, err);
                 _channel.sendReplyMessage(message.messageId, error);

--- a/herddb-core/src/test/java/herddb/core/AlterTableSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/AlterTableSQLTest.java
@@ -67,14 +67,14 @@ public class AlterTableSQLTest {
             assertEquals(2, table.getColumn("s1").serialPosition);
             execute(manager, "INSERT INTO tblspace1.tsql (k1,n1,s1) values('a',1,'b')", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
             }
             execute(manager, "ALTER TABLE tblspace1.tsql add column k2 string", Collections.emptyList());
             execute(manager, "INSERT INTO tblspace1.tsql (k1,n1,s1,k2) values('b',1,'b','c')", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql WHERE k2='c'", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql WHERE k2='c'", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(4, tuples.get(0).getFieldNames().length);
             }
@@ -103,7 +103,7 @@ public class AlterTableSQLTest {
             assertEquals(2, table.getColumn("s1").serialPosition);
             execute(manager, "INSERT INTO tblspace1.tsql (k1,n1,s1) values('a',1,'b')", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
                 assertEquals(RawString.of("b"), tuples.get(0).get("s1"));
@@ -115,7 +115,7 @@ public class AlterTableSQLTest {
             assertEquals(2, table.columns.length);
 
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(2, tuples.get(0).getFieldNames().length);
                 try {
@@ -131,7 +131,7 @@ public class AlterTableSQLTest {
             assertEquals(1, table.getColumn("n1").serialPosition);
             assertEquals(3, table.getColumn("s1").serialPosition);
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
                 assertEquals(null, tuples.get(0).get("s1"));
@@ -164,19 +164,19 @@ public class AlterTableSQLTest {
             assertEquals(2, table.getColumn("s1").serialPosition);
             execute(manager, "INSERT INTO tblspace1.tsql (n1,s1) values(1,'b')", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql where k1=1", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql where k1=1", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
             }
             execute(manager, "ALTER TABLE tblspace1.tsql modify column k1 int", Collections.emptyList());
             execute(manager, "INSERT INTO tblspace1.tsql (k1,n1,s1) values(2, 2,'b')", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
                 assertEquals(2, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
             }
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql where k1=2", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql where k1=2", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
             }
@@ -185,7 +185,7 @@ public class AlterTableSQLTest {
             assertTrue(manager.getTableSpaceManager("tblspace1").getTableManager("tsql").getTable().auto_increment);
             execute(manager, "INSERT INTO tblspace1.tsql (n1,s1) values(1,'b')", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
                 assertEquals(3, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
             }
@@ -210,7 +210,7 @@ public class AlterTableSQLTest {
 
             {
                 List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql "
-                    + "where l2=1", Collections.emptyList()).consume();
+                    + "where l2=1", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(Arrays.toString(tuples.get(0).getFieldNames()), 3, tuples.get(0).getFieldNames().length);
                 assertEquals("l2", tuples.get(0).getFieldNames()[0]);
@@ -233,13 +233,13 @@ public class AlterTableSQLTest {
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 int primary key auto_increment,n1 int,s1 string)", Collections.emptyList());
             execute(manager, "INSERT INTO tblspace1.tsql (n1,s1) values(1,'b')", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql where k1=1", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql where k1=1", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
             }
             execute(manager, "EXECUTE RENAMETABLE 'tblspace1','tsql','tsql2'", Collections.emptyList());
             {
-                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql2 where k1=1", Collections.emptyList()).consume();
+                List<DataAccessor> tuples = scan(manager, "SELECT * FROM tblspace1.tsql2 where k1=1", Collections.emptyList()).consumeAndClose();
                 assertEquals(1, tuples.size());
                 assertEquals(3, tuples.get(0).getFieldNames().length);
             }

--- a/herddb-core/src/test/java/herddb/core/AutoIncrementTest.java
+++ b/herddb-core/src/test/java/herddb/core/AutoIncrementTest.java
@@ -67,7 +67,7 @@ public class AutoIncrementTest {
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?)", Arrays.asList("aa")).getUpdateCount());
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?)", Arrays.asList("aa")).getUpdateCount());
 
-            List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+            List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
             assertEquals(6, rows.size());
             for (int i = 1; i <= 6; i++) {
                 int _i = i;
@@ -98,7 +98,7 @@ public class AutoIncrementTest {
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?)", Arrays.asList("aa")).getUpdateCount());
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?)", Arrays.asList("aa")).getUpdateCount());
 
-            List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+            List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
             assertEquals(6, rows.size());
             for (int i = 1; i <= 6; i++) {
                 int _i = i;
@@ -129,7 +129,7 @@ public class AutoIncrementTest {
                 assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?)", Arrays.asList("aa")).getUpdateCount());
                 assertEquals(2, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?),(?)", Arrays.asList("aa", "aa")).getUpdateCount());
 
-                List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume();
+                List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose();
                 assertEquals(6, rows.size());
                 for (int i = 1; i <= 6; i++) {
                     int _i = i;
@@ -153,7 +153,7 @@ public class AutoIncrementTest {
                 assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?)", Arrays.asList("aa"), new TransactionContext(tx)).getUpdateCount());
                 assertEquals(2, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?),(?)", Arrays.asList("aa", "aa"), new TransactionContext(tx)).getUpdateCount());
 
-                List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList(), new TransactionContext(tx)).consume();
+                List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose();
                 assertEquals(6, rows.size());
                 for (int i = 8; i <= 13; i++) {
                     int _i = i;
@@ -177,7 +177,7 @@ public class AutoIncrementTest {
                 assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?)", Arrays.asList("aa"), new TransactionContext(tx)).getUpdateCount());
                 assertEquals(2, executeUpdate(manager, "INSERT INTO tblspace1.tsql(s1) values(?),(?)", Arrays.asList("aa", "aa"), new TransactionContext(tx)).getUpdateCount());
 
-                List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList(), new TransactionContext(tx)).consume();
+                List<DataAccessor> rows = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose();
                 assertEquals(6, rows.size());
                 for (int i = 15; i <= 20; i++) {
                     int _i = i;

--- a/herddb-core/src/test/java/herddb/core/AutoTransactionTest.java
+++ b/herddb-core/src/test/java/herddb/core/AutoTransactionTest.java
@@ -162,7 +162,7 @@ public class AutoTransactionTest extends BaseTestcase {
 
         long tx;
         try (DataScanner scan = manager.scan(new ScanStatement(tableSpace, tableName, Projection.IDENTITY(table.columnNames, table.getColumns()), null, null, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);) {
-            tx = scan.transactionId;
+            tx = scan.getTransactionId();
             assertEquals(1, scan.consume().size());
         }
 

--- a/herddb-core/src/test/java/herddb/core/AutocheckPointTest.java
+++ b/herddb-core/src/test/java/herddb/core/AutocheckPointTest.java
@@ -101,7 +101,7 @@ public class AutocheckPointTest {
             assertNotEquals(lastCheckpont, manager.getLastCheckPointTs());
             execute(manager, "EXECUTE committransaction 'tblspace1'," + tx, Collections.emptyList());
 
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE N1=1234 and s1='b'", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE N1=1234 and s1='b'", Collections.emptyList()).consumeAndClose().size());
 
         }
     }

--- a/herddb-core/src/test/java/herddb/core/DeleteTest.java
+++ b/herddb-core/src/test/java/herddb/core/DeleteTest.java
@@ -77,7 +77,7 @@ public class DeleteTest {
 
             assertEquals(4, executeUpdate(manager, "DELETE FROM tblspace1.tsql WHERE N1=1234", Collections.emptyList()).getUpdateCount());
 
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE N1=1234", Collections.emptyList()).consume().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE N1=1234", Collections.emptyList()).consumeAndClose().size());
 
         }
     }
@@ -127,7 +127,7 @@ public class DeleteTest {
                 for (int i = 0; i < inserts; ++i) {
                     assertEquals(1, scan(manager,
                             "SELECT * FROM tblspace1.tsql WHERE k1 = ?",
-                            Arrays.asList(Integer.valueOf(i), ctx)).consume().size());
+                            Arrays.asList(Integer.valueOf(i), ctx)).consumeAndClose().size());
                 }
 
                 execute(manager, "DROP TABLE tblspace1.tsql", Collections.emptyList());

--- a/herddb-core/src/test/java/herddb/core/HeapTest.java
+++ b/herddb-core/src/test/java/herddb/core/HeapTest.java
@@ -63,7 +63,7 @@ public class HeapTest {
 
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,s1) values(?,?,?)", Arrays.asList("mykey", Integer.valueOf(1234), "aa")).getUpdateCount());
 
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose().size());
 
             try (DataScanner dataScanner = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList());) {
 

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -261,7 +261,7 @@ public class RawSQLTest {
 
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,t1) values(?,?,CURRENT_TIMESTAMP)", Arrays.asList("mykey", Integer.valueOf(1234))).getUpdateCount());
             Thread.sleep(500);
-            assertEquals(1234, scan(manager, "SELECT n1 FROM tblspace1.tsql WHERE t1<CURRENT_TIMESTAMP", Collections.emptyList()).consume().get(0).get("n1"));
+            assertEquals(1234, scan(manager, "SELECT n1 FROM tblspace1.tsql WHERE t1<CURRENT_TIMESTAMP", Collections.emptyList()).consumeAndClose().get(0).get("n1"));
 
             java.sql.Timestamp now = new java.sql.Timestamp(System.currentTimeMillis());
             if (manager.getPlanner() instanceof DDLSQLPlanner) {
@@ -288,21 +288,21 @@ public class RawSQLTest {
             java.sql.Timestamp now = new java.sql.Timestamp(System.currentTimeMillis());
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,s1,n1,t1,n2,n3) values(?,?,?,?,?,?)", Arrays.asList("mykey", "a", Integer.valueOf(1234), now, 1, 2)).getUpdateCount());
 
-            DataAccessor before = scan(manager, "SELECT n2,n3 FROM tblspace1.tsql WHERE k1=?", Arrays.asList("mykey")).consume().get(0);
+            DataAccessor before = scan(manager, "SELECT n2,n3 FROM tblspace1.tsql WHERE k1=?", Arrays.asList("mykey")).consumeAndClose().get(0);
             assertEquals(1, before.get(0));
             assertEquals(2, before.get(1));
 
             assertEquals(1, executeUpdate(manager, "UPDATE tblspace1.tsql set n2=n2+1,n3=n3+5 WHERE k1=?",
                     Arrays.asList("mykey")).getUpdateCount());
 
-            DataAccessor after = scan(manager, "SELECT n2,n3 FROM tblspace1.tsql WHERE k1=?", Arrays.asList("mykey")).consume().get(0);
+            DataAccessor after = scan(manager, "SELECT n2,n3 FROM tblspace1.tsql WHERE k1=?", Arrays.asList("mykey")).consumeAndClose().get(0);
             assertEquals(2, after.get(0));
             assertEquals(7, after.get(1));
 
             assertEquals(1, executeUpdate(manager, "UPDATE tblspace1.tsql set n2=n2+n2,n3=n3+n2 WHERE k1=?",
                     Arrays.asList("mykey")).getUpdateCount());
 
-            DataAccessor after2 = scan(manager, "SELECT n2,n3 FROM tblspace1.tsql WHERE k1=?", Arrays.asList("mykey")).consume().get(0);
+            DataAccessor after2 = scan(manager, "SELECT n2,n3 FROM tblspace1.tsql WHERE k1=?", Arrays.asList("mykey")).consumeAndClose().get(0);
             assertEquals(4, after2.get(0));
             assertEquals(9, after2.get(1));
 
@@ -578,13 +578,13 @@ public class RawSQLTest {
 
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", Integer.valueOf(1234))).getUpdateCount());
-            assertEquals(1234, scan(manager, "SELECT n1 FROM tblspace1.tsql", Collections.emptyList()).consume().get(0).get("n1"));
+            assertEquals(1234, scan(manager, "SELECT n1 FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose().get(0).get("n1"));
             assertEquals(1, executeUpdate(manager, "UPDATE tblspace1.tsql set n1=n1+1 where k1=?", Arrays.asList("mykey")).getUpdateCount());
-            assertEquals(1235, scan(manager, "SELECT n1 FROM tblspace1.tsql", Collections.emptyList()).consume().get(0).get("n1"));
-            assertEquals(1236L, scan(manager, "SELECT n1+1 FROM tblspace1.tsql", Collections.emptyList()).consume().get(0).get(0));
-            assertEquals(1234L, scan(manager, "SELECT n1-1 FROM tblspace1.tsql", Collections.emptyList()).consume().get(0).get(0));
-            assertEquals(1235, scan(manager, "SELECT n1 FROM tblspace1.tsql WHERE n1+1=1236", Collections.emptyList()).consume().get(0).get(0));
-            assertEquals(1235, scan(manager, "SELECT n1 FROM tblspace1.tsql WHERE n1+n1=2470", Collections.emptyList()).consume().get(0).get(0));
+            assertEquals(1235, scan(manager, "SELECT n1 FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose().get(0).get("n1"));
+            assertEquals(1236L, scan(manager, "SELECT n1+1 FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose().get(0).get(0));
+            assertEquals(1234L, scan(manager, "SELECT n1-1 FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose().get(0).get(0));
+            assertEquals(1235, scan(manager, "SELECT n1 FROM tblspace1.tsql WHERE n1+1=1236", Collections.emptyList()).consumeAndClose().get(0).get(0));
+            assertEquals(1235, scan(manager, "SELECT n1 FROM tblspace1.tsql WHERE n1+n1=2470", Collections.emptyList()).consumeAndClose().get(0).get(0));
         }
     }
 
@@ -655,7 +655,7 @@ public class RawSQLTest {
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", Integer.valueOf(1234))).getUpdateCount());
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql values(?,?,?)", Arrays.asList("mykey2", Integer.valueOf(1234), "value")).getUpdateCount());
 
-            assertEquals(2, scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consume().size());
+            assertEquals(2, scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose().size());
 
         }
     }
@@ -672,9 +672,9 @@ public class RawSQLTest {
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
 
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,s1) values(?,?,?)", Arrays.asList("mykey", Integer.valueOf(1234), "value1")).getUpdateCount());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where s1='value1'", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where s1='value1'", Collections.emptyList()).consumeAndClose().size());
             assertEquals(1, executeUpdate(manager, "UPDATE tblspace1.tsql set s1=k1  where k1=?", Arrays.asList("mykey")).getUpdateCount());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where s1='mykey'", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where s1='mykey'", Collections.emptyList()).consumeAndClose().size());
         }
     }
 
@@ -2024,40 +2024,40 @@ public class RawSQLTest {
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,ts,l1) values(?,?,?,?)", Arrays.asList("mykey", Integer.valueOf(1234), new java.sql.Timestamp(now), Long.valueOf(2234))).getUpdateCount());
 
             // integer
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1234 and 1234", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1234 and 1235", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1233 and 1234", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1200 and 1239", Collections.emptyList()).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 0 and -1", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1234 and 1234", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1234 and 1235", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1233 and 1234", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 1200 and 1239", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where n1 between 0 and -1", Collections.emptyList()).consumeAndClose().size());
 
             // long
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2234 and 2234", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2234 and 2235", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2233 and 2234", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2200 and 2239", Collections.emptyList()).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 0 and -1", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2234 and 2234", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2234 and 2235", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2233 and 2234", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 2200 and 2239", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where l1 between 0 and -1", Collections.emptyList()).consumeAndClose().size());
 
             // string
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykey' and 'mykey'", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykey' and 'mykfy'", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykdy' and 'mykey'", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykay' and 'mykqy'", Collections.emptyList()).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykfy' and 'mykgy'", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykey' and 'mykey'", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykey' and 'mykfy'", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykdy' and 'mykey'", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykay' and 'mykqy'", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where k1 between 'mykfy' and 'mykgy'", Collections.emptyList()).consumeAndClose().size());
 
             // timestamp
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now), new java.sql.Timestamp(now))).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now), new java.sql.Timestamp(now + 60000))).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now - 1000), new java.sql.Timestamp(now))).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now - 1000), new java.sql.Timestamp(now + 60000))).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(0), new java.sql.Timestamp(1000))).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now + 1000), new java.sql.Timestamp(now - 1000))).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now), new java.sql.Timestamp(now))).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now), new java.sql.Timestamp(now + 60000))).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now - 1000), new java.sql.Timestamp(now))).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now - 1000), new java.sql.Timestamp(now + 60000))).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(0), new java.sql.Timestamp(1000))).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql where ts between ? and ?", Arrays.asList(new java.sql.Timestamp(now + 1000), new java.sql.Timestamp(now - 1000))).consumeAndClose().size());
 
             if (manager.getPlanner() instanceof DDLSQLPlanner) {
                 System.out.println("now:" + new java.sql.Timestamp(now));
-                assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts >= {ts '" + new java.sql.Timestamp(now) + "'}", Collections.emptyList()).consume().size());
+                assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts >= {ts '" + new java.sql.Timestamp(now) + "'}", Collections.emptyList()).consumeAndClose().size());
 
                 // timestamp with jdbc literals
-                assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between {ts '" + new java.sql.Timestamp(now) + "'} and {ts '" + new java.sql.Timestamp(now) + "'}", Collections.emptyList()).consume().size());
+                assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where ts between {ts '" + new java.sql.Timestamp(now) + "'} and {ts '" + new java.sql.Timestamp(now) + "'}", Collections.emptyList()).consumeAndClose().size());
 
             } else {
                 // Calcite interprets JDBC syntax as in UTC Timezone
@@ -2079,17 +2079,17 @@ public class RawSQLTest {
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string, t1 timestamp)", Collections.emptyList());
 
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,s1) values(?,?,?)", Arrays.asList("mykey", Integer.valueOf(1), "a")).getUpdateCount());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=2 and n1=1", Collections.emptyList()).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 and n1=2", Collections.emptyList()).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=3 and n1=2", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 and n1=1", Collections.emptyList()).consume().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=2 and n1=1", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 and n1=2", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=3 and n1=2", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 and n1=1", Collections.emptyList()).consumeAndClose().size());
 
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=2 or n1=1", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 or n1=2", Collections.emptyList()).consume().size());
-            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=3 or n1=2", Collections.emptyList()).consume().size());
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 or n1=1", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=2 or n1=1", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 or n1=2", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=3 or n1=2", Collections.emptyList()).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=1 or n1=1", Collections.emptyList()).consumeAndClose().size());
 
-            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE not (n1=2) or n1=3", Collections.emptyList()).consume().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql WHERE not (n1=2) or n1=3", Collections.emptyList()).consumeAndClose().size());
         }
     }
 

--- a/herddb-core/src/test/java/herddb/core/ScanTest.java
+++ b/herddb-core/src/test/java/herddb/core/ScanTest.java
@@ -69,7 +69,7 @@ public class ScanTest extends BaseTestcase {
                 }
             });
             DataScanner scanner = manager.scan(scan, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            List<?> result = scanner.consume();
+            List<?> result = scanner.consumeAndClose();
             assertEquals(50, result.size());
         }
 
@@ -87,14 +87,14 @@ public class ScanTest extends BaseTestcase {
                 }
             });
             DataScanner scanner = manager.scan(scan, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            List<?> result = scanner.consume();
+            List<?> result = scanner.consumeAndClose();
             assertEquals(30, result.size());
         }
 
         {
             ScanStatement scan = new ScanStatement(tableSpace, table, null);
             DataScanner scanner = manager.scan(scan, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            List<?> result = scanner.consume();
+            List<?> result = scanner.consumeAndClose();
             assertEquals(80, result.size());
         }
     }
@@ -131,7 +131,7 @@ public class ScanTest extends BaseTestcase {
                 }
             });
             DataScanner scanner = manager.scan(scan, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
-            List<?> result = scanner.consume();
+            List<?> result = scanner.consumeAndClose();
             assertEquals(10, result.size());
         }
 
@@ -148,7 +148,7 @@ public class ScanTest extends BaseTestcase {
                 }
             });
             DataScanner scanner = manager.scan(scan, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
-            List<?> result = scanner.consume();
+            List<?> result = scanner.consumeAndClose();
             assertEquals(0, result.size());
         }
 

--- a/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
@@ -470,7 +470,7 @@ public class SimpleJoinTest {
                 List<DataAccessor> tuples = scan(manager, "SELECT t1.k1 as first, t2.k1 as seco FROM"
                         + " tblspace1.table1 t1 "
                         + " NATURAL JOIN tblspace1.table3 t2 " // NATURAL JOIN is on columns with the same name and type
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -494,7 +494,7 @@ public class SimpleJoinTest {
                 List<DataAccessor> tuples = scan(manager, "SELECT t1.k1 as first, t2.k1 as seco FROM"
                         + " tblspace1.table1 t1 "
                         + " NATURAL JOIN tblspace1.table3 t2 " // NATURAL is on columns with the same name and type
-                        + " WHERE t1.n1 + 1 = t2.n3", Collections.emptyList()).consume();
+                        + " WHERE t1.n1 + 1 = t2.n3", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -516,7 +516,7 @@ public class SimpleJoinTest {
                         + " tblspace1.table1 t1"
                         + " JOIN tblspace1.table2 t2"
                         + " ON  t1.n1 > 0"
-                        + "   and t2.n2 >= 1", Collections.emptyList()).consume();
+                        + "   and t2.n2 >= 1", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
 
                     assertEquals(3, t.getFieldNames().length);
@@ -557,7 +557,7 @@ public class SimpleJoinTest {
                         + " tblspace1.table1 t1"
                         + " JOIN tblspace1.table2 t2"
                         + " ON t1.n1 > 0"
-                        + "   and t2.n2 >= 1", Collections.emptyList()).consume();
+                        + "   and t2.n2 >= 1", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
 
                     assertEquals(6, t.getFieldNames().length);
@@ -600,7 +600,7 @@ public class SimpleJoinTest {
                 List<DataAccessor> tuples = scan(manager, "SELECT * FROM"
                         + " tblspace1.table1 t1"
                         + " JOIN tblspace1.table2 t2 ON  (1=1)"
-                        + " ORDER BY n2,n1", Collections.emptyList()).consume();
+                        + " ORDER BY n2,n1", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
 
                     assertEquals(6, t.getFieldNames().length);
@@ -644,7 +644,7 @@ public class SimpleJoinTest {
                 List<DataAccessor> tuples = scan(manager, "SELECT * FROM"
                         + " tblspace1.table1 t1"
                         + " JOIN tblspace1.table2 t2 ON (1<>2)"
-                        + " ORDER BY n2 desc,n1", Collections.emptyList()).consume();
+                        + " ORDER BY n2 desc,n1", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
 
                     assertEquals(6, t.getFieldNames().length);
@@ -688,7 +688,7 @@ public class SimpleJoinTest {
                 List<DataAccessor> tuples = scan(manager, "SELECT t1.k1, t2.k2 FROM"
                         + " tblspace1.table1 t1 "
                         + " JOIN tblspace1.table2 t2 "
-                        + " ON t1.n1 + 3 <= t2.n2", Collections.emptyList()).consume();
+                        + " ON t1.n1 + 3 <= t2.n2", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -710,7 +710,7 @@ public class SimpleJoinTest {
                         + " tblspace1.table1 t1 "
                         + " LEFT JOIN tblspace1.table2 t2 "
                         + " ON t1.s1 = t2.s2"
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(4, t.getFieldNames().length);
@@ -741,7 +741,7 @@ public class SimpleJoinTest {
                         + " tblspace1.table1 t1 "
                         + " RIGHT JOIN tblspace1.table2 t2 "
                         + " ON t1.s1 = t2.s2"
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(4, t.getFieldNames().length);
@@ -788,7 +788,7 @@ public class SimpleJoinTest {
                 List<DataAccessor> tuples = scan(manager,
                         "SELECT t1.k1, max(n1) as maxn1, max(select n2 from tblspace1.table2 t2 WHERE t1.s1=t2.s2) as maxn2 FROM "
                         + " tblspace1.table1 t1 "
-                        + " group by k1", Collections.emptyList()).consume();
+                        + " group by k1", Collections.emptyList()).consumeAndClose();
 
                 for (DataAccessor t : tuples) {
                     System.out.println("t:" + t);
@@ -817,7 +817,7 @@ public class SimpleJoinTest {
                         "SELECT t1.k1, max(n1) as maxn1, max(select n2 from tblspace1.table2 t2 WHERE t1.s1=t2.s2) as maxn2 FROM "
                         + " tblspace1.table1 t1 "
                         + " group by k1"
-                        + " order by max(select n2 from tblspace1.table2 t2 WHERE t1.s1=t2.s2) desc", Collections.emptyList()).consume();
+                        + " order by max(select n2 from tblspace1.table2 t2 WHERE t1.s1=t2.s2) desc", Collections.emptyList()).consumeAndClose();
 
                 for (DataAccessor t : tuples) {
                     System.out.println("t:" + t);

--- a/herddb-core/src/test/java/herddb/core/SimpleSubqueryTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleSubqueryTest.java
@@ -64,12 +64,12 @@ public class SimpleSubqueryTest {
             assertEquals(1, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1='mykey2'"
-                    + "", Collections.emptyList()).consume().size());
+                    + "", Collections.emptyList()).consumeAndClose().size());
 
             assertEquals(1, scan(manager, "SELECT t1.k1 "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1='mykey2'"
-                    + "", Collections.emptyList()).consume().size());
+                    + "", Collections.emptyList()).consumeAndClose().size());
 
             try {
                 scan(manager, "SELECT t2.k1 "
@@ -149,22 +149,22 @@ public class SimpleSubqueryTest {
             assertEquals(2, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1 in ('mykey','mykey3')"
-                    + "", Collections.emptyList()).consume().size());
+                    + "", Collections.emptyList()).consumeAndClose().size());
 
             assertEquals(1, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2='subkey4')"
-                    + "", Collections.emptyList()).consume().size());
+                    + "", Collections.emptyList()).consumeAndClose().size());
 
             assertEquals(1, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.n1 = ? and t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2=?)"
-                    + "", Arrays.asList(1234, "subkey4")).consume().size());
+                    + "", Arrays.asList(1234, "subkey4")).consumeAndClose().size());
 
             assertEquals(0, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.n1 = ? and t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2=?)"
-                    + "", Arrays.asList(1234, "subkey5")).consume().size());
+                    + "", Arrays.asList(1234, "subkey5")).consumeAndClose().size());
 
         }
     }
@@ -194,32 +194,32 @@ public class SimpleSubqueryTest {
             assertEquals(2, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1 in ('mykey','mykey3')"
-                    + "", Collections.emptyList()).consume().size());
+                    + "", Collections.emptyList()).consumeAndClose().size());
 
             assertEquals(1, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2='subkey4')"
-                    + "", Arrays.asList("mykey4")).consume().size());
+                    + "", Arrays.asList("mykey4")).consumeAndClose().size());
 
             assertEquals(1, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.n1=1238 and t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2='subkey4')"
-                    + "", Arrays.asList("mykey4")).consume().size());
+                    + "", Arrays.asList("mykey4")).consumeAndClose().size());
 
             assertEquals(1, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.n1=? and t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2='subkey4')"
-                    + "", Arrays.asList(1238, "mykey4")).consume().size());
+                    + "", Arrays.asList(1238, "mykey4")).consumeAndClose().size());
 
             assertEquals(0, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.n1=? and t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2='subkey4')"
-                    + "", Arrays.asList(124, "mykey4")).consume().size());
+                    + "", Arrays.asList(124, "mykey4")).consumeAndClose().size());
 
             assertEquals(1, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2=?)"
-                    + "", Arrays.asList("subkey4")).consume().size());
+                    + "", Arrays.asList("subkey4")).consumeAndClose().size());
 
             assertEquals(1, executeUpdate(manager, "UPDATE tblspace1.table1 set n1=1000"
                     + "WHERE k1 in (SELECT fk FROM tblspace1.table2 WHERE k2=?)"
@@ -233,7 +233,7 @@ public class SimpleSubqueryTest {
             assertEquals(0, scan(manager, "SELECT * "
                     + "FROM tblspace1.table1 t1 "
                     + "WHERE t1.k1 in (SELECT fk FROM tblspace1.table2 WHERE k2=?)"
-                    + "", Arrays.asList("subkey4")).consume().size());
+                    + "", Arrays.asList("subkey4")).consumeAndClose().size());
 
         }
     }

--- a/herddb-core/src/test/java/herddb/core/SystemTablesJoinTest.java
+++ b/herddb-core/src/test/java/herddb/core/SystemTablesJoinTest.java
@@ -62,7 +62,7 @@ public class SystemTablesJoinTest {
                     + "sysnodes.address FROM"
                     + " systablespaces "
                     + " JOIN sysnodes ON systablespaces.leader = sysnodes.nodeid"
-                    + " ORDER BY tablespace_name", Collections.emptyList()).consume();
+                    + " ORDER BY tablespace_name", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     assertEquals(3, t.getFieldNames().length);
                     assertEquals("leader", t.getFieldNames()[0]);
@@ -88,7 +88,7 @@ public class SystemTablesJoinTest {
                     + "sysnodes.address FROM"
                     + " systablespaces "
                     + " JOIN sysnodes ON systablespaces.leader = sysnodes.nodeid"
-                    + " ORDER BY tablespace_name DESC", Collections.emptyList()).consume();
+                    + " ORDER BY tablespace_name DESC", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     assertEquals(3, t.getFieldNames().length);
                     assertEquals("leader", t.getFieldNames()[0]);
@@ -114,7 +114,7 @@ public class SystemTablesJoinTest {
                     + "sysnodes.address FROM"
                     + " systablespaces "
                     + " JOIN sysnodes ON systablespaces.leader = sysnodes.nodeid AND systablespaces.tablespace_name <> ?"
-                    + " ORDER BY tablespace_name DESC", Arrays.asList(TableSpace.DEFAULT)).consume();
+                    + " ORDER BY tablespace_name DESC", Arrays.asList(TableSpace.DEFAULT)).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     assertEquals(3, t.getFieldNames().length);
                     assertEquals("leader", t.getFieldNames()[0]);

--- a/herddb-core/src/test/java/herddb/core/UpdateTest.java
+++ b/herddb-core/src/test/java/herddb/core/UpdateTest.java
@@ -110,14 +110,14 @@ public class UpdateTest {
                 for (int i = 0; i < inserts; ++i) {
                     assertEquals(1, scan(manager,
                             "SELECT k1, n1 FROM tblspace1.tsql WHERE k1 = ? AND n1 = 100",
-                            Arrays.asList(Integer.valueOf(i)), ctx).consume().size());
+                            Arrays.asList(Integer.valueOf(i)), ctx).consumeAndClose().size());
                 }
 
                 for (int i = 0; i < inserts; ++i) {
                     try {
                     assertEquals(1, scan(manager,
                             "SELECT k1, n1 FROM tblspace1.tsql WHERE k1 = ? AND n1 = 100",
-                            Arrays.asList(Integer.valueOf(i)), ctx).consume().size());
+                            Arrays.asList(Integer.valueOf(i)), ctx).consumeAndClose().size());
                     } catch (AssertionError e) {
 
                         throw e;
@@ -129,7 +129,7 @@ public class UpdateTest {
                 for (int i = 0; i < inserts; ++i) {
                     assertEquals(1, scan(manager,
                             "SELECT k1, n1 FROM tblspace1.tsql WHERE k1 = ? AND n1 = 100",
-                            Arrays.asList(Integer.valueOf(i), ctx)).consume().size());
+                            Arrays.asList(Integer.valueOf(i), ctx)).consumeAndClose().size());
                 }
 
                 execute(manager, "DROP TABLE tblspace1.tsql", Collections.emptyList());

--- a/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
@@ -71,6 +71,11 @@ public class SimpleClientScanTest {
                 // single fetch result test
                 assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='test_1'", true, Collections.emptyList(), 0, 0, 10).consume().size());
 
+                 // agregation in transaction, this is trickier than what you can think
+                long tx = connection.beginTransaction(TableSpace.DEFAULT);
+                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT count(*) FROM mytable WHERE id='test_1'", true, Collections.emptyList(), tx, 0, 10).consume().size());
+                connection.rollbackTransaction(TableSpace.DEFAULT, tx);
+               
             }
         }
     }

--- a/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesTest.java
@@ -180,7 +180,7 @@ public class DirectMultipleConcurrentUpdatesTest {
                                         throw new RuntimeException("not found?");
                                     }
                                     res.close();
-                                    transactionId = res.transactionId;
+                                    transactionId = res.getTransactionId();
                                     // value did not change actually
                                     value = actual;
                                 }

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -250,7 +250,7 @@ public class CalcitePlannerTest {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2,n1 "
                         + "  from tblspace1.tsql2 join tblspace1.tsql on k2<>k1 "
                         + "  where n2 > 1 "
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(3, t.getFieldNames().length);
@@ -272,7 +272,7 @@ public class CalcitePlannerTest {
                         + "  from tblspace1.tsql2"
                         + "  left join tblspace1.tsql on n2 < n1-1000"
                         + "  "
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(3, t.getFieldNames().length);
@@ -298,7 +298,7 @@ public class CalcitePlannerTest {
                         + "  from tblspace1.tsql2"
                         + "  left join tblspace1.tsql on n2 < n1-?"
                         + "  "
-                        + " ", Arrays.asList(-1000)).consume();
+                        + " ", Arrays.asList(-1000)).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(3, t.getFieldNames().length);
@@ -322,7 +322,7 @@ public class CalcitePlannerTest {
             {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
                         + "                     where k2 not in (select k1 from tblspace1.tsql)"
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -341,7 +341,7 @@ public class CalcitePlannerTest {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
                         + "                     where n2 in (select n1 from tblspace1.tsql"
                         + "                                    )"
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -365,7 +365,7 @@ public class CalcitePlannerTest {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
                         + "                     where exists (select * from tblspace1.tsql"
                         + "                                     where n1=n2)"
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -393,7 +393,7 @@ public class CalcitePlannerTest {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
                         + "                     where n2 in (select n1 from tblspace1.tsql"
                         + "                                     order by n1 desc limit 1)"
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);
@@ -412,7 +412,7 @@ public class CalcitePlannerTest {
                 List<DataAccessor> tuples = scan(manager, "select k2,n2 from tblspace1.tsql2"
                         + "                     where n2 in (select n1 from tblspace1.tsql"
                         + "                                     order by n1 asc limit 1)"
-                        + " ", Collections.emptyList()).consume();
+                        + " ", Collections.emptyList()).consumeAndClose();
                 for (DataAccessor t : tuples) {
                     System.out.println("tuple -: " + t.toMap());
                     assertEquals(2, t.getFieldNames().length);


### PR DESCRIPTION
In case of a timeout any usual JDBC client receives an SQLException and it rollbacks the transaction.
The command (say, an huge DELETE) still continues its execution and so we fall into a case in which a transaction command (ROLLBACK, but the same could happen for a commit) that runs concurrently with an operation pertaining to the same transaction.

We must not fall into this case.

So the fix here is to have some kind of "reference count" of the transaction and wait for any pending activity to complete before proceeding with a rollback or a commit.

Summary of changes:
- add a "refcount" in Transaction class
- bind the DataScanner to the Transaction, this way we can track the end of a SELECT
- wrap the executions of DML in a way such that we track the end of the DML command
