### PR TITLE
Fix transactions refcounts for aggregating queries

### DIFF
--- a/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
+++ b/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
@@ -25,6 +25,7 @@ import herddb.model.DataScannerException;
 import herddb.model.Transaction;
 import herddb.utils.DataAccessor;
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Simple data scanner on a in memory MaterializedRecordSet
@@ -37,6 +38,7 @@ public class SimpleDataScanner extends DataScanner {
     private Iterator<DataAccessor> iterator;
     private DataAccessor next;
     private boolean finished;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     public SimpleDataScanner(Transaction transaction, MaterializedRecordSet recordSet) {
         super(transaction, recordSet.fieldNames, recordSet.columns);
@@ -49,6 +51,11 @@ public class SimpleDataScanner extends DataScanner {
 
     @Override
     public void close() throws DataScannerException {
+        if (closed.compareAndSet(false, true)) {
+            if (transaction != null) {
+                transaction.decreaseRefCount();
+            }
+        }
         finished = true;
         try {
             recordSet.close();

--- a/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
+++ b/herddb-core/src/main/java/herddb/core/SimpleDataScanner.java
@@ -55,12 +55,12 @@ public class SimpleDataScanner extends DataScanner {
             if (transaction != null) {
                 transaction.decreaseRefCount();
             }
-        }
-        finished = true;
-        try {
-            recordSet.close();
-        } finally {
-            super.close();
+            finished = true;
+            try {
+                recordSet.close();
+            } finally {
+                super.close();
+            }
         }
     }
 

--- a/herddb-core/src/main/java/herddb/core/StreamDataScanner.java
+++ b/herddb-core/src/main/java/herddb/core/StreamDataScanner.java
@@ -26,6 +26,7 @@ import herddb.model.DataScannerException;
 import herddb.model.Transaction;
 import herddb.utils.DataAccessor;
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 /**
@@ -37,6 +38,7 @@ class StreamDataScanner extends DataScanner {
 
     private final Iterator<DataAccessor> wrapped;
     private DataAccessor next;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     public StreamDataScanner(
             Transaction transaction, String[] fieldNames, Column[] schema,
@@ -72,7 +74,11 @@ class StreamDataScanner extends DataScanner {
 
     @Override
     public void close() throws DataScannerException {
+        if (closed.compareAndSet(false, true)) {
+            if (transaction != null) {
+                transaction.decreaseRefCount();
+            }
+        }
         super.close();
     }
-
 }

--- a/herddb-core/src/main/java/herddb/core/StreamDataScanner.java
+++ b/herddb-core/src/main/java/herddb/core/StreamDataScanner.java
@@ -78,7 +78,7 @@ class StreamDataScanner extends DataScanner {
             if (transaction != null) {
                 transaction.decreaseRefCount();
             }
+            super.close();
         }
-        super.close();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/DataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/DataScanner.java
@@ -82,9 +82,6 @@ public abstract class DataScanner implements AutoCloseable {
 
     @Override
     public void close() throws DataScannerException {
-        if (transaction != null) {
-            transaction.decreaseRefCount();
-        }
     }
 
     /**

--- a/herddb-core/src/main/java/herddb/model/Transaction.java
+++ b/herddb-core/src/main/java/herddb/model/Transaction.java
@@ -88,16 +88,21 @@ public class Transaction {
      */
     public void increaseRefcount() {
         refCount.incrementAndGet();
-//        new Exception("START tx "+transactionId+" now "+refCount).printStackTrace();
+        // new Exception("START tx "+transactionId+" now "+refCount).printStackTrace();
     }
 
     public void decreaseRefCount() {
+        // new Exception("END tx "+transactionId+" now "+refCount).printStackTrace();
         int res = refCount.decrementAndGet();
         if (res < 0) {
             LOG.log(Level.SEVERE, "transaction {0} "
                             + "on tablespace {1} "
                             + "has {2} pending activities",
                     new Object[]{transactionId, tableSpace, res});
+            throw new IllegalStateException(String.format("transaction {0} "
+                            + "on tablespace {1} "
+                            + "has {2} pending activities", transactionId, tableSpace, res));
+
         }
 //         new Exception("END tsx "+transactionId+" now "+res).printStackTrace();
     }

--- a/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
@@ -97,6 +97,9 @@ public class UnionAllOp implements PlannerOp {
             } else if (index == inputs.size() - 1) {
                 next = null;
             } else {
+                if (current != null) {
+                    current.close();
+                }
                 index++;
                 ScanResult execute = (ScanResult) inputs
                         .get(index).execute(tableSpaceManager,
@@ -120,6 +123,11 @@ public class UnionAllOp implements PlannerOp {
             final DataAccessor current = next;
             fetchNext();
             return current;
+        }
+
+        @Override
+        public void close() throws DataScannerException {
+            current.close();
         }
 
     }

--- a/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
@@ -1,23 +1,22 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.server;
 
 import static org.junit.Assert.assertEquals;
@@ -55,31 +54,41 @@ public class SimpleClientScanTest {
             server.start();
             server.waitForStandaloneBoot();
             try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
-                 HDBConnection connection = client.openConnection()) {
+                    HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
 
                 long resultCreateTable = connection.executeUpdate(TableSpace.DEFAULT,
-                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true, Collections.emptyList()).updateCount;
+                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true,
+                        Collections.emptyList()).updateCount;
                 Assert.assertEquals(1, resultCreateTable);
 
                 for (int i = 0; i < 99; i++) {
-                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.asList("test_" + i, 1, 2)).updateCount);
+                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT,
+                            "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.
+                                    asList("test_" + i, 1, 2)).updateCount);
                 }
 
-                assertEquals(99, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(99, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                        emptyList(), 0, 0, 10).consume().size());
 
                 // maxRows
-                assertEquals(17, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), 0, 17, 10).consume().size());
+                assertEquals(17, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                        emptyList(), 0, 17, 10).consume().size());
 
                 // empty result set
