### PR TITLE
Remove spammy log for healty leader

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -1209,7 +1209,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
                         long delta = now - leaderState.timestamp;
                         if (tableSpaceInfo.maxLeaderInactivityTime > delta) {
-                            LOGGER.log(Level.SEVERE, "Leader for " + tableSpaceUuid + " is " + tableSpaceInfo.leaderId
+                            LOGGER.log(Level.FINE, "Leader for " + tableSpaceUuid + " is " + tableSpaceInfo.leaderId
                                     + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is healty");
                         } else {
                             LOGGER.log(Level.SEVERE, "Leader for " + tableSpaceUuid + " is " + tableSpaceInfo.leaderId


### PR DESCRIPTION
Just lower spammy log about leadership healty state (1 row x second x tablespace defined)

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
