### PR TITLE
Fix BRIN blocks successor of themselves

### DIFF
--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -109,7 +109,7 @@ public class BRINIndexManager extends AbstractIndexManager {
         }
 
         void serialize(ExtendedDataOutputStream out) throws IOException {
-            out.writeVLong(2); // version
+            out.writeVLong(3); // version
             out.writeVLong(0); // flags for future implementations
 
             out.writeVInt(this.type);
@@ -135,12 +135,12 @@ public class BRINIndexManager extends AbstractIndexManager {
                         if (!head) {
                             out.writeArray(md.firstKey);
                         }
-                        out.writeVLong(md.blockId);
+                        out.writeZLong(md.blockId);
                         out.writeVLong(md.size);
                         out.writeVLong(md.pageId);
 
                         if (!tail) {
-                            out.writeVLong(md.nextBlockId);
+                            out.writeZLong(md.nextBlockId);
                         }
                     }
                     break;
@@ -160,12 +160,12 @@ public class BRINIndexManager extends AbstractIndexManager {
             long version = in.readVLong(); // version
             long flags = in.readVLong(); // flags for future implementations
 
-            /* Only version 2 actually supported, older versions will need a full rebuild */
-            if (version < 2) {
+            /* Only version 3 actually supported, older versions will need a full rebuild */
+            if (version < 3) {
                 throw new UnsupportedMetadataVersionException(version);
             }
 
-            if (version > 2 || flags != 0) {
+            if (version > 3 || flags != 0) {
                 throw new DataStorageManagerException("corrupted index page");
             }
 
@@ -186,7 +186,7 @@ public class BRINIndexManager extends AbstractIndexManager {
                             firstKey = in.readBytesNoCopy();
                         }
 
-                        long blockId = in.readVLong();
+                        long blockId = in.readZLong();
                         long size = in.readVLong();
                         long pageId = in.readVLong();
 
@@ -196,7 +196,7 @@ public class BRINIndexManager extends AbstractIndexManager {
                             /* Next block is null if is the tail block */
                             nextBlockId = null;
                         } else {
-                            nextBlockId = in.readVLong();
+                            nextBlockId = in.readZLong();
                         }
 
                         BlockRangeIndexMetadata.BlockMetadata<Bytes> md

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -773,6 +773,9 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                         }
                     }
 
+                    if (Objects.equals(first, other.next)) {
+                        LOG.log(Level.SEVERE, "this is the bug ! should not happen: "+first+" - "+other+" ?");
+                    }
                     /* Update next reference */
                     first.next = other.next;
 

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -245,10 +245,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             this.size = size;
             this.next = next;
 
-            if (next != null && (next.key.equals(key) || next.key.blockId == key.blockId)) {
-                System.out.println("ERRORE");
-            }
-
             this.loaded = false;
             this.dirty = false;
             this.pageId = pageId;
@@ -282,10 +278,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             this.values = values;
             this.size = size;
             this.next = next;
-
-            if (next != null && (next.key.equals(key) || next.key.blockId == key.blockId)) {
-                System.out.println("ERRORE");
-            }
 
             this.loaded = true;
             this.dirty = true;
@@ -636,8 +628,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                 newBlockId = -newBlockId;
             }
 
-            System.out.println("split newBlockId " + newBlockId + " key " + key + " newOtherMinKey " + newOtherMinKey);
-
             Block<KEY,VAL> newblock = new Block<>(index, BlockStartKey.valueOf(newOtherMinKey, newBlockId), otherValues, otherSize, next);
 
             this.next = newblock;
@@ -839,14 +829,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                             LOG.fine("linking block " + first.pageId + " (" + first.key + ") to real next block "
                                     + other.next.pageId + " (" + other.next.key + ")");
                         }
-                    }
-
-                    if (Objects.equals(first, other.next)) {
-                        LOG.log(Level.SEVERE, "This is the bug! Should not happen: " + first + " - " + other + " ?");
-                    }
-
-                    if (other.next != null && (other.next.equals(first) || other.key.blockId == first.key.blockId)) {
-                        System.out.println("ERRORE");
                     }
 
                     /* Update next reference */

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -97,6 +97,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             }
         }
 
