### PR TITLE
Add new configFile JDBC url string parameter to ease setup of embedded server

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -20,9 +20,16 @@
 
 package herddb.client;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Client configuration
@@ -31,6 +38,7 @@ import java.util.Properties;
  */
 public class ClientConfiguration {
 
+    private static final Logger LOG = Logger.getLogger(ClientConfiguration.class.getName());
     private final Properties properties;
 
     /**
@@ -198,6 +206,25 @@ public class ClientConfiguration {
                     set(param, "");
                 }
             }
+        }
+        readAdditionalProperties();
+
+    }
+
+    private void readAdditionalProperties() {
+        String configFile = getString("configFile", "");
+        if (!configFile.isEmpty()) {
+            File file = new File(configFile);
+            LOG.log(Level.INFO, "Reading additional configuration file configFile={0}", file.getAbsolutePath());
+            Properties additionalProperties = new Properties();
+            try (InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
+                additionalProperties.load(reader);
+            } catch (IOException err) {
+                throw new RuntimeException(err);
+            }
+            additionalProperties.forEach((k, v) -> {
+                set(k.toString(), v);
+            });
         }
     }
 

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -21,6 +21,11 @@
 package herddb.server;
 
 import herddb.utils.SystemProperties;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -378,7 +383,6 @@ public final class ServerConfiguration {
         if (questionMark < url.length()) {
             String qs = url.substring(questionMark + 1);
             String[] params = qs.split("&");
-            LOG.log(Level.SEVERE, "url " + url + " qs " + qs + " params " + Arrays.toString(params));
             for (String param : params) {
                 // TODO: URLDecoder??
                 int pos = param.indexOf('=');
@@ -390,6 +394,25 @@ public final class ServerConfiguration {
                     set(param, "");
                 }
             }
+        }
+        readAdditionalProperties();
+
+    }
+
+    private void readAdditionalProperties() {
+        String configFile = getString("configFile", "");
+        if (!configFile.isEmpty()) {
+            File file = new File(configFile);
+            LOG.log(Level.INFO, "Reading additional server configuration file configFile={0}", file.getAbsolutePath());
+            Properties additionalProperties = new Properties();
+            try (InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
+                additionalProperties.load(reader);
+            } catch (IOException err) {
+                throw new RuntimeException(err);
+            }
+            additionalProperties.forEach((k, v) -> {
+                set(k.toString(), v);
+            });
         }
     }
 

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;

--- a/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
@@ -180,7 +180,11 @@ public class BasicHerdDBDataSource implements javax.sql.DataSource, AutoCloseabl
                 propsNoPassword.setProperty("password", "-------");
             }
             LOGGER.log(Level.INFO, "Booting HerdDB Client, url:" + url + ", properties:" + propsNoPassword + " clientConfig " + clientConfiguration);
-            clientConfiguration.readJdbcUrl(url);
+            try {
+                clientConfiguration.readJdbcUrl(url);
+            } catch (RuntimeException err) {
+                throw new SQLException(err);
+            }
             if (properties.containsKey("discoverTableSpaceFromQuery")) {
                 this.discoverTableSpaceFromQuery = clientConfiguration.getBoolean("discoverTableSpaceFromQuery", true);
             }

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBEmbeddedDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBEmbeddedDataSource.java
@@ -77,7 +77,11 @@ public class HerdDBEmbeddedDataSource extends BasicHerdDBDataSource {
     private void startEmbeddedServer() throws SQLException {
         if (!serverInitialized) {
             ServerConfiguration serverConfiguration = new ServerConfiguration(properties);
-            serverConfiguration.readJdbcUrl(url);
+            try {
+                serverConfiguration.readJdbcUrl(url);
+            } catch (RuntimeException err) {
+                throw new SQLException(err);
+            }
             startServer = serverConfiguration.getBoolean("server.start", startServer);
             String mode = serverConfiguration.getString(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_LOCAL);
             if (ServerConfiguration.PROPERTY_MODE_LOCAL.equals(mode)

--- a/herddb-jdbc/src/test/java/herddb/jdbc/SimpleEmbeddedTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/SimpleEmbeddedTest.java
@@ -50,7 +50,7 @@ public class SimpleEmbeddedTest {
             dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
             dataSource.getProperties().setProperty(ClientConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
             try (Connection con = dataSource.getConnection();
-                 Statement statement = con.createStatement()) {
+                    Statement statement = con.createStatement()) {
                 statement.execute("CREATE TABLE mytable (key string primary key, name string)");
                 assertEquals(1, statement.executeUpdate("INSERT INTO mytable (key,name) values('k1','name1')"));
                 try (ResultSet rs = statement.executeQuery("SELECT * FROM mytable")) {
@@ -68,20 +68,20 @@ public class SimpleEmbeddedTest {
         }
     }
 
-     @Test
+    @Test
     public void testAdditionalConfiguration() throws Exception {
         File baseDir = folder.newFolder();
         File file = new File(baseDir, "additionalConfiguration.txt");
         try (FileWriter w = new FileWriter(file);) {
-            w.write("server.base.dir="+baseDir.getAbsolutePath()+"\n");
-            w.write("client.base.dir="+baseDir.getAbsolutePath()+"\n");
+            w.write("server.base.dir=" + baseDir.getAbsolutePath() + "\n");
+            w.write("client.base.dir=" + baseDir.getAbsolutePath() + "\n");
             w.write("server.start=true");
         }
 
         try (HerdDBEmbeddedDataSource dataSource = new HerdDBEmbeddedDataSource()) {
-            dataSource.setUrl("jdbc:herddb:server:localhost:7000?configFile="+file.getAbsolutePath());
+            dataSource.setUrl("jdbc:herddb:server:localhost:7000?configFile=" + file.getAbsolutePath());
             try (Connection con = dataSource.getConnection();
-                Statement statement = con.createStatement()) {
+                    Statement statement = con.createStatement()) {
                 assertEquals(baseDir.getAbsolutePath(), dataSource.getServer().getManager().getServerConfiguration().getString(ServerConfiguration.PROPERTY_BASEDIR, ""));
                 assertEquals(baseDir.getAbsolutePath(), dataSource.getClient().getConfiguration().getString(ClientConfiguration.PROPERTY_BASEDIR, ""));
                 statement.execute("CREATE TABLE mytable (key string primary key, name string)");


### PR DESCRIPTION
Setting up an embedded server using pure JDBC URL is very difficult.
We can let the user create a simple properties file and link to it

jdbc:herddb:server:localhost:7000?configFile=PATH/TO/CONFIGFILE