-                assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='none'", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(0, connection.
+                        executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='none'", true, Collections.
+                                emptyList(), 0, 0, 10).consume().size());
 
                 // single fetch result test
-                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='test_1'", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='test_1'",
+                        true, Collections.emptyList(), 0, 0, 10).consume().size());
 
                 // agregation in transaction, this is trickier than what you can think
                 long tx = connection.beginTransaction(TableSpace.DEFAULT);
-                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT count(*) FROM mytable WHERE id='test_1'", true, Collections.emptyList(), tx, 0, 10).consume().size());
+                assertEquals(1, connection.executeScan(TableSpace.DEFAULT,
+                        "SELECT count(*) FROM mytable WHERE id='test_1'", true, Collections.emptyList(), tx, 0, 10).
+                        consume().size());
                 connection.rollbackTransaction(TableSpace.DEFAULT, tx);
 
             }
@@ -95,15 +104,18 @@ public class SimpleClientScanTest {
             ClientConfiguration clientConfiguration = new ClientConfiguration(folder.newFolder().toPath());
             clientConfiguration.set(ClientConfiguration.PROPERTY_MAX_CONNECTIONS_PER_SERVER, 10); // more than one socket
             try (HDBClient client = new HDBClient(clientConfiguration);
-                 HDBConnection connection = client.openConnection()) {
+                    HDBConnection connection = client.openConnection()) {
                 client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
 
                 long resultCreateTable = connection.executeUpdate(TableSpace.DEFAULT,
-                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true, Collections.emptyList()).updateCount;
+                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true,
+                        Collections.emptyList()).updateCount;
                 Assert.assertEquals(1, resultCreateTable);
 
                 for (int i = 0; i < 99; i++) {
-                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.asList("test_" + i, 1, 2)).updateCount);
+                    Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT,
+                            "INSERT INTO mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.
+                                    asList("test_" + i, 1, 2)).updateCount);
                 }
 
                 checkUseOnlyOneSocket(connection, server);
