### PR TITLE
Fix fillbuffer timeout to respect configured client.timeout

### DIFF
--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -905,7 +905,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             try {
                 long requestId = channel.generateRequestId();
                 ByteBuf message = PduCodec.FetchScannerData.write(requestId, scannerId, fetchSize);
-                result = channel.sendMessageWithPduReply(requestId, message, 10000);
+                result = channel.sendMessageWithPduReply(requestId, message, timeout);
 
                 //LOGGER.log(Level.SEVERE, "fillBuffer result " + result);
                 if (result.type == Pdu.TYPE_ERROR) {


### PR DESCRIPTION
Fix fillBuffer method in RoutedClientSideConnection to use configured timeout instead a fixed unconfigurable time of 10 seconds.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
