### PR TITLE
PR for https://github.com/diennea/herddb/issues/468

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -317,7 +317,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                         foundPk = true;
                         tablebuilder.primaryKey(columnName, auto_increment);
                     }
-                    if (auto_increment && primaryKey.contains(cf.getColumnName())) {
+                    if (auto_increment && primaryKey.contains(columnName)) {
                         tablebuilder.primaryKey(columnName, auto_increment);
                     }
 

--- a/herddb-core/src/test/java/herddb/sql/functions/ShowCreateTableCalculatorTest.java
+++ b/herddb-core/src/test/java/herddb/sql/functions/ShowCreateTableCalculatorTest.java
@@ -226,5 +226,19 @@ public class ShowCreateTableCalculatorTest {
 
         tm = new MockTableManager(t, new ArrayList<>());
         assertTrue(ShowCreateTableCalculator.calculate(false, "test3", "ts1", tm).equals("CREATE TABLE ts1.test3(k1 integer auto_increment,s1 string not null,l1 long not null,i1 integer not null,PRIMARY KEY(k1))"));
+
+        t = Table.builder()
+                .uuid("1234")
+                .column("ID", ColumnTypes.INTEGER, 0)
+                .column("s1", ColumnTypes.NOTNULL_STRING, 1)
+                .column("l1", ColumnTypes.NOTNULL_LONG, 2)
+                .column("i1", ColumnTypes.NOTNULL_INTEGER, 3)
+                .primaryKey("ID", true)
+                .tablespace("ts1")
+                .name("test4")
+                .build();
+
+        tm = new MockTableManager(t, new ArrayList<>());
+        assertTrue(ShowCreateTableCalculator.calculate(false, "test4", "ts1", tm).equals("CREATE TABLE ts1.test4(id integer auto_increment,s1 string not null,l1 long not null,i1 integer not null,PRIMARY KEY(id))"));
     }
 }


### PR DESCRIPTION
The fix for this PR deals with using lower case to search for columns that are auto_increment are also part of primary key. We lowercase the primary keys column names and were searching the list for it with uppercase name. Hence we would not find it. The fix deals with this issue. 