### PR TITLE
Fix race condition that leads to NPE in case of internal BookKeeper error

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -257,7 +257,7 @@ public class BookkeeperCommitLog extends CommitLog {
                 // we are "closed", no need to create a new writer
                 return _writer;
             }
-            if (!_writer.isWritable()) {
+            if (_writer == null || !_writer.isWritable()) {
                 lock.readLock().unlock();
                 lock.writeLock().lock();
                 if (closed) {
@@ -266,7 +266,7 @@ public class BookkeeperCommitLog extends CommitLog {
                 }
                 try {
                     _writer = writer;
-                    if (!_writer.isWritable()) {
+                    if (_writer == null || !_writer.isWritable()) {
                         return openNewLedger();
                     }
                 } finally {


### PR DESCRIPTION
This is a fix for #521 

It is very difficult to reproduce the error, but actually in all of the code paths that access 'writer' object we are testing for a null value and not for the case of the NPE.
