### PR TITLE
Right index restore behaviour

### DIFF
--- a/herddb-core/src/main/java/herddb/core/ReplicaFullTableDataDumpReceiver.java
+++ b/herddb-core/src/main/java/herddb/core/ReplicaFullTableDataDumpReceiver.java
@@ -23,6 +23,7 @@ package herddb.core;
 import herddb.backup.DumpedTableMetadata;
 import herddb.client.TableSpaceDumpReceiver;
 import herddb.log.LogSequenceNumber;
+import herddb.model.Index;
 import herddb.model.Record;
 import herddb.model.Table;
 import herddb.storage.DataStorageManagerException;
@@ -109,6 +110,9 @@ class ReplicaFullTableDataDumpReceiver extends TableSpaceDumpReceiver {
         Table table = dumpedTable.table;
         LOGGER.log(Level.SEVERE, "dumpReceiver " + tableSpaceName + ", beginTable " + table.name + ", stats:" + stats + ", dumped at " + dumpedTable.logSequenceNumber + " (general dump at " + logSequenceNumber + ")");
         currentTable = tableSpaceManager.bootTable(table, 0, dumpedTable.logSequenceNumber);
+        for (Index index : dumpedTable.indexes) {
+            tableSpaceManager.bootIndex(index, currentTable, 0, false, true);
+        }
     }
 
 }

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -944,6 +944,25 @@ public class FileDataStorageManager extends DataStorageManager {
             }
 
         } catch (IOException err) {
+            LOGGER.log(Level.SEVERE, "Failed to write on path: {0}", pageFile);
+            Path path = pageFile;
+            boolean exists;
+            do {
+                exists = Files.exists(path);
+
+                if (exists) {
+                    LOGGER.log(Level.SEVERE,
+                            "Path {0}: directory {1}, file {2}, link {3}, writable {4}, readable {5}, executable {6}",
+                            new Object[] { path, Files.isDirectory(path), Files.isRegularFile(path),
+                                    Files.isSymbolicLink(path), Files.isWritable(path), Files.isReadable(path),
+                                    Files.isExecutable(path) });
+                } else {
+                    LOGGER.log(Level.SEVERE, "Path {0} doesn't exists", path);
+                }
+
+                path = path.getParent();
+            } while (path != null && !exists);
+
             throw new DataStorageManagerException(err);
         }
 

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -23,7 +23,6 @@ package herddb.server;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_BEGIN_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_COMMIT_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_ROLLBACK_TRANSACTION;
-
 import herddb.backup.DumpedLogEntry;
 import herddb.codec.RecordSerializer;
 import herddb.core.HerdDBInternalException;

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -23,6 +23,7 @@ package herddb.server;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_BEGIN_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_COMMIT_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_ROLLBACK_TRANSACTION;
+
 import herddb.backup.DumpedLogEntry;
 import herddb.codec.RecordSerializer;
 import herddb.core.HerdDBInternalException;

--- a/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
@@ -1,28 +1,21 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Diennea S.r.l.
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
  */
 
 package herddb.cluster;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
 import herddb.codec.RecordSerializer;
 import herddb.core.AbstractTableManager;
 import herddb.core.TableSpaceManager;
@@ -99,53 +92,63 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1
-                .copy()
-                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder()
-                    .name("t1")
-                    .column("c", ColumnTypes.INTEGER)
-                    .column("s", ColumnTypes.INTEGER)
-                    .primaryKey("c")
-                    .build();
-            Index index = Index
-                    .builder()
-                    .onTable(table)
-                    .type(Index.TYPE_BRIN)
-                    .column("s", ColumnTypes.STRING)
-                    .build();
+            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).column("s", ColumnTypes.INTEGER)
+                    .primaryKey("c").build();
+            Index index = Index.builder().onTable(table).type(Index.TYPE_BRIN).column("s", ColumnTypes.STRING).build();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateIndexStatement(index),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // force BK LAC
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
 
-                server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeStatement(
+                        new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                                new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(
+                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
@@ -153,17 +156,20 @@ public class MultiServerTest {
                 }
                 for (int i = 1; i <= 5; i++) {
                     System.out.println("checking key c=" + i);
-                    assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                            TransactionContext.NO_TRANSACTION).found());
+                    assertTrue(server_2.getManager()
+                            .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
+                                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                    TransactionContext.NO_TRANSACTION)
+                            .found());
                 }
 
                 TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
-                        Collections.emptyList(), true, true, false, -1);
+                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true,
+                        false, -1);
                 ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
                 assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-                try (DataScanner scan = server_1.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
+                try (DataScanner scan = server_1.getManager().scan(statement, translated.context,
+                        TransactionContext.NO_TRANSACTION)) {
                     assertEquals(1, scan.consume().size());
                 }
 
@@ -185,40 +191,52 @@ public class MultiServerTest {
         // send a dummy write after 1 seconds of inactivity
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 1000);
 
-        ServerConfiguration serverconfig_2 = serverconfig_1
-                .copy()
-                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder()
-                    .name("t1")
-                    .column("c", ColumnTypes.INTEGER)
-                    .primaryKey("c")
-                    .build();
-            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).primaryKey("c").build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
 
