### PR TITLE
Make automatic failover more stable

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -1213,7 +1213,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                                     + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is healty");
                         } else {
                             LOGGER.log(Level.SEVERE, "Leader for " + tableSpaceUuid + " is " + tableSpaceInfo.leaderId
-                                    + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is failed. "+nodeId+" now trying to take leadership");
+                                    + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is failed. " + nodeId + " now trying to take leadership");
                             tryBecomeLeaderFor(tableSpaceInfo);
                             // only one change at a time
                             break;


### PR DESCRIPTION
This patch simply make it more clear that a node should take into account the last ping for the leader only of counting on the replica state of the current known leader.
This makes the system converge more quickly to a new leader