### PR TITLE
Clean up CLI jar

### DIFF
--- a/herddb-cli/pom.xml
+++ b/herddb-cli/pom.xml
@@ -9,32 +9,38 @@
     <modelVersion>4.0.0</modelVersion>
     <name>HerdDB CLI</name>
     <artifactId>herddb-cli</artifactId>
-    <dependencies>       
+    <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>herddb-jdbc</artifactId>
-            <version>${project.version}</version>            
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.rocksdb</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>                  
-        </dependency>        
+            <artifactId>commons-cli</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <classifier>indy</classifier>            
+            <classifier>indy</classifier>
         </dependency>
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-        </dependency>               
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>            
+            <artifactId>slf4j-jdk14</artifactId>
         </dependency>
     </dependencies>
     <build>
-        <plugins>            
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -44,7 +50,7 @@
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
-                        </goals>                        
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -58,15 +64,14 @@
                             </excludes>
                         </filter>
                     </filters>
-                </configuration>   
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifest>
-                            <addClasspath>true</addClasspath>
                             <mainClass>herddb.cli.HerdDBCLI</mainClass>
                         </manifest>
                     </archive>


### PR DESCRIPTION
- remove RocksDB jar, not useful and it keeps 10MB
- remove Class-Path entry in herddb-cli jar, not needed and it creates spam logs due to duplicate slf4j bindings