-                server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeStatement(
+                        new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                                new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(
+                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
@@ -226,9 +244,11 @@ public class MultiServerTest {
                 }
                 for (int i = 1; i <= 5; i++) {
                     System.out.println("checking key c=" + i);
-                    assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                            TransactionContext.NO_TRANSACTION).found());
+                    assertTrue(server_2.getManager()
+                            .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
+                                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                    TransactionContext.NO_TRANSACTION)
+                            .found());
                 }
 
             }
@@ -248,45 +268,47 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1
-                .copy()
-                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder()
-                    .name("t1")
-                    .column("c", ColumnTypes.INTEGER)
-                    .column("s", ColumnTypes.INTEGER)
-                    .primaryKey("c")
-                    .build();
-            Index index = Index
-                    .builder()
-                    .onTable(table)
-                    .type(Index.TYPE_BRIN)
-                    .column("s", ColumnTypes.STRING)
-                    .build();
+            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).column("s", ColumnTypes.INTEGER)
+                    .primaryKey("c").build();
+            Index index = Index.builder().onTable(table).type(Index.TYPE_BRIN).column("s", ColumnTypes.STRING).build();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateIndexStatement(index),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
+                            "server1", 2, 0),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
-                    Collections.emptyList(), true, true, false, -1);
+                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true, false,
+                    -1);
             ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
             assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-            try (DataScanner scan = server_1.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
+            try (DataScanner scan = server_1.getManager().scan(statement, translated.context,
+                    TransactionContext.NO_TRANSACTION)) {
                 assertEquals(1, scan.consume().size());
             }
         }
@@ -298,20 +320,26 @@ public class MultiServerTest {
 
             // wait for data to arrive on server_2
             for (int i = 0; i < 100; i++) {
-                GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                GetResult found = server_2.getManager().get(
+                        new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 if (found.found()) {
                     break;
                 }
                 Thread.sleep(100);
             }
-            assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
+            assertTrue(server_2.getManager()
+                    .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)
+                    .found());
 
             TranslatedQuery translated = server_2.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
-                    Collections.emptyList(), true, true, false, -1);
+                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true, false,
+                    -1);
             ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
             assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-            try (DataScanner scan = server_2.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
+            try (DataScanner scan = server_2.getManager().scan(statement, translated.context,
+                    TransactionContext.NO_TRANSACTION)) {
                 assertEquals(1, scan.consume().size());
             }
         }
@@ -331,44 +359,46 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD, 0);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1
-                .copy()
-                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
-        Table table = Table.builder()
-                .name("t1")
-                .column("c", ColumnTypes.INTEGER)
-                .column("s", ColumnTypes.INTEGER)
-                .primaryKey("c")
-                .build();
-        Index index = Index
-                .builder()
-                .onTable(table)
-                .type(Index.TYPE_BRIN)
-                .column("s", ColumnTypes.STRING)
-                .build();
+        Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).column("s", ColumnTypes.INTEGER)
+                .primaryKey("c").build();
+        Index index = Index.builder().onTable(table).type(Index.TYPE_BRIN).column("s", ColumnTypes.STRING).build();
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateIndexStatement(index),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
+                            "server1", 2, 0),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
-                    Collections.emptyList(), true, true, false, -1);
+                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true, false,
+                    -1);
             ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
             assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-            try (DataScanner scan = server_1.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
+            try (DataScanner scan = server_1.getManager().scan(statement, translated.context,
+                    TransactionContext.NO_TRANSACTION)) {
                 assertEquals(1, scan.consume().size());
             }
         }
@@ -378,26 +408,36 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
                 tableSpaceUUID = man.describeTableSpace(TableSpace.DEFAULT).uuid;
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             server_1.getManager().checkpoint();
         }
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
             server_1.getManager().checkpoint();
@@ -406,8 +446,10 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
                 assertTrue(!ledgersList.getActiveLedgers().contains(ledgersList.getFirstLedger()));
             }
@@ -420,13 +462,19 @@ public class MultiServerTest {
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(
+                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
                     Thread.sleep(100);
                 }
-                assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
+                assertTrue(server_2.getManager()
+                        .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
+                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                TransactionContext.NO_TRANSACTION)
+                        .found());
 
 
                 TableSpaceManager tsm1 = server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT);
@@ -437,11 +485,12 @@ public class MultiServerTest {
                 assertEquals(indexes1, indexes2);
 
                 TranslatedQuery translated = server_2.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(),
-                        true, true, false, -1);
+                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true,
+                        false, -1);
                 ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
                 assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-                try (DataScanner scan = server_2.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
+                try (DataScanner scan = server_2.getManager().scan(statement, translated.context,
+                        TransactionContext.NO_TRANSACTION)) {
                     assertEquals(1, scan.consume().size());
                 }
             }
