### PR TITLE
Fix transactions refcounts for aggregating queries

### DIFF
--- a/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
+++ b/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
@@ -25,6 +25,7 @@ import herddb.model.DataScannerException;
 import herddb.model.Transaction;
 import herddb.utils.DataAccessor;
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Simple data scanner on a in memory MaterializedRecordSet
@@ -37,6 +38,7 @@ public class SimpleDataScanner extends DataScanner {
     private Iterator<DataAccessor> iterator;
     private DataAccessor next;
     private boolean finished;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     public SimpleDataScanner(Transaction transaction, MaterializedRecordSet recordSet) {
         super(transaction, recordSet.fieldNames, recordSet.columns);
@@ -49,6 +51,11 @@ public class SimpleDataScanner extends DataScanner {
 
     @Override
     public void close() throws DataScannerException {
+        if (closed.compareAndSet(false, true)) {
+            if (transaction != null) {
+                transaction.decreaseRefCount();
+            }
+        }
         finished = true;
         try {
             recordSet.close();

--- a/herddb-core/src/main/java/herddb/model/DataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/DataScanner.java
@@ -41,7 +41,7 @@ public abstract class DataScanner implements AutoCloseable {
 
     private final Column[] schema;
     private final String[] fieldNames;
-    public Transaction transaction; // no final    
+    public Transaction transaction; // no final
 
     public DataScanner(Transaction transaction, String[] fieldNames, Column[] schema) {
         this.schema = schema;
@@ -82,7 +82,7 @@ public abstract class DataScanner implements AutoCloseable {
     }
 
     @Override
-    public void close() throws DataScannerException {       
+    public void close() throws DataScannerException {
     }
 
     /**

--- a/herddb-core/src/main/java/herddb/model/DataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/DataScanner.java
@@ -25,6 +25,7 @@ import herddb.core.HerdDBInternalException;
 import herddb.utils.DataAccessor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.apache.calcite.linq4j.AbstractEnumerable;
 import org.apache.calcite.linq4j.Enumerable;
@@ -40,7 +41,7 @@ public abstract class DataScanner implements AutoCloseable {
 
     private final Column[] schema;
     private final String[] fieldNames;
-    public Transaction transaction; // no final
+    public Transaction transaction; // no final    
 
     public DataScanner(Transaction transaction, String[] fieldNames, Column[] schema) {
         this.schema = schema;
@@ -81,10 +82,7 @@ public abstract class DataScanner implements AutoCloseable {
     }
 
     @Override
-    public void close() throws DataScannerException {
-        if (transaction != null) {
-            transaction.decreaseRefCount();
-        }
+    public void close() throws DataScannerException {       
     }
 
     /**

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -88,16 +88,21 @@ public class Transaction {
      */
     public void increaseRefcount() {
         refCount.incrementAndGet();
-//        new Exception("START tx "+transactionId+" now "+refCount).printStackTrace();
+        // new Exception("START tx "+transactionId+" now "+refCount).printStackTrace();
     }
 
     public void decreaseRefCount() {
+        // new Exception("END tx "+transactionId+" now "+refCount).printStackTrace();
         int res = refCount.decrementAndGet();
         if (res < 0) {
             LOG.log(Level.SEVERE, "transaction {0} "
                             + "on tablespace {1} "
                             + "has {2} pending activities",
                     new Object[]{transactionId, tableSpace, res});
+            throw new IllegalStateException(String.format("transaction {0} "
+                            + "on tablespace {1} "
+                            + "has {2} pending activities", transactionId, tableSpace, res));
+            
         }
 //         new Exception("END tsx "+transactionId+" now "+res).printStackTrace();
     }

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -120,7 +120,7 @@ public class AggregateOp implements PlannerOp {
                 StatementEvaluationContext context,
                 RecordSetFactory recordSetFactory
         ) throws StatementExecutionException {
-            super(wrapped.getTransaction(), fieldnames, columns);
+            super(wrapped.getTransaction(), fieldnames, columns);           
             this.wrapped = wrapped;
             this.context = context;
             this.recordSetFactory = recordSetFactory;
@@ -202,7 +202,7 @@ public class AggregateOp implements PlannerOp {
                         Tuple tuple = new Tuple(fieldnames, values);
                         results.add(tuple);
                     }
-                    results.writeFinished();
+                    results.writeFinished();                    
                     aggregatedScanner = new SimpleDataScanner(wrapped.getTransaction(), results);
                 } else {
                     Group group = createGroup();
@@ -222,7 +222,7 @@ public class AggregateOp implements PlannerOp {
                     MaterializedRecordSet results = recordSetFactory
                             .createFixedSizeRecordSet(1, getFieldNames(), getSchema());
                     results.add(tuple);
-                    results.writeFinished();
+                    results.writeFinished();                   
                     aggregatedScanner = new SimpleDataScanner(wrapped.getTransaction(), results);
                 }
             } catch (StatementExecutionException err) {
@@ -268,7 +268,7 @@ public class AggregateOp implements PlannerOp {
             wrapped.close();
             if (aggregatedScanner != null) {
                 aggregatedScanner.close();
-            }
+            }            
         }
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
@@ -97,6 +97,9 @@ public class UnionAllOp implements PlannerOp {
             } else if (index == inputs.size() - 1) {
                 next = null;
             } else {
+                if (current != null) {
+                    current.close();
+                }
                 index++;
                 ScanResult execute = (ScanResult) inputs
                         .get(index).execute(tableSpaceManager,
@@ -120,6 +123,11 @@ public class UnionAllOp implements PlannerOp {
             final DataAccessor current = next;
             fetchNext();
             return current;
+        }
+
+        @Override
+        public void close() throws DataScannerException {
+            current.close();
         }
 
     }

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -527,6 +527,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
     private void handleCloseScanner(Pdu message, Channel channel) {
         long scannerId = PduCodec.CloseScanner.readScannerId(message);
         ServerSideScannerPeer removed = scanners.remove(scannerId);
+        LOGGER.log(Level.SEVERE,"closeScanner "+scannerId+" "+removed+" from "+this);
         if (removed != null) {
             if (LOGGER.isLoggable(Level.FINER)) {
                 LOGGER.log(Level.FINER, "remove scanner {0} as requested by client", scannerId);

--- a/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
@@ -1,23 +1,22 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.server;
 
 import static org.junit.Assert.assertEquals;
@@ -55,31 +54,41 @@ public class SimpleClientScanTest {
             server.start();
             server.waitForStandaloneBoot();
             try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
-                 HDBConnection connection = client.openConnection()) {
+                    HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
 
                 long resultCreateTable = connection.executeUpdate(TableSpace.DEFAULT,
-                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true, Collections.emptyList()).updateCount;
+                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true,
+                        Collections.emptyList()).updateCount;
                 Assert.assertEquals(1, resultCreateTable);
 
                 for (int i = 0; i < 99; i++) {
-                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.asList("test_" + i, 1, 2)).updateCount);
+                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT,
+                            "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.
+                                    asList("test_" + i, 1, 2)).updateCount);
                 }
 
-                assertEquals(99, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(99, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                        emptyList(), 0, 0, 10).consume().size());
 
                 // maxRows
-                assertEquals(17, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), 0, 17, 10).consume().size());
+                assertEquals(17, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                        emptyList(), 0, 17, 10).consume().size());
 
                 // empty result set
-                assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='none'", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(0, connection.
+                        executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='none'", true, Collections.
+                                emptyList(), 0, 0, 10).consume().size());
 
                 // single fetch result test
-                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='test_1'", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='test_1'",
+                        true, Collections.emptyList(), 0, 0, 10).consume().size());
 
                 // agregation in transaction, this is trickier than what you can think
                 long tx = connection.beginTransaction(TableSpace.DEFAULT);
-                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT count(*) FROM mytable WHERE id='test_1'", true, Collections.emptyList(), tx, 0, 10).consume().size());
+                assertEquals(1, connection.executeScan(TableSpace.DEFAULT,
+                        "SELECT count(*) FROM mytable WHERE id='test_1'", true, Collections.emptyList(), tx, 0, 10).
+                        consume().size());
                 connection.rollbackTransaction(TableSpace.DEFAULT, tx);
 
             }
