### PR TITLE
Fix race condition on creating a tablespace with a very slow leader

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ZookeeperClientSideMetadataProvider.java
+++ b/herddb-core/src/main/java/herddb/client/ZookeeperClientSideMetadataProvider.java
@@ -156,7 +156,7 @@ public class ZookeeperClientSideMetadataProvider implements ClientSideMetadataPr
         tableSpace = tableSpace.toLowerCase();
         Stat stat = new Stat();
         byte[] result = zooKeeper.getData(basePath + "/tableSpaces/" + tableSpace, false, stat);
-        String leader = TableSpace.deserialize(result, stat.getVersion()).leaderId;
+        String leader = TableSpace.deserialize(result, stat.getVersion(), stat.getCtime()).leaderId;
         tableSpaceLeaders.put(tableSpace, leader);
         return leader;
     }

--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -214,7 +214,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
                 byte[] actualLedgers = zooKeeper.getData(ledgersPath + "/" + tableSpaceUUID, false, stat);
                 return LedgersInfo.deserialize(actualLedgers, stat.getVersion());
             } catch (KeeperException.NoNodeException firstboot) {
-                LOGGER.log(Level.SEVERE, "node " + ledgersPath + "/" + tableSpaceUUID + " not found");
+                LOGGER.log(Level.INFO, "node " + ledgersPath + "/" + tableSpaceUUID + " not found");
                 return LedgersInfo.deserialize(null, -1); // -1 is a special ZK version
             } catch (KeeperException.ConnectionLossException error) {
                 LOGGER.log(Level.SEVERE, "error while loading actual ledgers list at " + ledgersPath + "/" + tableSpaceUUID, error);
@@ -378,7 +378,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         try {
             Stat stat = new Stat();
             byte[] result = ensureZooKeeper().getData(tableSpacesPath + "/" + name.toLowerCase(), mainWatcher, stat);
-            return TableSpace.deserialize(result, stat.getVersion());
+            return TableSpace.deserialize(result, stat.getVersion(), stat.getCtime());
         } catch (KeeperException.NoNodeException ex) {
             return null;
         } catch (KeeperException | InterruptedException | IOException ex) {

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -419,7 +419,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 .ssl(hostData.isSsl())
                 .nodeId(nodeId)
                 .build();
-        LOGGER.log(Level.SEVERE, "Registering on metadata storage manager my data: {0}", nodeMetadata);
+        LOGGER.log(Level.INFO, "Registering on metadata storage manager my data: {0}", nodeMetadata);
         metadataStorageManager.registerNode(nodeMetadata);
 
         try {
@@ -529,13 +529,13 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         }
 
         if (tableSpace.replicas.contains(nodeId) && !tablesSpaces.containsKey(tableSpaceName)) {
-            LOGGER.log(Level.SEVERE, "Booting tablespace {0} on {1}, uuid {2}", new Object[]{tableSpaceName, nodeId, tableSpace.uuid});
+            LOGGER.log(Level.INFO, "Booting tablespace {0} on {1}, uuid {2}", new Object[]{tableSpaceName, nodeId, tableSpace.uuid});
             long _start = System.currentTimeMillis();
             CommitLog commitLog = commitLogManager.createCommitLog(tableSpace.uuid, tableSpace.name, nodeId);
             TableSpaceManager manager = new TableSpaceManager(nodeId, tableSpaceName, tableSpace.uuid, metadataStorageManager, dataStorageManager, commitLog, this, false);
             try {
                 manager.start();
-                LOGGER.log(Level.SEVERE, "Boot success tablespace {0} on {1}, uuid {2}, time {3} ms", new Object[]{tableSpaceName, nodeId, tableSpace.uuid, (System.currentTimeMillis() - _start) + ""});
+                LOGGER.log(Level.INFO, "Boot success tablespace {0} on {1}, uuid {2}, time {3} ms", new Object[]{tableSpaceName, nodeId, tableSpace.uuid, (System.currentTimeMillis() - _start) + ""});
                 tablesSpaces.put(tableSpaceName, manager);
                 if (serverConfiguration.getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT)) {
                     JMXUtils.registerTableSpaceManagerStatsMXBean(tableSpaceName, manager.getStats());
@@ -771,12 +771,12 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                         || metadataStorageManager instanceof FileMetadataStorageManager) {
                     poolTime = 5;
                 }
-                LOGGER.log(Level.SEVERE, "waiting for  " + tableSpace.name + ", uuid " + tableSpace.uuid + ", to be up withint " + createTableSpaceStatement.getWaitForTableSpaceTimeout() + " ms");
+                LOGGER.log(Level.INFO, "waiting for  " + tableSpace.name + ", uuid " + tableSpace.uuid + ", to be up withint " + createTableSpaceStatement.getWaitForTableSpaceTimeout() + " ms");
                 final int timeout = createTableSpaceStatement.getWaitForTableSpaceTimeout();
                 for (int i = 0; i < timeout; i += poolTime) {
                     List<TableSpaceReplicaState> replicateStates = metadataStorageManager.getTableSpaceReplicaState(tableSpace.uuid);
                     for (TableSpaceReplicaState ts : replicateStates) {
-                        LOGGER.log(Level.SEVERE, "waiting for  " + tableSpace.name + ", uuid " + tableSpace.uuid + ", to be up, replica state node: " + ts.nodeId + ", state: " + TableSpaceReplicaState.modeToSQLString(ts.mode) + ", ts " + new java.sql.Timestamp(ts.timestamp));
+                        LOGGER.log(Level.INFO, "waiting for  " + tableSpace.name + ", uuid " + tableSpace.uuid + ", to be up, replica state node: " + ts.nodeId + ", state: " + TableSpaceReplicaState.modeToSQLString(ts.mode) + ", ts " + new java.sql.Timestamp(ts.timestamp));
                         if (ts.mode == TableSpaceReplicaState.MODE_LEADER) {
                             okWait = true;
                             break;
@@ -909,7 +909,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     }
 
     private void tryBecomeLeaderFor(TableSpace tableSpace) throws DDLException, MetadataStorageManagerException {
-        LOGGER.log(Level.SEVERE, "node {0}, try to become leader of {1}", new Object[]{nodeId, tableSpace.name});
+        LOGGER.log(Level.INFO, "node {0}, try to become leader of {1}", new Object[]{nodeId, tableSpace.name});
         TableSpace.Builder newTableSpaceBuilder =
                 TableSpace
                         .builder()
@@ -989,9 +989,9 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                         try {
 
                             if (activatorPaused) {
-                                LOGGER.log(Level.SEVERE, "{0} activator paused", nodeId);
+                                LOGGER.log(Level.INFO, "{0} activator paused", nodeId);
                                 resume.awaitUninterruptibly();
-                                LOGGER.log(Level.SEVERE, "{0} activator resumed", nodeId);
+                                LOGGER.log(Level.INFO, "{0} activator resumed", nodeId);
                                 continue;
                             }
                         } finally {
@@ -1038,7 +1038,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 } catch (Exception err) {
                     LOGGER.log(Level.SEVERE, "error during shutdown", err);
                 }
-                LOGGER.log(Level.SEVERE, "{0} activator stopped", nodeId);
+                LOGGER.log(Level.INFO, "{0} activator stopped", nodeId);
             } catch (RuntimeException err) {
                 LOGGER.log(Level.SEVERE, "fatal activator erro", err);
             }
@@ -1201,19 +1201,23 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                                 .findAny()
                                 .orElse(null);
                         if (leaderState == null) {
-                            LOGGER.log(Level.SEVERE, "Leader for " + tableSpaceUuid + " should be " + tableSpaceInfo.leaderId + ", but it never sent pings or it disappeared");
-                            tryBecomeLeaderFor(tableSpaceInfo);
-                        } else {
-                            long delta = now - leaderState.timestamp;
-                            if (tableSpaceInfo.maxLeaderInactivityTime > delta) {
-                                LOGGER.log(Level.FINER, "Leader for " + tableSpaceUuid + " is " + leaderState.nodeId + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is healty");
-                            } else {
-                                LOGGER.log(Level.SEVERE, "Leader for " + tableSpaceUuid + " is " + leaderState.nodeId + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is failed. trying to take leadership");
-                                tryBecomeLeaderFor(tableSpaceInfo);
-                                // only one change at a time
-                                break;
-                            }
+                            leaderState = new TableSpaceReplicaState(tableSpaceUuid, tableSpaceInfo.leaderId, tableSpaceInfo.metadataStorageCreationTime, TableSpaceReplicaState.MODE_STOPPED);
+                            LOGGER.log(Level.INFO, "Leader for " + tableSpaceUuid + " should be " + tableSpaceInfo.leaderId + ", but it never sent pings or it disappeared,"
+                                    + " considering last activity as tablespace creation time: "+new java.sql.Timestamp(tableSpaceInfo.metadataStorageCreationTime)+" to leave a minimal grace period");
                         }
+                        
+                        long delta = now - leaderState.timestamp;
+                        if (tableSpaceInfo.maxLeaderInactivityTime > delta) {
+                            LOGGER.log(Level.FINER, "Leader for " + tableSpaceUuid + " is " + leaderState.nodeId
+                                    + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is healty");
+                        } else {
+                            LOGGER.log(Level.SEVERE, "Leader for " + tableSpaceUuid + " is " + leaderState.nodeId
+                                    + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is failed. trying to take leadership");
+                            tryBecomeLeaderFor(tableSpaceInfo);
+                            // only one change at a time
+                            break;
+                        }
+                        
                     }
                 }
             } catch (MetadataStorageManagerException | DDLException error) {
@@ -1283,7 +1287,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
     @Override
     public void metadataChanged() {
-        LOGGER.log(Level.SEVERE, "metadata changed");
+        LOGGER.log(Level.INFO, "metadata changed");
         triggerActivator(ActivatorRunRequest.TABLESPACEMANAGEMENT);
     }
 

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -1203,9 +1203,9 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                         if (leaderState == null) {
                             leaderState = new TableSpaceReplicaState(tableSpaceUuid, tableSpaceInfo.leaderId, tableSpaceInfo.metadataStorageCreationTime, TableSpaceReplicaState.MODE_STOPPED);
                             LOGGER.log(Level.INFO, "Leader for " + tableSpaceUuid + " should be " + tableSpaceInfo.leaderId + ", but it never sent pings or it disappeared,"
-                                    + " considering last activity as tablespace creation time: "+new java.sql.Timestamp(tableSpaceInfo.metadataStorageCreationTime)+" to leave a minimal grace period");
+                                    + " considering last activity as tablespace creation time: " + new java.sql.Timestamp(tableSpaceInfo.metadataStorageCreationTime) + " to leave a minimal grace period");
                         }
-                        
+
                         long delta = now - leaderState.timestamp;
                         if (tableSpaceInfo.maxLeaderInactivityTime > delta) {
                             LOGGER.log(Level.FINER, "Leader for " + tableSpaceUuid + " is " + leaderState.nodeId
@@ -1217,7 +1217,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                             // only one change at a time
                             break;
                         }
-                        
+
                     }
                 }
             } catch (MetadataStorageManagerException | DDLException error) {

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -147,9 +147,9 @@ public class FileDataStorageManager extends DataStorageManager {
     @Override
     public void start() throws DataStorageManagerException {
         try {
-            LOGGER.log(Level.SEVERE, "ensuring directory {0}", baseDirectory.toAbsolutePath().toString());
+            LOGGER.log(Level.INFO, "ensuring directory {0}", baseDirectory.toAbsolutePath().toString());
             Files.createDirectories(baseDirectory);
-            LOGGER.log(Level.SEVERE, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+            LOGGER.log(Level.INFO, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
             FileUtils.cleanDirectory(tmpDirectory);
             Files.createDirectories(tmpDirectory);
         } catch (IOException err) {
@@ -159,7 +159,7 @@ public class FileDataStorageManager extends DataStorageManager {
 
     @Override
     public void close() throws DataStorageManagerException {
-        LOGGER.log(Level.SEVERE, "cleaning tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+        LOGGER.log(Level.INFO, "cleaning tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
         try {
             FileUtils.cleanDirectory(tmpDirectory);
         } catch (IOException err) {
@@ -657,7 +657,7 @@ public class FileDataStorageManager extends DataStorageManager {
         if (Files.isRegularFile(checkpointFile)) {
             IndexStatus actualStatus = readIndexStatusFromFile(checkpointFile);
             if (actualStatus != null && actualStatus.equals(indexStatus)) {
-                LOGGER.log(Level.SEVERE,
+                LOGGER.log(Level.INFO,
                         "indexCheckpoint " + tableSpace + ", " + indexName + ": " + indexStatus + " already saved on" + checkpointFile);
                 return Collections.emptyList();
             }
@@ -817,7 +817,7 @@ public class FileDataStorageManager extends DataStorageManager {
             long pageId = getPageId(p);
             LOGGER.log(Level.FINER, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId);
             if (pageId > 0 && !activePagesAtBoot.contains(pageId)) {
-                LOGGER.log(Level.SEVERE, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted");
+                LOGGER.log(Level.INFO, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted");
                 try {
                     Files.deleteIfExists(p);
                 } catch (IOException err) {
@@ -951,13 +951,13 @@ public class FileDataStorageManager extends DataStorageManager {
                 exists = Files.exists(path);
 
                 if (exists) {
-                    LOGGER.log(Level.SEVERE,
+                    LOGGER.log(Level.INFO,
                             "Path {0}: directory {1}, file {2}, link {3}, writable {4}, readable {5}, executable {6}",
                             new Object[] { path, Files.isDirectory(path), Files.isRegularFile(path),
                                     Files.isSymbolicLink(path), Files.isWritable(path), Files.isReadable(path),
                                     Files.isExecutable(path) });
                 } else {
-                    LOGGER.log(Level.SEVERE, "Path {0} doesn't exists", path);
+                    LOGGER.log(Level.INFO, "Path {0} doesn't exists", path);
                 }
 
                 path = path.getParent();
@@ -1020,10 +1020,10 @@ public class FileDataStorageManager extends DataStorageManager {
             Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
             Files.createDirectories(tableSpaceDirectory);
             Path file = getTablespaceTablesMetadataFile(tableSpace, sequenceNumber);
-            LOGGER.log(Level.SEVERE, "loadTables for tableSpace " + tableSpace + " from " + file.toAbsolutePath().toString() + ", sequenceNumber:" + sequenceNumber);
+            LOGGER.log(Level.INFO, "loadTables for tableSpace " + tableSpace + " from " + file.toAbsolutePath().toString() + ", sequenceNumber:" + sequenceNumber);
             if (!Files.isRegularFile(file)) {
                 if (sequenceNumber.isStartOfTime()) {
-                    LOGGER.log(Level.SEVERE, "file " + file.toAbsolutePath().toString() + " not found");
+                    LOGGER.log(Level.INFO, "file " + file.toAbsolutePath().toString() + " not found");
                     return Collections.emptyList();
                 } else {
                     throw new DataStorageManagerException("local table data not available for tableSpace " + tableSpace + ", recovering from sequenceNumber " + sequenceNumber);
@@ -1071,10 +1071,10 @@ public class FileDataStorageManager extends DataStorageManager {
             Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
             Files.createDirectories(tableSpaceDirectory);
             Path file = getTablespaceIndexesMetadataFile(tableSpace, sequenceNumber);
-            LOGGER.log(Level.SEVERE, "loadIndexes for tableSpace " + tableSpace + " from " + file.toAbsolutePath().toString() + ", sequenceNumber:" + sequenceNumber);
+            LOGGER.log(Level.INFO, "loadIndexes for tableSpace " + tableSpace + " from " + file.toAbsolutePath().toString() + ", sequenceNumber:" + sequenceNumber);
             if (!Files.isRegularFile(file)) {
                 if (sequenceNumber.isStartOfTime()) {
-                    LOGGER.log(Level.SEVERE, "file " + file.toAbsolutePath().toString() + " not found");
+                    LOGGER.log(Level.INFO, "file " + file.toAbsolutePath().toString() + " not found");
                     return Collections.emptyList();
                 } else {
                     throw new DataStorageManagerException("local index data not available for tableSpace " + tableSpace + ", recovering from sequenceNumber " + sequenceNumber);

--- a/herddb-core/src/main/java/herddb/file/FileMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileMetadataStorageManager.java
@@ -214,7 +214,7 @@ public class FileMetadataStorageManager extends MetadataStorageManager {
             if (version != 1 || flags != 0) {
                 throw new IOException("corrupted data file " + p.toAbsolutePath());
             }
-            ts = TableSpace.deserialize(iin, 0);
+            ts = TableSpace.deserialize(iin, 0, 0);
         }
         return ts;
     }

--- a/herddb-core/src/main/java/herddb/model/TableSpace.java
+++ b/herddb-core/src/main/java/herddb/model/TableSpace.java
@@ -64,7 +64,7 @@ public class TableSpace {
     public final long maxLeaderInactivityTime;
 
     public final Object metadataStorageVersion;
-    
+
     public final long metadataStorageCreationTime;
 
     private TableSpace(

--- a/herddb-core/src/main/java/herddb/model/TableSpace.java
+++ b/herddb-core/src/main/java/herddb/model/TableSpace.java
@@ -64,10 +64,12 @@ public class TableSpace {
     public final long maxLeaderInactivityTime;
 
     public final Object metadataStorageVersion;
+    
+    public final long metadataStorageCreationTime;
 
     private TableSpace(
             String uuid, String name, String leaderId, Set<String> replicas, int expectedReplicaCount,
-            long maxLeaderInactivityTime, Object metadataStorageVersion
+            long maxLeaderInactivityTime, Object metadataStorageVersion, long metadataStorageCreationTime
     ) {
         this.name = name;
         this.uuid = uuid;
@@ -76,17 +78,18 @@ public class TableSpace {
         this.expectedReplicaCount = expectedReplicaCount;
         this.metadataStorageVersion = metadataStorageVersion;
         this.maxLeaderInactivityTime = maxLeaderInactivityTime;
+        this.metadataStorageCreationTime = metadataStorageCreationTime;
     }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    public static TableSpace deserialize(byte[] data, Object metadataStorageVersion) throws IOException {
-        return deserialize(new ExtendedDataInputStream(new SimpleByteArrayInputStream(data)), metadataStorageVersion);
+    public static TableSpace deserialize(byte[] data, Object metadataStorageVersion, long metadataStorageCreationTime) throws IOException {
+        return deserialize(new ExtendedDataInputStream(new SimpleByteArrayInputStream(data)), metadataStorageVersion, metadataStorageCreationTime);
     }
 
-    public static TableSpace deserialize(ExtendedDataInputStream in, Object metadataStorageVersion) throws IOException {
+    public static TableSpace deserialize(ExtendedDataInputStream in, Object metadataStorageVersion, long metadataStorageCreationTime) throws IOException {
         long version = in.readVLong(); // version
         long flags = in.readVLong(); // flags for future implementations
         if (version != 1 || flags != 0) {
@@ -102,7 +105,7 @@ public class TableSpace {
             replicas.add(in.readUTF());
         }
         long maxLeaderInactivityTime = in.readVLong();
-        return new TableSpace(uuid, name, leaderId, replicas, expectedReplicaCount, maxLeaderInactivityTime, metadataStorageVersion);
+        return new TableSpace(uuid, name, leaderId, replicas, expectedReplicaCount, maxLeaderInactivityTime, metadataStorageVersion, metadataStorageCreationTime);
     }
 
     public byte[] serialize() throws IOException {
@@ -211,7 +214,7 @@ public class TableSpace {
             if (maxLeaderInactivityTime > 0 && maxLeaderInactivityTime < 5000) {
                 throw new IllegalArgumentException("maxLeaderInactivityTime must be >= 5000");
             }
-            return new TableSpace(uuid, name, leaderId, Collections.unmodifiableSet(replicas), expectedReplicaCount, maxLeaderInactivityTime, null);
+            return new TableSpace(uuid, name, leaderId, Collections.unmodifiableSet(replicas), expectedReplicaCount, maxLeaderInactivityTime, null, 0);
         }
 
     }

--- a/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
@@ -202,9 +202,9 @@ public class NettyChannelAcceptor implements AutoCloseable {
     public void start() throws Exception {
         if (ssl) {
             if (sslCertFile == null) {
-                LOGGER.log(Level.SEVERE, "start SSL with self-signed auto-generated certificate");
+                LOGGER.log(Level.INFO, "start SSL with self-signed auto-generated certificate");
                 if (sslCiphers != null) {
-                    LOGGER.log(Level.SEVERE, "required sslCiphers " + sslCiphers);
+                    LOGGER.log(Level.INFO, "required sslCiphers " + sslCiphers);
                 }
                 SelfSignedCertificate ssc = new SelfSignedCertificate();
                 try {
@@ -213,9 +213,9 @@ public class NettyChannelAcceptor implements AutoCloseable {
                     ssc.delete();
                 }
             } else {
-                LOGGER.log(Level.SEVERE, "start SSL with certificate " + sslCertFile.getAbsolutePath() + " chain file " + sslCertChainFile.getAbsolutePath());
+                LOGGER.log(Level.INFO, "start SSL with certificate " + sslCertFile.getAbsolutePath() + " chain file " + sslCertChainFile.getAbsolutePath());
                 if (sslCiphers != null) {
-                    LOGGER.log(Level.SEVERE, "required sslCiphers " + sslCiphers);
+                    LOGGER.log(Level.INFO, "required sslCiphers " + sslCiphers);
                 }
                 sslCtx = SslContextBuilder.forServer(sslCertChainFile, sslCertFile, sslCertPassword).ciphers(sslCiphers).build();
             }
@@ -248,7 +248,7 @@ public class NettyChannelAcceptor implements AutoCloseable {
 
         });
         InetSocketAddress address = new InetSocketAddress(host, port);
-        LOGGER.log(Level.SEVERE, "Starting HerdDB network server at {0}:{1}", new Object[]{host, port + ""});
+        LOGGER.log(Level.INFO, "Starting HerdDB network server at {0}:{1}", new Object[]{host, port + ""});
         if (address.isUnresolved()) {
             throw new IOException("Bind address " + host + ":" + port + " cannot be resolved");
         }


### PR DESCRIPTION
Give a little more time to the new leader to write its state right after the creation of the tablespace.
Clean up logs during the boot, some "SEVERE" logs should be reported as INFO