@@ -461,25 +510,28 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1
-                .copy()
-                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
-        try (Server server_1 = new Server(serverconfig_1);
-             Server server_2 = new Server(serverconfig_2)) {
+        try (Server server_1 = new Server(serverconfig_1); Server server_2 = new Server(serverconfig_2)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
 
             server_2.start();
 
             // two tablespaces, leader is server_1
-            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1, 0, 0);
-            server_1.getManager().executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
+                    new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1,
+                    0, 0);
+            server_1.getManager().executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
 
-            CreateTableSpaceStatement st2 = new CreateTableSpaceStatement("tblspace2", new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1, 0, 0);
-            server_2.getManager().executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            CreateTableSpaceStatement st2 = new CreateTableSpaceStatement("tblspace2",
+                    new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1,
+                    0, 0);
+            server_2.getManager().executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
 
             server_1.waitForTableSpaceBoot("tblspace1", 30000, true);
             server_1.waitForTableSpaceBoot("tblspace2", 30000, true);
@@ -487,53 +539,81 @@ public class MultiServerTest {
             server_2.waitForTableSpaceBoot("tblspace1", 30000, false);
             server_2.waitForTableSpaceBoot("tblspace2", 30000, false);
 
-            Table table1 = Table.builder()
-                    .name("t1")
-                    .column("c", ColumnTypes.INTEGER)
-                    .tablespace("tblspace1")
-                    .primaryKey("c")
-                    .build();
-            server_1.getManager().executeStatement(new CreateTableStatement(table1), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            Table table1 = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).tablespace("tblspace1")
+                    .primaryKey("c").build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table1),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            Table table2 = Table.builder()
-                    .name("t2")
-                    .column("c", ColumnTypes.INTEGER)
-                    .tablespace("tblspace2")
-                    .primaryKey("c")
-                    .build();
+            Table table2 = Table.builder().name("t2").column("c", ColumnTypes.INTEGER).tablespace("tblspace2")
+                    .primaryKey("c").build();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table2), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table2),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 1)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 2)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 3)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 4)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 1)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 2)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 3)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 4)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(new CommitTransactionStatement("tblspace1", executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 5)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new CommitTransactionStatement("tblspace1", executeUpdateTransaction.transactionId),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction2 = server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(new CommitTransactionStatement("tblspace2", executeUpdateTransaction2.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction2 = server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 5)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new CommitTransactionStatement("tblspace2", executeUpdateTransaction2.transactionId),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // force BK LAC
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 6)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 6)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 6)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 6)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // wait for data to arrive on server_2
             for (int i = 0; i < 100; i++) {
-                GetResult found = server_2.getManager().get(new GetStatement("tblspace1", "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                GetResult found = server_2.getManager().get(
+                        new GetStatement("tblspace1", "t1", Bytes.from_int(5), null, false),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 if (found.found()) {
                     break;
                 }
                 Thread.sleep(100);
             }
             for (int i = 0; i < 100; i++) {
-                GetResult found = server_2.getManager().get(new GetStatement("tblspace2", "t2", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                GetResult found = server_2.getManager().get(
+                        new GetStatement("tblspace2", "t2", Bytes.from_int(5), null, false),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 if (found.found()) {
                     break;
                 }
@@ -541,13 +621,17 @@ public class MultiServerTest {
             }
             for (int i = 1; i <= 5; i++) {
                 System.out.println("checking key c=" + i);
-                assertTrue(server_2.getManager().get(new GetStatement("tblspace1", "t1", Bytes.from_int(i), null, false),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                        TransactionContext.NO_TRANSACTION).found());
+                assertTrue(server_2.getManager()
+                        .get(new GetStatement("tblspace1", "t1", Bytes.from_int(i), null, false),
+                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                TransactionContext.NO_TRANSACTION)
+                        .found());
 
-                assertTrue(server_2.getManager().get(new GetStatement("tblspace2", "t2", Bytes.from_int(i), null, false),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                        TransactionContext.NO_TRANSACTION).found());
+                assertTrue(server_2.getManager()
+                        .get(new GetStatement("tblspace2", "t2", Bytes.from_int(i), null, false),
+                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                TransactionContext.NO_TRANSACTION)
+                        .found());
             }
 
         }
@@ -567,28 +651,33 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD, 0);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1
-                .copy()
-                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
-        Table table = Table.builder()
-                .name("t1")
-                .column("c", ColumnTypes.INTEGER)
-                .primaryKey("c")
-                .build();
+        Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).primaryKey("c").build();
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
+                            "server1", 2, 0),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
         }
 
         String tableSpaceUUID;
@@ -596,26 +685,36 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
                 tableSpaceUUID = man.describeTableSpace(TableSpace.DEFAULT).uuid;
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             server_1.getManager().checkpoint();
         }
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
             server_1.getManager().checkpoint();
@@ -624,8 +723,10 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 System.out.println("current ledgersList: " + ledgersList);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
                 assertTrue(!ledgersList.getActiveLedgers().contains(ledgersList.getFirstLedger()));
