### PR TITLE
Upgrade ZooKeeper to 3.5.6

### DIFF
--- a/herddb-jdbc/pom.xml
+++ b/herddb-jdbc/pom.xml
@@ -37,6 +37,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${libs.slf4j}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>         
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,11 @@
         <libs.calcite>1.19.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
         <libs.jackson.mapper>1.9.11</libs.jackson.mapper>
-        <libs.zookeeper>3.5.5</libs.zookeeper>
+        <libs.zookeeper>3.5.6</libs.zookeeper>
         <libs.jsqlparser>0.9.7</libs.jsqlparser>
         <libs.curator>2.12.0</libs.curator>
         <libs.guava>21.0</libs.guava>
-        <libs.slf4j>1.7.21</libs.slf4j>
+        <libs.slf4j>1.7.29</libs.slf4j>
         <libs.commonscollections>3.2.1</libs.commonscollections>
         <libs.lz4>1.3.0</libs.lz4>
         <libs.bookkeeper>4.10.0</libs.bookkeeper>


### PR DESCRIPTION
- upgrade ZooKeeper to 3.5.6
- add slf4j implementation to JDBC tests, in order to better see errors on Jenkins
