### PR TITLE
Do not hang in case of internal error during system management tasks:

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1837,7 +1837,7 @@ public class TableSpaceManager {
         @Override
         public void accept(LogSequenceNumber t, LogEntry u) {
             if (dbmanager.isStopped()) {
-                throw new RuntimeException("System was requested to stop, aborting recovery at "+t);
+                throw new RuntimeException("System was requested to stop, aborting recovery at " + t);
             }
             try {
                 apply(new CommitLogResult(t, false, true), u, true);


### PR DESCRIPTION
 Do not hang in case of internal error during system management tasks:
    - early exit in case of system shutdown and recovery in progress
    - wait for transactions to be in a stable status before forcing a rollback
    - do not exist core lifecycle management tasks

Fixes #476