@@ -122,6 +134,14 @@ public class SimpleClientScanTest {
                 checkNoScannersOnTheServer(server);
 
                 checkCloseResultSetNotFullyScanned(connection, server, false);
+
+                checkNoScannersOnTheServer(server);
+
+                checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(connection, server, true);
+
+                checkNoScannersOnTheServer(server);
+
+                checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(connection, server, false);
 
                 checkNoScannersOnTheServer(server);
 
@@ -152,7 +172,8 @@ public class SimpleClientScanTest {
                 // scan with fetchSize = 1, we will have 100 chunks
                 ServerSideConnectionPeer peerWithScanner = null;
                 long tx = withTransaction ? primary.beginTransaction(TableSpace.DEFAULT) : 0;
-                try (ScanResultSet scan = connection2.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), tx, 0, 1)) {
+                try (ScanResultSet scan = connection2.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true,
+                        Collections.emptyList(), tx, 0, 1)) {
                     assertTrue(scan.hasNext());
                     System.out.println("next:" + scan.next());
 
@@ -189,7 +210,8 @@ public class SimpleClientScanTest {
     private void checkUseOnlyOneSocket(final HDBConnection connection, final Server server) throws HDBException, ClientSideMetadataProviderException, InterruptedException {
         // scan with fetchSize = 1, we will have 100 chunks
         ServerSideConnectionPeer peerWithScanner = null;
-        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), 0, 0, 1)) {
+        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                emptyList(), 0, 0, 1)) {
             while (scan.hasNext()) {
                 System.out.println("next:" + scan.next());
 
@@ -217,7 +239,8 @@ public class SimpleClientScanTest {
         // scan with fetchSize = 1, we will have 100 chunks
         ServerSideConnectionPeer peerWithScanner = null;
         int chunks = 0;
-        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.emptyList(), tx, 0, 1)) {
+        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
+                emptyList(), tx, 0, 1)) {
 
             while (scan.hasNext()) {
                 System.out.println("next:" + scan.next());
@@ -247,36 +270,37 @@ public class SimpleClientScanTest {
         }
     }
 
-    private void checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(final HDBConnection connection, final Server server, boolean withTransaction) throws HDBException, ClientSideMetadataProviderException, InterruptedException {
+    private void checkCloseResultSetNotFullyScannedWithTransactionAndAggregation(final HDBConnection connection,
+                                                                                 final Server server,
+                                                                                 boolean withTransaction) throws HDBException, ClientSideMetadataProviderException, InterruptedException {
         long tx = withTransaction ? connection.beginTransaction(TableSpace.DEFAULT) : 0;
-// scan with fetchSize = 1, we will have 100 chunks
+
         ServerSideConnectionPeer peerWithScanner = null;
-        int chunks = 0;
-        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT count(*) FROM mytable", true, Collections.emptyList(), tx, 0, 1)) {
 
-            while (scan.hasNext()) {
-                System.out.println("next:" + scan.next());
+        try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT,
+                "SELECT count(*) FROM mytable "
+                + "UNION ALL "
+                + "SELECT count(*) FROM mytable", true, Collections.emptyList(), tx,
+                0, 1)) {
 
-                for (ServerSideConnectionPeer peer : server.getConnections().values()) {
-                    System.out.println("peer " + peer + " scanners: " + peer.getScanners());
-                    if (!peer.getScanners().isEmpty()) {
-                        if (peerWithScanner != null && peerWithScanner != peer) {
-                            fail("Found more then one peer with an open scanner");
-                        }
-                        peerWithScanner = peer;
-                        assertEquals(1, peer.getScanners().size());
+            assertTrue(scan.hasNext());
+            System.out.println("next:" + scan.next());
+
+            for (ServerSideConnectionPeer peer : server.getConnections().values()) {
+                System.out.println("peer " + peer + " scanners: " + peer.getScanners());
+                if (!peer.getScanners().isEmpty()) {
+                    if (peerWithScanner != null && peerWithScanner != peer) {
+                        fail("Found more then one peer with an open scanner");
                     }
+                    peerWithScanner = peer;
+                    assertEquals(1, peer.getScanners().size());
                 }
-                assertNotNull(peerWithScanner);
-
-                if (chunks++ >= 5) {
-                    break;
-                }
-
             }
+            assertNotNull(peerWithScanner);
+
         }
         assertNotNull(peerWithScanner);
-        assertEquals(6, chunks);
+
         if (withTransaction) {
             connection.rollbackTransaction(TableSpace.DEFAULT, tx);
         }

--- a/herddb-jdbc/src/test/java/herddb/jdbc/SimpleScanTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/SimpleScanTest.java
@@ -1,37 +1,41 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.jdbc;
 
+import static herddb.utils.TestUtils.NOOP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import herddb.client.ClientConfiguration;
 import herddb.client.HDBClient;
+import herddb.model.TableSpace;
+import herddb.model.Transaction;
 import herddb.server.Server;
 import herddb.server.ServerConfiguration;
 import herddb.server.StaticClientSideMetadataProvider;
+import herddb.utils.TestUtils;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,13 +63,15 @@ public class SimpleScanTest {
                 try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client)) {
 
                     try (Connection con = dataSource.getConnection();
-                         Statement statement = con.createStatement()) {
-                        statement.execute("CREATE TABLE mytable (k1 string primary key, n1 int, l1 long, t1 timestamp, nu string, b1 bool, d1 double)");
+                            Statement statement = con.createStatement()) {
+                        statement.execute(
+                                "CREATE TABLE mytable (k1 string primary key, n1 int, l1 long, t1 timestamp, nu string, b1 bool, d1 double)");
 
                     }
 
                     try (Connection con = dataSource.getConnection();
-                         PreparedStatement statement = con.prepareStatement("INSERT INTO mytable(k1,n1,l1,t1,nu,b1,d1) values(?,?,?,?,?,?,?)")) {
+                            PreparedStatement statement = con.prepareStatement(
+                                    "INSERT INTO mytable(k1,n1,l1,t1,nu,b1,d1) values(?,?,?,?,?,?,?)")) {
 
                         for (int n = 0; n < 10; ++n) {
                             int i = 1;
@@ -91,7 +97,8 @@ public class SimpleScanTest {
                     try (Connection con = dataSource.getConnection()) {
 
                         // Get and projection
-                        try (PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable WHERE k1 = 'mykey_1'")) {
+                        try (PreparedStatement statement = con.prepareStatement(
+                                "SELECT n1, k1 FROM mytable WHERE k1 = 'mykey_1'")) {
                             int count = 0;
                             try (ResultSet rs = statement.executeQuery()) {
                                 while (rs.next()) {
@@ -104,7 +111,8 @@ public class SimpleScanTest {
                         }
 
                         // Scan and projection
-                        try (PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable WHERE n1 > 1")) {
+                        try (PreparedStatement statement = con.prepareStatement(
+                                "SELECT n1, k1 FROM mytable WHERE n1 > 1")) {
                             int count = 0;
                             try (ResultSet rs = statement.executeQuery()) {
                                 while (rs.next()) {
@@ -117,7 +125,8 @@ public class SimpleScanTest {
                         }
 
                         // Scan, sort and projection
-                        try (PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable WHERE n1 > 1 ORDER BY n1")) {
+                        try (PreparedStatement statement = con.prepareStatement(
+                                "SELECT n1, k1 FROM mytable WHERE n1 > 1 ORDER BY n1")) {
                             int count = 0;
                             try (ResultSet rs = statement.executeQuery()) {
                                 while (rs.next()) {
@@ -148,13 +157,13 @@ public class SimpleScanTest {
                 try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client)) {
 
                     try (Connection con = dataSource.getConnection();
-                         Statement statement = con.createStatement()) {
+                            Statement statement = con.createStatement()) {
                         statement.execute("CREATE TABLE mytable (id string)"); // no primary key
 
                     }
 
                     try (Connection con = dataSource.getConnection();
-                         PreparedStatement statement = con.prepareStatement("INSERT INTO mytable(id) values(?)")) {
+                            PreparedStatement statement = con.prepareStatement("INSERT INTO mytable(id) values(?)")) {
 
                         for (int n = 0; n < 10; ++n) {
                             int i = 1;
@@ -184,6 +193,88 @@ public class SimpleScanTest {
                         }
 
                     }
+
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCloseResultSetsOnCloseConnection() throws Exception {
+        try (Server server = new Server(new ServerConfiguration(folder.newFolder().toPath()))) {
+            server.start();
+            server.waitForStandaloneBoot();
+
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()))) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+
+                try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client)) {
+                    try (Connection con = dataSource.getConnection();
+                            Statement statement = con.createStatement()) {
+                        statement.execute(
+                                "CREATE TABLE mytable (k1 string primary key, n1 int, l1 long, t1 timestamp, nu string, b1 bool, d1 double)");
+
+                    }
+
+                    try (Connection con = dataSource.getConnection();
+                            PreparedStatement statement = con.prepareStatement(
+                                    "INSERT INTO mytable(k1,n1,l1,t1,nu,b1,d1) values(?,?,?,?,?,?,?)")) {
+
+                        for (int n = 0; n < 10; ++n) {
+                            int i = 1;
+                            statement.setString(i++, "mykey_" + n);
+                            statement.setInt(i++, n);
+                            statement.setLong(i++, n);
+                            statement.setTimestamp(i++, new java.sql.Timestamp(System.currentTimeMillis()));
+                            statement.setString(i++, null);
+                            statement.setBoolean(i++, true);
+                            statement.setDouble(i++, n + 0.5);
+
+                            statement.addBatch();
+                        }
+
+                        int[] batches = statement.executeBatch();
+                        Assert.assertEquals(10, batches.length);
+
+                        for (int batch : batches) {
+                            Assert.assertEquals(1, batch);
+                        }
+                    }
+
+                    try (Connection con = dataSource.getConnection()) {
+                        con.setAutoCommit(false);
+                        Transaction tx;
+                        try (PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable ")) {
+                            statement.setFetchSize(1);
+                            ResultSet rs = statement.executeQuery();
+                            assertTrue(rs.next());
+                            List<Transaction> transactions =
+                                    server.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTransactions();
+                            assertEquals(1, transactions.size());
+                            tx = transactions.get(0);
+                            assertEquals(1, tx.getRefCount());
+                        }
+                        // close statement -> close result set -> transaction refcount = 0
+                        // closing of scanners is non blocking, we have to wait
+                        TestUtils.waitForCondition(() -> tx.getRefCount() == 0, NOOP, 100);
+
+                    }
+
+                    Transaction tx;
+                    try (Connection con = dataSource.getConnection()) {
+                        con.setAutoCommit(false);
+                        PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable ");
+                        statement.setFetchSize(1);
+                        ResultSet rs = statement.executeQuery();
+                        assertTrue(rs.next());
+                        List<Transaction> transactions =
+                                server.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTransactions();
+                        assertEquals(1, transactions.size());
+                        tx = transactions.get(0);
+                        assertEquals(1, tx.getRefCount());
+                    }
+                    // close connection -> close statement -> close result set -> transaction refcount = 0 (and rolled back)
+                    TestUtils.waitForCondition(() -> tx.getRefCount() == 0, NOOP, 100);
 
                 }
             }

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -94,7 +94,8 @@ public interface SQLRecordPredicateFunctions {
         if (a instanceof Comparable && b instanceof Comparable && a.getClass() == b.getClass()) {
             return ((Comparable) a).compareTo(b);
         }
-        throw new IllegalArgumentException("uncompable objects " + a.getClass() + " vs " + b.getClass());
+        throw new IllegalArgumentException(
+                "uncomparable objects " + a.getClass() + " ('" + a + "') vs " + b.getClass() + " ('" + b + ")");
     }
 
     static Object add(Object a, Object b) throws IllegalArgumentException {


### PR DESCRIPTION
Fix transactions refcounts for aggregating queries
Ensure ResultSets are closed from JDBC Driver
With this patch we are now clearly stating that when you commit, rollback or close a transaction you are implicitly closing open every result set (DataScanner).
The behaviour of previous versions was undefined.
This change in particular affects only scans with more records that the fetch size, this was very unlikely to happen in the original usecase of HerdDB (only PK get/put/delete), in fact if fetchsize if greater than the number of records than all of the records are returned to the client and the DataScanner is automatically closed after sending the results to the client.


