### PR TITLE
Enable Calcite ReduceExpressionsRule in order to simplify expressions

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -133,6 +133,7 @@ import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.logical.LogicalTableModify;
+import org.apache.calcite.rel.rules.ReduceExpressionsRule;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -505,6 +506,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
         RelDataType originalRowType = logicalPlan.getRowType();
         RelOptCluster cluster = logicalPlan.getCluster();
         final RelOptPlanner optPlanner = cluster.getPlanner();
+        optPlanner.addRule(ReduceExpressionsRule.FILTER_INSTANCE);
         RelTraitSet desiredTraits =
                 cluster.traitSet()
                         .replace(EnumerableConvention.INSTANCE);

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledEqualsExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledEqualsExpression.java
@@ -64,4 +64,12 @@ public class CompiledEqualsExpression extends CompiledBinarySQLExpression {
                 right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }
 
+    public CompiledSQLExpression getLeft() {
+        return left;
+    }
+
+    public CompiledSQLExpression getRight() {
+        return right;
+    }
+
 }

--- a/herddb-core/src/test/java/herddb/core/IndexScanRangeTest.java
+++ b/herddb-core/src/test/java/herddb/core/IndexScanRangeTest.java
@@ -279,7 +279,7 @@ public class IndexScanRangeTest {
             }
 
             {
-                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1<= 1 and n1>=2", Collections.emptyList(), true, true, false, -1);
+                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1<= -10 and n1<=2", Collections.emptyList(), true, true, false, -1);
                 ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
                 System.out.println("indexOperation:" + scan.getPredicate().getIndexOperation());
                 assertTrue(scan.getPredicate().getIndexOperation() instanceof SecondaryIndexRangeScan);

--- a/herddb-core/src/test/java/herddb/core/SecondaryIndexAccessSuite.java
+++ b/herddb-core/src/test/java/herddb/core/SecondaryIndexAccessSuite.java
@@ -225,12 +225,12 @@ public abstract class SecondaryIndexAccessSuite {
             }
 
             {
-                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1<= 1 and n1>=2", Collections.emptyList(), true, true, false, -1);
+                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1>=2", Collections.emptyList(), true, true, false, -1);
                 ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
                 System.out.println("indexOperation:" + scan.getPredicate().getIndexOperation());
                 assertTrue(scan.getPredicate().getIndexOperation() instanceof SecondaryIndexRangeScan);
                 try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
-                    assertEquals(0, scan1.consume().size());
+                    assertEquals(4, scan1.consume().size());
                 }
             }
 

--- a/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
@@ -294,28 +294,14 @@ public class SimpleOperatorsTest {
             }
 
             // In expressions
-            // Warning: jsqlParser doesn't handle this kind of expressions in select clause
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE '1' in (1,2,3)", Collections.emptyList())) {
-                if (manager.getPlanner() instanceof CalcitePlanner) {
-                    assertEquals(0, scan1.consume().size());
-                } else {
-                    assertEquals(1, scan1.consume().size());
-                }
-            }
-            if ((manager.getPlanner() instanceof DDLSQLPlanner)) {
-                try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE '1' in ('1',2,3)", Collections.emptyList())) {
-                    assertEquals(1, scan1.consume().size());
-                }
-                try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'b' in ('1',2,3)", Collections.emptyList())) {
-                    assertEquals(0, scan1.consume().size());
-                }
+                assertEquals(1, scan1.consume().size());
             }
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'b' in (1)", Collections.emptyList())) {
                 assertEquals(0, scan1.consume().size());
             }
 
             // Between expressions
-            // Warning: Parser doesn't handle this kind of expressions in select clause
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 3 BETWEEN 1 AND 5", Collections.emptyList())) {
                 assertEquals(1, scan1.consume().size());
             }

--- a/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
@@ -32,8 +32,6 @@ import herddb.model.DataScanner;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
-import herddb.sql.CalcitePlanner;
-import herddb.sql.DDLSQLPlanner;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <url>https://github.com/diennea/herddb.git</url>
         <connection>scm:git:https://github.com/diennea/herddb.git</connection>
         <developerConnection>scm:git:https://github.com/diennea/herddb.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>release/0.7</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
With ReduceExpressionsRule Calcite tries to simplify more aggressively input expressions.
Stuff like: 
"SELECT from a where n = 1 and n is not null" becomes "SELECT from a where n = 1"
"SELECT from a where n < 1 and n < 2" becomes "SELECT from a where n < 1"
