### PR TITLE
Retain column aliases with identity scans

### DIFF
--- a/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
@@ -43,7 +43,11 @@ public class ScanStatement extends TableAwareStatement {
     private Table tableDef;
 
     public ScanStatement(String tableSpace, Table table, Predicate predicate) {
-        this(tableSpace, table.name, Projection.IDENTITY(table.columnNames, table.columns), predicate, null, null);
+        this(tableSpace, table, Projection.IDENTITY(table.columnNames, table.columns), predicate);
+    }
+
+    public ScanStatement(String tableSpace, Table table, final Projection projection, Predicate predicate) {
+        this(tableSpace, table.name, projection, predicate, null, null);
         this.tableDef = table;
     }
 

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -787,19 +787,24 @@ public class CalcitePlanner implements AbstractSQLPlanner {
         Column[] columns = table.getColumns();
         int numColumns = columns.length;
         boolean usingAliases = false;
-        for (int i = 0; i < numColumns; i++) {
-            String alias = rowType.getFieldNames().get(i).toLowerCase();
-            String colName = columns[i].name;
-            if (!alias.equals(colName)) {
-                usingAliases = true;
-                break;
+        if (rowType != null) {
+            List<String> fieldNamesFromQuery = rowType.getFieldNames();
+            for (int i = 0; i < numColumns; i++) {
+                String fieldName = fieldNamesFromQuery.get(i);
+                String alias = fieldName.toLowerCase();
+                String colName = columns[i].name;
+                if (!alias.equals(colName)) {
+                    usingAliases = true;
+                    break;
+                }
             }
         }
         if (usingAliases) {
+            List<String> fieldNamesFromQuery = rowType.getFieldNames();
             String[] fieldNames = new String[numColumns];
             int[] projections = new int[numColumns];
             for (int i = 0; i < numColumns; i++) {
-                String alias = rowType.getFieldNames().get(i).toLowerCase();
+                String alias = fieldNamesFromQuery.get(i).toLowerCase();
                 fieldNames[i] = alias;
                 projections[i] = i;
             }


### PR DESCRIPTION
In case of a scan with IdentityProjection that aliases names of column we must use ZeroCopyProjection in order to preserve alias names

fixes #513 
