### PR TITLE
Remove exception swallowing in LockAndUnload.unload

### DIFF
--- a/herddb-utils/src/main/java/herddb/index/blink/BLink.java
+++ b/herddb-utils/src/main/java/herddb/index/blink/BLink.java
@@ -3009,7 +3009,7 @@ public class BLink<K extends Comparable<K>, V> implements AutoCloseable, Page.Ow
             try {
                 unload.owner.unload(unload.pageId);
             } catch (RuntimeException e) {
-                throw new IOException("failed to unload " + unload.pageId);
+                throw new IOException("failed to unload " + unload.pageId, e);
             }
         }
 


### PR DESCRIPTION
A mini fix to avoid exception swallowing on page unload failures

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