@@ -95,15 +104,18 @@ public class SimpleClientScanTest {
             ClientConfiguration clientConfiguration = new ClientConfiguration(folder.newFolder().toPath());
             clientConfiguration.set(ClientConfiguration.PROPERTY_MAX_CONNECTIONS_PER_SERVER, 10); // more than one socket
             try (HDBClient client = new HDBClient(clientConfiguration);
-                 HDBConnection connection = client.openConnection()) {
+                    HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
 
                 long resultCreateTable = connection.executeUpdate(TableSpace.DEFAULT,
-                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true, Collections.emptyList()).updateCount;
+                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true,
+                        Collections.emptyList()).updateCount;
                 Assert.assertEquals(1, resultCreateTable);
 
                 for (int i = 0; i < 99; i++) {
-                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.asList("test_" + i, 1, 2)).updateCount);
+                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT,
+                            "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.
+                                    asList("test_" + i, 1, 2)).updateCount);
                 }
 
                 checkUseOnlyOneSocket(connection, server);
@@ -122,6 +134,14 @@ public class SimpleClientScanTest {
                 checkNoScannersOnTheServer(server);
 
                 checkCloseResultSetNotFullyScanned(connection, server, false);
+
+                checkNoScannersOnTheServer(server);
+
+                checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(connection, server, true);
+
+                checkNoScannersOnTheServer(server);
+
+                checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(connection, server, false);
 
                 checkNoScannersOnTheServer(server);
 
@@ -152,7 +172,8 @@ public class SimpleClientScanTest {
                 // scan with fetchSize = 1, we will have 100 chunks
                 ServerSideConnectionPeer peerWithScanner = null;
                 long tx = withTransaction ? primary.beginTransaction(TableSpace.DEFAULT) : 0;
-                try (ScanResultSet scan = connection2.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), tx, 0, 1)) {
+                try (ScanResultSet scan = connection2.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true,
+                        Collections.emptyList(), tx, 0, 1)) {
                     assertTrue(scan.hasNext());
                     System.out.println("next:" + scan.next());
 
@@ -189,7 +210,8 @@ public class SimpleClientScanTest {
     private void checkUseOnlyOneSocket(final HDBConnection connection, final Server server) throws HDBException, ClientSideMetadataProviderException, InterruptedException {
         // scan with fetchSize = 1, we will have 100 chunks
         ServerSideConnectionPeer peerWithScanner = null;
-        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), 0, 0, 1)) {
+        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                emptyList(), 0, 0, 1)) {
             while (scan.hasNext()) {
                 System.out.println("next:" + scan.next());
 
@@ -217,7 +239,8 @@ public class SimpleClientScanTest {
         // scan with fetchSize = 1, we will have 100 chunks
         ServerSideConnectionPeer peerWithScanner = null;
         int chunks = 0;
-        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), tx, 0, 1)) {
+        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                emptyList(), tx, 0, 1)) {
 
             while (scan.hasNext()) {
                 System.out.println("next:" + scan.next());
@@ -247,36 +270,37 @@ public class SimpleClientScanTest {
         }
     }
 
-    private void checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(final HDBConnection connection, final Server server, boolean withTransaction) throws HDBException, ClientSideMetadataProviderException, InterruptedException {
+    private void checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(final HDBConnection connection,
+                                                                                 final Server server,
+                                                                                 boolean withTransaction) throws HDBException, ClientSideMetadataProviderException, InterruptedException {
         long tx = withTransaction ? connection.beginTransaction(TableSpace.DEFAULT) : 0;
-// scan with fetchSize = 1, we will have 100 chunks
+
         ServerSideConnectionPeer peerWithScanner = null;
-        int chunks = 0;
-        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT count(*) FROM mytable", true, Collections.emptyList(), tx, 0, 1)) {
 
-            while (scan.hasNext()) {
-                System.out.println("next:" + scan.next());
+        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT,
+                "SELECT count(*) FROM mytable "
+                + "UNION ALL "
+                + "SELECT count(*) FROM mytable", true, Collections.emptyList(), tx,
+                0, 1)) {
 
-                for (ServerSideConnectionPeer peer : server.getConnections().values()) {
-                    System.out.println("peer " + peer + " scanners: " + peer.getScanners());
-                    if (!peer.getScanners().isEmpty()) {
-                        if (peerWithScanner != null && peerWithScanner != peer) {
-                            fail("Found more then one peer with an open scanner");
-                        }
-                        peerWithScanner = peer;
-                        assertEquals(1, peer.getScanners().size());
+            assertTrue(scan.hasNext());
+            System.out.println("next:" + scan.next());
+
+            for (ServerSideConnectionPeer peer : server.getConnections().values()) {
+                System.out.println("peer " + peer + " scanners: " + peer.getScanners());
+                if (!peer.getScanners().isEmpty()) {
+                    if (peerWithScanner != null && peerWithScanner != peer) {
+                        fail("Found more then one peer with an open scanner");
                     }
+                    peerWithScanner = peer;
+                    assertEquals(1, peer.getScanners().size());
                 }
-                assertNotNull(peerWithScanner);
-
-                if (chunks++ >= 5) {
-                    break;
-                }
-
             }
+            assertNotNull(peerWithScanner);
+
         }
         assertNotNull(peerWithScanner);
-        assertEquals(6, chunks);
+
         if (withTransaction) {
             connection.rollbackTransaction(TableSpace.DEFAULT, tx);
         }

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
@@ -22,6 +22,7 @@ package herddb.jdbc;
 
 import static herddb.model.TransactionContext.AUTOTRANSACTION_ID;
 import static herddb.model.TransactionContext.NOTRANSACTION_ID;
+
 import herddb.client.ClientSideMetadataProviderException;
 import herddb.client.HDBConnection;
 import herddb.client.HDBException;
@@ -47,6 +48,7 @@ import java.sql.Struct;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,6 +66,7 @@ public class HerdDBConnection implements java.sql.Connection {
     private String tableSpace;
     private final BasicHerdDBDataSource datasource;
     private boolean closed;
+    private ConcurrentHashMap<Long, HerdDBPreparedStatement> openStatements = new ConcurrentHashMap<>();
 
     HerdDBConnection(BasicHerdDBDataSource datasource, HDBConnection connection, String defaultTablespace) throws SQLException {
         if (connection == null) {

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
@@ -48,7 +48,6 @@ import java.sql.Struct;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -66,7 +65,6 @@ public class HerdDBConnection implements java.sql.Connection {
     private String tableSpace;
     private final BasicHerdDBDataSource datasource;
     private boolean closed;
-    private ConcurrentHashMap<Long, HerdDBPreparedStatement> openStatements = new ConcurrentHashMap<>();
 
     HerdDBConnection(BasicHerdDBDataSource datasource, HDBConnection connection, String defaultTablespace) throws SQLException {
         if (connection == null) {


### PR DESCRIPTION
Fix ref count during aggregations and in general on Scanners.

SimpleDataScanner and StreamingDataScanner are the root holders of references to the Transaction.
Fix refcount and close() methods of every DataScanner implementation.
Prevent "double release" in root DataScanners