@@ -639,37 +740,53 @@ public class MultiServerTest {
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(
+                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
                     Thread.sleep(100);
                 }
-                assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
+                assertTrue(server_2.getManager()
+                        .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
+                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                TransactionContext.NO_TRANSACTION)
+                        .found());
             }
 
             // write more data, server_2 is down, it will need to catch up
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 8)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 9)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 10)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 8)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 9)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 10)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // truncate Bookkeeper logs, we want the follower to download again the dump
-            BookkeeperCommitLog bklog = (BookkeeperCommitLog) server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT).getLog();
+            BookkeeperCommitLog bklog = (BookkeeperCommitLog) server_1.getManager()
+                    .getTableSpaceManager(TableSpace.DEFAULT).getLog();
             bklog.rollNewLedger();
             Thread.sleep(1000);
             server_1.getManager().checkpoint();
 
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
+                        .getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
+                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 System.out.println("current ledgersList: " + ledgersList);
                 assertEquals(1, ledgersList.getActiveLedgers().size());
                 assertTrue(!ledgersList.getActiveLedgers().contains(ledgersList.getFirstLedger()));
             }
 
-            Table table1 = server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTableManager("t1").getTable();
-            try (DataScanner scan = server_1.getManager()
-                    .scan(new ScanStatement(TableSpace.DEFAULT, table1, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)) {
+            Table table1 = server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTableManager("t1")
+                    .getTable();
+            try (DataScanner scan = server_1.getManager().scan(new ScanStatement(TableSpace.DEFAULT, table1, null),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)) {
                 List<DataAccessor> all = scan.consume();
                 all.forEach(d -> {
                     System.out.println("RECORD ON SERVER 1: " + d.toMap());
@@ -681,19 +798,24 @@ public class MultiServerTest {
                 server_2.start();
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
-                AbstractTableManager tableManager = server_2.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTableManager("t1");
+                AbstractTableManager tableManager = server_2.getManager().getTableSpaceManager(TableSpace.DEFAULT)
+                        .getTableManager("t1");
                 Table table2 = tableManager.getTable();
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
 
-                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(
+                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
 
-                    try (DataScanner scan = server_2.getManager()
-                            .scan(new ScanStatement(TableSpace.DEFAULT, table2, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)) {
+                    try (DataScanner scan = server_2.getManager().scan(
+                            new ScanStatement(TableSpace.DEFAULT, table2, null),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                            TransactionContext.NO_TRANSACTION)) {
                         List<DataAccessor> all = scan.consume();
                         System.out.println("WAIT #" + i);
                         all.forEach(d -> {
@@ -703,7 +825,11 @@ public class MultiServerTest {
 
                     Thread.sleep(1000);
                 }
-                assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
+                assertTrue(server_2.getManager()
+                        .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false),
+                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                TransactionContext.NO_TRANSACTION)
+                        .found());
             }
 
         }
@@ -723,32 +849,37 @@ public class MultiServerTest {
         // send a dummy write after 1 seconds of inactivity
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 1000);
 
-        ServerConfiguration serverconfig_2 = serverconfig_1
-                .copy()
-                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder()
-                    .name("t1")
-                    .column("c", ColumnTypes.INTEGER)
-                    .primaryKey("c")
-                    .build();
-            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).primaryKey("c").build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(
+                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(
+                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
+                            "server1", 2, 0),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
 
-                server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-                server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-                server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeUpdate(
+                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeUpdate(
+                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeUpdate(
+                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -758,12 +889,19 @@ public class MultiServerTest {
                 logServer1.rollNewLedger();
                 logServer1.rollNewLedger();
 
-                DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
-                server_1.getManager().executeStatement(new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
+                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        TransactionContext.AUTOTRANSACTION_TRANSACTION);
+                server_1.getManager().executeStatement(
+                        new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(
+                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
@@ -771,9 +909,11 @@ public class MultiServerTest {
                 }
                 for (int i = 1; i <= 5; i++) {
                     System.out.println("checking key c=" + i);
-                    assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                            TransactionContext.NO_TRANSACTION).found());
+                    assertTrue(server_2.getManager()
+                            .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
+                                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                                    TransactionContext.NO_TRANSACTION)
+                            .found());
                 }
                 BookkeeperCommitLog logServer2 = (BookkeeperCommitLog) tableSpaceManager.getLog();
                 LogSequenceNumber lastSequenceNumberServer1 = logServer1.getLastSequenceNumber();
@@ -781,7 +921,8 @@ public class MultiServerTest {
                 System.out.println("POS AT SERVER 1: " + lastSequenceNumberServer1);
                 System.out.println("POS AT SERVER 2: " + lastSequenceNumberServer2);
                 assertTrue(lastSequenceNumberServer1.equals(lastSequenceNumberServer2)
-                        || lastSequenceNumberServer1.after(lastSequenceNumberServer2)); // maybe after due to NOOPs
+                        || lastSequenceNumberServer1.after(lastSequenceNumberServer2)); // maybe after due to
+                                                                                        // NOOPs
 
             }
 

--- a/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
@@ -1,15 +1,21 @@
 /*
- * Licensed to Diennea S.r.l. under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright ownership. Diennea S.r.l.
- * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is
- * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and limitations under the License.
- *
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 
 package herddb.cluster;
@@ -92,63 +98,53 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).column("s", ColumnTypes.INTEGER)
-                    .primaryKey("c").build();
-            Index index = Index.builder().onTable(table).type(Index.TYPE_BRIN).column("s", ColumnTypes.STRING).build();
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .column("s", ColumnTypes.INTEGER)
+                    .primaryKey("c")
+                    .build();
+            Index index = Index
+                    .builder()
+                    .onTable(table)
+                    .type(Index.TYPE_BRIN)
+                    .column("s", ColumnTypes.STRING)
+                    .build();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeStatement(new CreateIndexStatement(index),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(
-                    new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // force BK LAC
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
 
-                server_1.getManager().executeStatement(
-                        new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                                new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(
-                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
@@ -156,20 +152,17 @@ public class MultiServerTest {
                 }
                 for (int i = 1; i <= 5; i++) {
                     System.out.println("checking key c=" + i);
-                    assertTrue(server_2.getManager()
-                            .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
-                                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                    TransactionContext.NO_TRANSACTION)
-                            .found());
+                    assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                            TransactionContext.NO_TRANSACTION).found());
                 }
 
                 TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true,
-                        false, -1);
+                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
+                        Collections.emptyList(), true, true, false, -1);
                 ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
                 assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-                try (DataScanner scan = server_1.getManager().scan(statement, translated.context,
-                        TransactionContext.NO_TRANSACTION)) {
+                try (DataScanner scan = server_1.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
                     assertEquals(1, scan.consume().size());
                 }
 
@@ -191,52 +184,40 @@ public class MultiServerTest {
         // send a dummy write after 1 seconds of inactivity
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 1000);
 
-        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).primaryKey("c").build();
-            server_1.getManager().executeStatement(new CreateTableStatement(table),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .primaryKey("c")
+                    .build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(
-                    new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
 
-                server_1.getManager().executeStatement(
-                        new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                                new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(
-                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
@@ -244,11 +225,9 @@ public class MultiServerTest {
                 }
                 for (int i = 1; i <= 5; i++) {
                     System.out.println("checking key c=" + i);
-                    assertTrue(server_2.getManager()
-                            .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
-                                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                    TransactionContext.NO_TRANSACTION)
-                            .found());
+                    assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                            TransactionContext.NO_TRANSACTION).found());
                 }
 
             }
@@ -268,47 +247,45 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).column("s", ColumnTypes.INTEGER)
-                    .primaryKey("c").build();
-            Index index = Index.builder().onTable(table).type(Index.TYPE_BRIN).column("s", ColumnTypes.STRING).build();
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .column("s", ColumnTypes.INTEGER)
+                    .primaryKey("c")
+                    .build();
+            Index index = Index
+                    .builder()
+                    .onTable(table)
+                    .type(Index.TYPE_BRIN)
+                    .column("s", ColumnTypes.STRING)
+                    .build();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeStatement(new CreateIndexStatement(index),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(
-                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
-                            "server1", 2, 0),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true, false,
-                    -1);
+                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
+                    Collections.emptyList(), true, true, false, -1);
             ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
             assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-            try (DataScanner scan = server_1.getManager().scan(statement, translated.context,
-                    TransactionContext.NO_TRANSACTION)) {
+            try (DataScanner scan = server_1.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
                 assertEquals(1, scan.consume().size());
             }
         }
@@ -320,26 +297,20 @@ public class MultiServerTest {
 
             // wait for data to arrive on server_2
             for (int i = 0; i < 100; i++) {
-                GetResult found = server_2.getManager().get(
-                        new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 if (found.found()) {
                     break;
                 }
                 Thread.sleep(100);
             }
-            assertTrue(server_2.getManager()
-                    .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)
-                    .found());
+            assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
 
             TranslatedQuery translated = server_2.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true, false,
-                    -1);
+                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
+                    Collections.emptyList(), true, true, false, -1);
             ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
             assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-            try (DataScanner scan = server_2.getManager().scan(statement, translated.context,
-                    TransactionContext.NO_TRANSACTION)) {
+            try (DataScanner scan = server_2.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
                 assertEquals(1, scan.consume().size());
             }
         }
@@ -359,46 +330,44 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD, 0);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
-        Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).column("s", ColumnTypes.INTEGER)
-                .primaryKey("c").build();
-        Index index = Index.builder().onTable(table).type(Index.TYPE_BRIN).column("s", ColumnTypes.STRING).build();
+        Table table = Table.builder()
+                .name("t1")
+                .column("c", ColumnTypes.INTEGER)
+                .column("s", ColumnTypes.INTEGER)
+                .primaryKey("c")
+                .build();
+        Index index = Index
+                .builder()
+                .onTable(table)
+                .type(Index.TYPE_BRIN)
+                .column("s", ColumnTypes.STRING)
+                .build();
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeStatement(new CreateIndexStatement(index),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "1")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "s", "2")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3, "s", "3")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4, "s", "4")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(
-                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
-                            "server1", 2, 0),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true, false,
-                    -1);
+                    "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
+                    Collections.emptyList(), true, true, false, -1);
             ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
             assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-            try (DataScanner scan = server_1.getManager().scan(statement, translated.context,
-                    TransactionContext.NO_TRANSACTION)) {
+            try (DataScanner scan = server_1.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
                 assertEquals(1, scan.consume().size());
             }
         }
@@ -408,36 +377,26 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
                 tableSpaceUUID = man.describeTableSpace(TableSpace.DEFAULT).uuid;
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5, "s", "5")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             server_1.getManager().checkpoint();
         }
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6, "s", "6")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
             server_1.getManager().checkpoint();
@@ -446,10 +405,8 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
                 assertTrue(!ledgersList.getActiveLedgers().contains(ledgersList.getFirstLedger()));
             }
@@ -462,19 +419,13 @@ public class MultiServerTest {
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(
-                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
                     Thread.sleep(100);
                 }
-                assertTrue(server_2.getManager()
-                        .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
-                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                TransactionContext.NO_TRANSACTION)
-                        .found());
+                assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
 
 
                 TableSpaceManager tsm1 = server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT);
@@ -485,12 +436,11 @@ public class MultiServerTest {
                 assertEquals(indexes1, indexes2);
 
                 TranslatedQuery translated = server_2.getManager().getPlanner().translate(TableSpace.DEFAULT,
-                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(), true, true,
-                        false, -1);
+                        "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1", Collections.emptyList(),
+                        true, true, false, -1);
                 ScanStatement statement = translated.plan.mainStatement.unwrap(ScanStatement.class);
                 assertTrue(statement.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
-                try (DataScanner scan = server_2.getManager().scan(statement, translated.context,
-                        TransactionContext.NO_TRANSACTION)) {
+                try (DataScanner scan = server_2.getManager().scan(statement, translated.context, TransactionContext.NO_TRANSACTION)) {
                     assertEquals(1, scan.consume().size());
                 }
             }
@@ -510,28 +460,25 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
-        try (Server server_1 = new Server(serverconfig_1); Server server_2 = new Server(serverconfig_2)) {
+        try (Server server_1 = new Server(serverconfig_1);
+             Server server_2 = new Server(serverconfig_2)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
 
             server_2.start();
 
             // two tablespaces, leader is server_1
-            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1",
-                    new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1,
-                    0, 0);
-            server_1.getManager().executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    TransactionContext.NO_TRANSACTION);
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1, 0, 0);
+            server_1.getManager().executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            CreateTableSpaceStatement st2 = new CreateTableSpaceStatement("tblspace2",
-                    new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1,
-                    0, 0);
-            server_2.getManager().executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    TransactionContext.NO_TRANSACTION);
+            CreateTableSpaceStatement st2 = new CreateTableSpaceStatement("tblspace2", new HashSet<>(Arrays.asList(server_1.getNodeId(), server_2.getNodeId())), server_1.getNodeId(), 1, 0, 0);
+            server_2.getManager().executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             server_1.waitForTableSpaceBoot("tblspace1", 30000, true);
             server_1.waitForTableSpaceBoot("tblspace2", 30000, true);
@@ -539,81 +486,53 @@ public class MultiServerTest {
             server_2.waitForTableSpaceBoot("tblspace1", 30000, false);
             server_2.waitForTableSpaceBoot("tblspace2", 30000, false);
 
-            Table table1 = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).tablespace("tblspace1")
-                    .primaryKey("c").build();
-            server_1.getManager().executeStatement(new CreateTableStatement(table1),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            Table table1 = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .tablespace("tblspace1")
+                    .primaryKey("c")
+                    .build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table1), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            Table table2 = Table.builder().name("t2").column("c", ColumnTypes.INTEGER).tablespace("tblspace2")
-                    .primaryKey("c").build();
+            Table table2 = Table.builder()
+                    .name("t2")
+                    .column("c", ColumnTypes.INTEGER)
+                    .tablespace("tblspace2")
+                    .primaryKey("c")
+                    .build();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table2),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table2), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 1)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 2)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 3)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 4)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 1)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 2)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 3)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 4)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 5)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(
-                    new CommitTransactionStatement("tblspace1", executeUpdateTransaction.transactionId),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(new CommitTransactionStatement("tblspace1", executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            DMLStatementExecutionResult executeUpdateTransaction2 = server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 5)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                    TransactionContext.AUTOTRANSACTION_TRANSACTION);
-            server_1.getManager().executeStatement(
-                    new CommitTransactionStatement("tblspace2", executeUpdateTransaction2.transactionId),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            DMLStatementExecutionResult executeUpdateTransaction2 = server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            server_1.getManager().executeStatement(new CommitTransactionStatement("tblspace2", executeUpdateTransaction2.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // force BK LAC
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 6)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 6)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace1", "t1", RecordSerializer.makeRecord(table1, "c", 6)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement("tblspace2", "t2", RecordSerializer.makeRecord(table2, "c", 6)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // wait for data to arrive on server_2
             for (int i = 0; i < 100; i++) {
-                GetResult found = server_2.getManager().get(
-                        new GetStatement("tblspace1", "t1", Bytes.from_int(5), null, false),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                GetResult found = server_2.getManager().get(new GetStatement("tblspace1", "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 if (found.found()) {
                     break;
                 }
                 Thread.sleep(100);
             }
             for (int i = 0; i < 100; i++) {
-                GetResult found = server_2.getManager().get(
-                        new GetStatement("tblspace2", "t2", Bytes.from_int(5), null, false),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                GetResult found = server_2.getManager().get(new GetStatement("tblspace2", "t2", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 if (found.found()) {
                     break;
                 }
@@ -621,17 +540,13 @@ public class MultiServerTest {
             }
             for (int i = 1; i <= 5; i++) {
                 System.out.println("checking key c=" + i);
-                assertTrue(server_2.getManager()
-                        .get(new GetStatement("tblspace1", "t1", Bytes.from_int(i), null, false),
-                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                TransactionContext.NO_TRANSACTION)
-                        .found());
+                assertTrue(server_2.getManager().get(new GetStatement("tblspace1", "t1", Bytes.from_int(i), null, false),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        TransactionContext.NO_TRANSACTION).found());
 
-                assertTrue(server_2.getManager()
-                        .get(new GetStatement("tblspace2", "t2", Bytes.from_int(i), null, false),
-                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                TransactionContext.NO_TRANSACTION)
-                        .found());
+                assertTrue(server_2.getManager().get(new GetStatement("tblspace2", "t2", Bytes.from_int(i), null, false),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        TransactionContext.NO_TRANSACTION).found());
             }
 
         }
@@ -651,33 +566,28 @@ public class MultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD, 0);
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
 
-        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
-        Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).primaryKey("c").build();
+        Table table = Table.builder()
+                .name("t1")
+                .column("c", ColumnTypes.INTEGER)
+                .primaryKey("c")
+                .build();
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
 
-            server_1.getManager().executeStatement(new CreateTableStatement(table),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(
-                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
-                            "server1", 2, 0),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
         }
 
         String tableSpaceUUID;
@@ -685,36 +595,26 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
                 tableSpaceUUID = man.describeTableSpace(TableSpace.DEFAULT).uuid;
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             server_1.getManager().checkpoint();
         }
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 6)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
             }
             server_1.getManager().checkpoint();
@@ -723,10 +623,8 @@ public class MultiServerTest {
             server_1.start();
             server_1.waitForStandaloneBoot();
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 System.out.println("current ledgersList: " + ledgersList);
                 assertEquals(2, ledgersList.getActiveLedgers().size());
                 assertTrue(!ledgersList.getActiveLedgers().contains(ledgersList.getFirstLedger()));
@@ -740,53 +638,37 @@ public class MultiServerTest {
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(
-                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
                     Thread.sleep(100);
                 }
-                assertTrue(server_2.getManager()
-                        .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false),
-                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                TransactionContext.NO_TRANSACTION)
-                        .found());
+                assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
             }
 
             // write more data, server_2 is down, it will need to catch up
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 8)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 9)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 10)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 8)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 9)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 10)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // truncate Bookkeeper logs, we want the follower to download again the dump
-            BookkeeperCommitLog bklog = (BookkeeperCommitLog) server_1.getManager()
-                    .getTableSpaceManager(TableSpace.DEFAULT).getLog();
+            BookkeeperCommitLog bklog = (BookkeeperCommitLog) server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT).getLog();
             bklog.rollNewLedger();
             Thread.sleep(1000);
             server_1.getManager().checkpoint();
 
             {
-                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1
-                        .getMetadataStorageManager();
-                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(
-                        man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
+                ZookeeperMetadataStorageManager man = (ZookeeperMetadataStorageManager) server_1.getMetadataStorageManager();
+                LedgersInfo ledgersList = ZookeeperMetadataStorageManager.readActualLedgersListFromZookeeper(man.getZooKeeper(), testEnv.getPath() + "/ledgers", tableSpaceUUID);
                 System.out.println("current ledgersList: " + ledgersList);
                 assertEquals(1, ledgersList.getActiveLedgers().size());
                 assertTrue(!ledgersList.getActiveLedgers().contains(ledgersList.getFirstLedger()));
             }
 
-            Table table1 = server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTableManager("t1")
-                    .getTable();
-            try (DataScanner scan = server_1.getManager().scan(new ScanStatement(TableSpace.DEFAULT, table1, null),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)) {
+            Table table1 = server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTableManager("t1").getTable();
+            try (DataScanner scan = server_1.getManager()
+                    .scan(new ScanStatement(TableSpace.DEFAULT, table1, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)) {
                 List<DataAccessor> all = scan.consume();
                 all.forEach(d -> {
                     System.out.println("RECORD ON SERVER 1: " + d.toMap());
@@ -798,24 +680,19 @@ public class MultiServerTest {
                 server_2.start();
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
-                AbstractTableManager tableManager = server_2.getManager().getTableSpaceManager(TableSpace.DEFAULT)
-                        .getTableManager("t1");
+                AbstractTableManager tableManager = server_2.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTableManager("t1");
                 Table table2 = tableManager.getTable();
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
 
-                    GetResult found = server_2.getManager().get(
-                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
 
-                    try (DataScanner scan = server_2.getManager().scan(
-                            new ScanStatement(TableSpace.DEFAULT, table2, null),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                            TransactionContext.NO_TRANSACTION)) {
+                    try (DataScanner scan = server_2.getManager()
+                            .scan(new ScanStatement(TableSpace.DEFAULT, table2, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION)) {
                         List<DataAccessor> all = scan.consume();
                         System.out.println("WAIT #" + i);
                         all.forEach(d -> {
@@ -825,11 +702,7 @@ public class MultiServerTest {
 
                     Thread.sleep(1000);
                 }
-                assertTrue(server_2.getManager()
-                        .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false),
-                                StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                TransactionContext.NO_TRANSACTION)
-                        .found());
+                assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(10), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION).found());
             }
 
         }
@@ -849,37 +722,32 @@ public class MultiServerTest {
         // send a dummy write after 1 seconds of inactivity
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 1000);
 
-        ServerConfiguration serverconfig_2 = serverconfig_1.copy().set(ServerConfiguration.PROPERTY_NODEID, "server2")
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
                 .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
                 .set(ServerConfiguration.PROPERTY_PORT, 7868);
 
         try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             server_1.waitForStandaloneBoot();
-            Table table = Table.builder().name("t1").column("c", ColumnTypes.INTEGER).primaryKey("c").build();
-            server_1.getManager().executeStatement(new CreateTableStatement(table),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-            server_1.getManager().executeUpdate(
-                    new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .primaryKey("c")
+                    .build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            server_1.getManager().executeStatement(
-                    new AlterTableSpaceStatement(TableSpace.DEFAULT, new HashSet<>(Arrays.asList("server1", "server2")),
-                            "server1", 2, 0),
-                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
 
-                server_1.getManager().executeUpdate(
-                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-                server_1.getManager().executeUpdate(
-                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
-                server_1.getManager().executeUpdate(
-                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -889,19 +757,12 @@ public class MultiServerTest {
                 logServer1.rollNewLedger();
                 logServer1.rollNewLedger();
 
-                DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(
-                        new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                        TransactionContext.AUTOTRANSACTION_TRANSACTION);
-                server_1.getManager().executeStatement(
-                        new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId),
-                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                DMLStatementExecutionResult executeUpdateTransaction = server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
+                server_1.getManager().executeStatement(new CommitTransactionStatement(TableSpace.DEFAULT, executeUpdateTransaction.transactionId), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 // wait for data to arrive on server_2
                 for (int i = 0; i < 100; i++) {
-                    GetResult found = server_2.getManager().get(
-                            new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false),
-                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    GetResult found = server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(5), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                     if (found.found()) {
                         break;
                     }
@@ -909,11 +770,9 @@ public class MultiServerTest {
                 }
                 for (int i = 1; i <= 5; i++) {
                     System.out.println("checking key c=" + i);
-                    assertTrue(server_2.getManager()
-                            .get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
-                                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
-                                    TransactionContext.NO_TRANSACTION)
-                            .found());
+                    assertTrue(server_2.getManager().get(new GetStatement(TableSpace.DEFAULT, "t1", Bytes.from_int(i), null, false),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                            TransactionContext.NO_TRANSACTION).found());
                 }
                 BookkeeperCommitLog logServer2 = (BookkeeperCommitLog) tableSpaceManager.getLog();
                 LogSequenceNumber lastSequenceNumberServer1 = logServer1.getLastSequenceNumber();
@@ -921,8 +780,7 @@ public class MultiServerTest {
                 System.out.println("POS AT SERVER 1: " + lastSequenceNumberServer1);
                 System.out.println("POS AT SERVER 2: " + lastSequenceNumberServer2);
                 assertTrue(lastSequenceNumberServer1.equals(lastSequenceNumberServer2)
-                        || lastSequenceNumberServer1.after(lastSequenceNumberServer2)); // maybe after due to
-                                                                                        // NOOPs
+                        || lastSequenceNumberServer1.after(lastSequenceNumberServer2)); // maybe after due to NOOPs
 
             }
 


### PR DESCRIPTION
During tablespace recovery index arent correctly handled and restored again but left unrestored.
Otherwise when using Backup recovery index are restored correctly

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
