### PR TITLE
Make JdbcDriverZookeeperTest less Flaky

### DIFF
--- a/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
@@ -41,6 +41,7 @@ public class ZKTestEnv implements AutoCloseable {
 
     public ZKTestEnv(Path path) throws Exception {
         zkServer = new TestingServer(1282, path.toFile(), true);
+        // waiting for ZK to be reachable
         CountDownLatch latch = new CountDownLatch(1);
         ZooKeeper zk = new ZooKeeper(zkServer.getConnectString(), 100, (WatchedEvent event) -> {
             System.out.println("ZK EVENT " + event);

--- a/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-jdbc/src/test/java/herddb/utils/ZKTestEnv.java
@@ -1,33 +1,37 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.utils;
 
 import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
 
 public class ZKTestEnv implements AutoCloseable {
 
@@ -37,6 +41,15 @@ public class ZKTestEnv implements AutoCloseable {
 
     public ZKTestEnv(Path path) throws Exception {
         zkServer = new TestingServer(1282, path.toFile(), true);
+        CountDownLatch latch = new CountDownLatch(1);
+        ZooKeeper zk = new ZooKeeper(zkServer.getConnectString(), 100, (WatchedEvent event) -> {
+            System.out.println("ZK EVENT " + event);
+            if (event.getState() == KeeperState.SyncConnected) {
+                latch.countDown();
+            }
+        });
+        latch.await(1000, TimeUnit.SECONDS);
+        zk.close(1000);
         this.path = path;
     }
 
@@ -67,7 +80,6 @@ public class ZKTestEnv implements AutoCloseable {
 
         conf.setAllowLoopback(true);
         conf.setProperty("journalMaxGroupWaitMSec", 10); // default 200ms
-
 
         try (ZooKeeperClient zkc = ZooKeeperClient
                 .newBuilder()


### PR DESCRIPTION
The test is failing very ofter on Jenkins, let's wait for ZK to be up and running.

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 13.897 s <<< FAILURE! - in herddb.jdbc.JdbcDriverZookeeperTest
[ERROR] test(herddb.jdbc.JdbcDriverZookeeperTest)  Time elapsed: 13.807 s  <<< ERROR!
org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:102)
	at org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase.waitForConnection(ZooKeeperWatcherBase.java:159)
	at org.apache.bookkeeper.zookeeper.ZooKeeperClient$Builder.build(ZooKeeperClient.java:257)
	at herddb.utils.ZKTestEnv.startBookie(ZKTestEnv.java:76)
	at herddb.utils.ZKTestEnv.startBookie(ZKTestEnv.java:44)
	at herddb.jdbc.JdbcDriverZookeeperTest.beforeSetup(JdbcDriverZookeeperTest.java:50)
```