### PR TITLE
Support CREATE TABLE IF NOT EXISTS clause

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1302,6 +1302,10 @@ public class TableSpaceManager {
         }
         try {
             if (tables.containsKey(statement.getTableDefinition().name)) {
+                if (statement.isIfExistsClause()) {
+                    return new DDLStatementExecutionResult(
+                            transaction != null ? transaction.transactionId : 0);
+                }
                 throw new TableAlreadyExistsException(statement.getTableDefinition().name);
             }
             for (Index additionalIndex : statement.getAdditionalIndexes()) {

--- a/herddb-core/src/main/java/herddb/model/commands/CreateTableStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CreateTableStatement.java
@@ -17,7 +17,6 @@
  under the License.
 
  */
-
 package herddb.model.commands;
 
 import herddb.model.DDLStatement;
@@ -35,17 +34,21 @@ public class CreateTableStatement extends DDLStatement {
 
     private final Table tableDefinition;
     private final List<Index> additionalIndexes;
+    private final boolean ifExistsClause;
 
     public CreateTableStatement(Table tableDefinition) {
-        super(tableDefinition.tablespace);
-        this.tableDefinition = tableDefinition;
-        this.additionalIndexes = Collections.emptyList();
+        this(tableDefinition, Collections.emptyList());
     }
 
     public CreateTableStatement(Table tableDefinition, List<Index> additionalIndexes) {
+        this(tableDefinition, additionalIndexes, false);
+    }
+
+    public CreateTableStatement(Table tableDefinition, List<Index> additionalIndexes, boolean ifExistsClause) {
         super(tableDefinition.tablespace);
         this.tableDefinition = tableDefinition;
         this.additionalIndexes = additionalIndexes;
+        this.ifExistsClause = ifExistsClause;
     }
 
     @Override
@@ -60,6 +63,10 @@ public class CreateTableStatement extends DDLStatement {
 
     public List<Index> getAdditionalIndexes() {
         return additionalIndexes;
+    }
+
+    public boolean isIfExistsClause() {
+        return ifExistsClause;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -281,6 +281,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
         if (tableSpace == null) {
             tableSpace = defaultTableSpace;
         }
+        final boolean isNotExsists = s.isIfNotExists();
         try {
             boolean foundPk = false;
             Table.Builder tablebuilder = Table.builder()
@@ -366,7 +367,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                 }
             }
 
-            CreateTableStatement statement = new CreateTableStatement(table, otherIndexes);
+            CreateTableStatement statement = new CreateTableStatement(table, otherIndexes, isNotExsists);
             return statement;
         } catch (IllegalArgumentException err) {
             throw new StatementExecutionException("bad table definition: " + err.getMessage(), err);

--- a/herddb-core/src/test/java/herddb/core/CreateTableTest.java
+++ b/herddb-core/src/test/java/herddb/core/CreateTableTest.java
@@ -63,6 +63,10 @@ public class CreateTableTest {
 
             CreateTableStatement st2 = new CreateTableStatement(table);
             manager.executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            CreateTableStatement st2IfNotExists = new CreateTableStatement(table, Collections.emptyList(), true);
+            manager.executeStatement(st2IfNotExists, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
         }
 
     }

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -424,6 +424,21 @@ public class RawSQLTest {
     }
 
     @Test
+    public void createTableIfNotExistsSQL() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE IF NOT EXISTS tblspace1.tsql (k1 string primary key,n1 int,s1 string,t1 timestamp)", Collections.emptyList());
+            execute(manager, "CREATE TABLE IF NOT EXISTS tblspace1.tsql (k1 string primary key,n1 int,s1 string,t1 timestamp)", Collections.emptyList());
+
+        }
+    }
+
+    @Test
     public void insertFromSelect() throws Exception {
         String nodeId = "localhost";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {


### PR DESCRIPTION
In order to have better compatibility with MySQL this change adds support for "IF NOT EXISTS" clause in "CREATE TABLE STATEMENT".
jSqlParser already supports such clause so the change is quite straightforward