+        @SuppressWarnings("unchecked")
         public static final <X extends Comparable<X>> BlockStartKey<X> valueOf(X minKey, long segmentId) {
             if (minKey == null) {
                 if (segmentId != HEAD_KEY.blockId) {
@@ -270,9 +271,9 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
         }
 
         /** Construtor for split operations */
-        private Block(BlockRangeIndex<KEY,VAL> index, KEY minKey, NavigableMap<KEY, List<VAL>> values, long size, Block<KEY,VAL> next) {
+        private Block(BlockRangeIndex<KEY,VAL> index, BlockStartKey<KEY> key, NavigableMap<KEY, List<VAL>> values, long size, Block<KEY,VAL> next) {
             this.index = index;
-            this.key = BlockStartKey.valueOf(minKey, index.currentBlockId.incrementAndGet());
+            this.key = key;
 
             this.values = values;
             this.size = size;
@@ -570,7 +571,64 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
             KEY newOtherMinKey = otherValues.firstKey();
 
-            Block<KEY,VAL> newblock = new Block<>(index, newOtherMinKey, otherValues, otherSize, next);
+            long newBlockId = index.currentBlockId.incrementAndGet();
+
+            /*
+             * For right sorting reasons block id must be negative if the splitting key is greater or equals
+             * than the current min key. Otherwise, when splitting a block with the same splitting key and min
+             * key the block id must be positive.
+             *
+             * Positive or negative means: negative: the new block must precede any other block with the same
+             * "new" min key that could exists positive: the new block must follow the current splitting bloc
+             * (this case is done right because we add elements in the greater block possible: if we have more
+             * blocks with the same min key we use the last one).
+             */
+            /**
+             * <pre>
+             *        +-----------------+    +-----------------+
+             *        | MinKey: 1       |    | MinKey: 3       |
+             * ... -> | BlockId: 10     | -> | BlockId: 11     | -> ...
+             *        | Keys: 1, 2, 2   |    | Keys: 3, 4      |
+             *        | Occupancy: 100% |    | Occupancy: 66%  |
+             *        +-----------------+    +-----------------+
+             *
+             * Adding key 2 with next block id 12: create a new block (2,-12)
+             *
+             *        +-----------------+    +-----------------+    +-----------------+
+             *        | MinKey: 1       |    | MinKey: 2       |    | MinKey: 3       |
+             * ... -> | BlockId: 10     | -> | BlockId: -12    | -> | BlockId: 11     | -> ...
+             *        | Keys: 1, 2      |    | Keys: 2, 2      |    | Keys: 3, 4      |
+             *        | Occupancy: 66%  |    | Occupancy: 66%  |    | Occupancy: 66%  |
+             *        +-----------------+    +-----------------+    +-----------------+
+             *
+             * Adding key 2 with next block id 13: add to block (2,-12)
+             *
+             *        +-----------------+    +-----------------+    +-----------------+
+             *        | MinKey: 1       |    | MinKey: 2       |    | MinKey: 3       |
+             * ... -> | BlockId: 10     | -> | BlockId: -12    | -> | BlockId: 11     | -> ...
+             *        | Keys: 1, 2      |    | Keys: 2, 2, 2   |    | Keys: 3, 4      |
+             *        | Occupancy: 66%  |    | Occupancy: 100% |    | Occupancy: 66%  |
+             *        +-----------------+    +-----------------+    +-----------------+
+             *
+             * Adding key 2 with next block id 13: create a new block (2,13)
+             *
+             *        +-----------------+    +-----------------+    +-----------------+    +-----------------+
+             *        | MinKey: 1       |    | MinKey: 2       |    | MinKey: 2       |    | MinKey: 3       |
+             * ... -> | BlockId: 10     | -> | BlockId: -12    | -> | BlockId: 13     | -> | BlockId: 11     | -> ...
+             *        | Keys: 1, 2      |    | Keys: 2, 2      |    | Keys: 2, 2      |    | Keys: 3, 4      |
+             *        | Occupancy: 66%  |    | Occupancy: 66%  |    | Occupancy: 66%  |    | Occupancy: 66%  |
+             *        +-----------------+    +-----------------+    +-----------------+    +-----------------+
+             *
+             * Notice than being the splitting (2,-12) permits to sort in the right order with the new block (2,13).
+             * The same thing would have happened if the block (1,10) was the HEAD block instead (just it doesn't have
+             * a min key).
+             * </pre>
+             */
+            if (key == BlockStartKey.HEAD_KEY || !key.minKey.equals(newOtherMinKey)) {
+                newBlockId = -newBlockId;
+            }
+
+            Block<KEY,VAL> newblock = new Block<>(index, BlockStartKey.valueOf(newOtherMinKey, newBlockId), otherValues, otherSize, next);
 
             this.next = newblock;
             this.size = mySize;
@@ -776,6 +834,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                     if (Objects.equals(first, other.next)) {
                         LOG.log(Level.SEVERE, "this is the bug ! should not happen: "+first+" - "+other+" ?");
                     }
+
                     /* Update next reference */
                     first.next = other.next;
 
@@ -986,7 +1045,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
     public void delete(K key, V value) {
 
         /* Lookup from the first possible block that could contain the value*/
-        final BlockStartKey<K> lookUp = BlockStartKey.valueOf(key, -1L);
+        final BlockStartKey<K> lookUp = BlockStartKey.valueOf(key, Long.MIN_VALUE);
 
         final DeleteState<K,V> state = new DeleteState<>();
 
@@ -1003,7 +1062,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
         if (firstKey != null ) {
             /* Lookup from the first possible block that could contain the first lookup key*/
-            final BlockStartKey<K> lookUp = BlockStartKey.valueOf(firstKey, -1L);
+            final BlockStartKey<K> lookUp = BlockStartKey.valueOf(firstKey, Long.MIN_VALUE);
 
             /* There is always at least the head block! */
             state.next = blocks.floorEntry(lookUp).getValue();
@@ -1066,7 +1125,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                 } else {
                     if (next != null) {
                         throw new DataStorageManagerException(
-                                "Wron next block, expected " + next.key.blockId + " but nothing found");
+                                "Wrong next block, expected " + next.key.blockId + " but nothing found");
                     }
 
                 }

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -245,6 +245,10 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             this.size = size;
             this.next = next;
 
+            if (next != null && (next.key.equals(key) || next.key.blockId == key.blockId)) {
+                System.out.println("ERRORE");
+            }
+
             this.loaded = false;
             this.dirty = false;
             this.pageId = pageId;
@@ -278,6 +282,10 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             this.values = values;
             this.size = size;
             this.next = next;
+
+            if (next != null && (next.key.equals(key) || next.key.blockId == key.blockId)) {
+                System.out.println("ERRORE");
+            }
 
             this.loaded = true;
             this.dirty = true;
@@ -628,6 +636,8 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                 newBlockId = -newBlockId;
             }
 
+            System.out.println("split newBlockId " + newBlockId + " key " + key + " newOtherMinKey " + newOtherMinKey);
+
             Block<KEY,VAL> newblock = new Block<>(index, BlockStartKey.valueOf(newOtherMinKey, newBlockId), otherValues, otherSize, next);
 
             this.next = newblock;
@@ -832,7 +842,11 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                     }
 
                     if (Objects.equals(first, other.next)) {
-                        LOG.log(Level.SEVERE, "this is the bug ! should not happen: "+first+" - "+other+" ?");
+                        LOG.log(Level.SEVERE, "This is the bug! Should not happen: " + first + " - " + other + " ?");
+                    }
+
+                    if (other.next != null && (other.next.equals(first) || other.key.blockId == first.key.blockId)) {
+                        System.out.println("ERRORE");
                     }
 
                     /* Update next reference */
@@ -1135,7 +1149,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                 next = new Block<>(this, key, blockData.size, blockData.pageId, next);
                 blocks.put(key, next);
 
-                currentBlockId.accumulateAndGet(next.key.blockId, EnsureLongIncrementAccumulator.INSTANCE);
+                currentBlockId.accumulateAndGet(Math.abs(next.key.blockId), EnsureLongIncrementAccumulator.INSTANCE);
             }
         }
 
