### PR TITLE
Fix javadoc configuration and upgrade plugins

### DIFF
--- a/herddb-ui/pom.xml
+++ b/herddb-ui/pom.xml
@@ -8,8 +8,8 @@
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    
-    
+
+
     <artifactId>herddb-ui</artifactId>
     <packaging>war</packaging>
     <name>HerdDB UI</name>
@@ -17,9 +17,9 @@
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        
+
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -48,33 +48,24 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>                   
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.1.0</version>
-                
+                <version>3.2.3</version>
+
                 <executions>
                     <execution>
                         <id>create-war-no-libs</id>
                         <goals>
-                            <goal>war</goal>                            
+                            <goal>war</goal>
                         </goals>
                         <configuration>
-                            <packagingExcludes>WEB-INF/lib/*.jar,WEB-INF/classes/**/*</packagingExcludes>                            
+                            <packagingExcludes>WEB-INF/lib/*.jar,WEB-INF/classes/**/*</packagingExcludes>
                             <attachClasses>true</attachClasses>
                             <classifier>war-no-libs</classifier>
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>  
-                        
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -627,6 +627,14 @@
                             <artifactId>maven-jar-plugin</artifactId>
                             <version>3.1.2</version>
                         </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <configuration>
+                            <detectJavaApiLink>false</detectJavaApiLink>
+                        </configuration>
+                    </plugin>
                     </plugins>
                 </pluginManagement>
                 <plugins>
@@ -645,7 +653,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.2</version>
+                        <version>0.8.4</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -673,7 +681,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.21.0</version>
+                        <version>2.22.2</version>
                         <configuration>
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
@@ -685,7 +693,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.6.0</version>
+                        <version>3.8.1</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
                         </configuration>
@@ -693,7 +701,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-resources-plugin</artifactId>
-                        <version>2.7</version>
+                        <version>3.1.0</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
                         </configuration>


### PR DESCRIPTION
This change cleans up javadoc plugin configuration and it makes easier the release to dev.majordodo.org repository, as it that case we are not activating the 'ossrh' profile, that is tweaking somehow the build and the javadoc tool does not complaint.