### PR TITLE
Remove useless spammy debug log

### DIFF
--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -531,10 +531,10 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         long scannerId = PduCodec.CloseScanner.readScannerId(message);
         ServerSideScannerPeer removed = scanners.remove(scannerId);
         if (removed != null) {
-            LOGGER.log(Level.SEVERE, "remove scanner {0} as requested by client", scannerId);
+            if (LOGGER.isLoggable(Level.FINER)) {
+               LOGGER.log(Level.FINER, "remove scanner {0} as requested by client", scannerId);
+            }
             removed.clientClose();
-        } else {
-            LOGGER.log(Level.SEVERE, "cannot remove scanner {0} as requested by client", scannerId);
         }
     }
 


### PR DESCRIPTION
Remove log like the lines below, it is normal that the scanner is removed automatically as soon as the client receives the last packet. 
Those lines were introduced during development and they was not removed by mistake.
We should cherry pick to 0.11.0 branch as those log is very verbose and it creates huge logs.

> 19-08-22-08-33-13       herddb.server.ServerSideConnectionPeer Aug 22, 2019 8:33:13 AM herddb.server.ServerSideConnectionPeer handleCloseScanner
> SEVERE: cannot remove scanner 820,397 as requested by client
> 
> 19-08-22-08-33-13       herddb.server.ServerSideConnectionPeer Aug 22, 2019 8:33:13 AM herddb.server.ServerSideConnectionPeer handleCloseScanner
> SEVERE: cannot remove scanner 821,545 as requested by client
> 
> 19-08-22-08-33-13       herddb.server.ServerSideConnectionPeer Aug 22, 2019 8:33:13 AM herddb.server.ServerSideConnectionPeer handleCloseScanner
> SEVERE: cannot remove scanner 821,546 as requested by client