### PR TITLE
Default bookkeeper port typo

### DIFF
--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -87,7 +87,7 @@ server.bookkeeper.max.idle.time=10000
 server.bookkeeper.start=true
 # if you leave port to zero a random port will be used an then persisted to bookie_port file
 # bookkeeper uses local hostname and this port to identify bookies
-server.bookkeeper.port=-1
+server.bookkeeper.port=0
 
 # max "logical" size in bytes of a data page. Defaults to 1MB
 #server.memory.page.size=


### PR DESCRIPTION
Default bookkeeper port should be 0

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