@@ -1172,6 +1186,10 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
     ConcurrentNavigableMap<BlockStartKey<K>, Block<K,V>> getBlocks() {
         return blocks;
+    }
+
+    long getCurrentBlockId() {
+        return currentBlockId.get();
     }
 
 }

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
@@ -58,15 +58,18 @@ public class BlockRangeIndexMetadata<K extends Comparable<K>> {
         final long blockId;
         final long size;
         final long pageId;
-        Long nextBlockId;
+        final Long nextBlockId;
 
-        public BlockMetadata(K firstKey, long blockId, long size, long pageId, Long nextBlockId) {
+        BlockMetadata(K firstKey, long blockId, long size, long pageId, Long nextBlockId) {
 
             this.firstKey = firstKey;
             this.blockId = blockId;
             this.size = size;
             this.pageId = pageId;
             this.nextBlockId = nextBlockId;
+            if (nextBlockId != null && nextBlockId == blockId) {
+                throw new IllegalStateException("I cannot be the successor of myself ! told block "+blockId);
+            }
 
             headBlock = firstKey == null;
         }

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndexMetadata.java
@@ -67,8 +67,9 @@ public class BlockRangeIndexMetadata<K extends Comparable<K>> {
             this.size = size;
             this.pageId = pageId;
             this.nextBlockId = nextBlockId;
+
             if (nextBlockId != null && nextBlockId == blockId) {
-                throw new IllegalStateException("I cannot be the successor of myself ! told block "+blockId);
+                throw new IllegalStateException("I cannot be the successor of myself! BlockId " + blockId);
             }
 
             headBlock = firstKey == null;

--- a/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexTest.java
@@ -373,7 +373,7 @@ public class BlockRangeIndexTest {
         int numCheckpoints = 0;
         int i = 0;
         try {
-            for (i = 0; i < 1000000; i++) {
+            for (i = 0; i < 60; i++) {
                 byte[] s = new byte[10];
                 random.nextBytes(s);
                 index.put(Sized.valueOf(random.nextInt(200)), Sized.valueOf(new String(s, "ASCII")));

--- a/herddb-utils/src/main/java/herddb/core/RandomPageReplacementPolicy.java
+++ b/herddb-utils/src/main/java/herddb/core/RandomPageReplacementPolicy.java
@@ -62,7 +62,7 @@ public class RandomPageReplacementPolicy implements PageReplacementPolicy {
     public PlainMetadata add(Page<?> page) {
         final PlainMetadata metadata = new PlainMetadata(page);
         page.metadata = metadata;
-        lock.lock();       
+        lock.lock();
         try {
             int count = positions.size();
             if (count < pages.length) {

--- a/herddb-utils/src/main/java/herddb/core/RandomPageReplacementPolicy.java
+++ b/herddb-utils/src/main/java/herddb/core/RandomPageReplacementPolicy.java
@@ -40,7 +40,7 @@ public class RandomPageReplacementPolicy implements PageReplacementPolicy {
     private final PlainMetadata[] pages;
     private final Map<PlainMetadata, Integer> positions;
 
-    private final Random random = new Random();
+    private final Random random;
 
     /**
      * Modification lock
@@ -48,6 +48,11 @@ public class RandomPageReplacementPolicy implements PageReplacementPolicy {
     private final Lock lock = new ReentrantLock();
 
     public RandomPageReplacementPolicy(int size) {
+        this(size, new Random());
+    }
+
+    public RandomPageReplacementPolicy(int size, Random random) {
+        this.random = random;
         pages = new PlainMetadata[size];
 
         positions = new HashMap<>(size);


### PR DESCRIPTION
Due to a wrong assumption, ordering between blocks tree and blocks next relationship differs when splitting a block and the split key is equals to the next block min key. When traversing blocks tree the old one comes before the new (wrong!) but following nex relationship it follow in the right way.
Due to this misbehaviour can even happens that after a checkpoint or node merges a node next elements is itself (which is deeply wrong)

-----------------------------------------------------------

@diegosalvi  I have created a reproducer for the problem about BRIN.
Now finding a fix should be easier

The test is using a fixed seed for the Random instance so the behaviour is 100% determistic. no need for concurrency