### PR TITLE
Fix table name case sensitivity during index creation

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -420,7 +420,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
             }
             String tableName = s.getTable().getName().toLowerCase();
 
-            String indexName = s.getIndex().getName();
+            String indexName = s.getIndex().getName().toLowerCase();
             String indexType = convertIndexType(s.getIndex().getType());
 
             herddb.model.Index.Builder builder = herddb.model.Index

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -372,11 +372,10 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
 
                         herddb.model.Index.Builder builder = herddb.model.Index
                                 .builder()
+                                .onTable(table)
                                 .name(indexName)
                                 .type(indexType)
-                                .uuid(UUID.randomUUID().toString())
-                                .table(tableName)
-                                .tablespace(tableSpace);
+                                .uuid(UUID.randomUUID().toString());
 
                         for (String columnName : index.getColumnsNames()) {
                             columnName = fixMySqlBackTicks(columnName.toLowerCase());
@@ -419,9 +418,9 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
             if (tableSpace == null) {
                 tableSpace = defaultTableSpace;
             }
-            String tableName = s.getTable().getName();
+            String tableName = s.getTable().getName().toLowerCase();
 
-            String indexName = s.getIndex().getName().toLowerCase();
+            String indexName = s.getIndex().getName();
             String indexType = convertIndexType(s.getIndex().getType());
 
             herddb.model.Index.Builder builder = herddb.model.Index


### PR DESCRIPTION
HerdDB fails to create indexes on tables when using uppercase table name like:
```
CREATE TABLE tbl1.TABLE_1 (TABLE_ID BIGINT NOT NULL, FIELD INT NOT NULL, PRIMARY KEY (TABLE_ID))
CREATE INDEX TABLE_1_INDEX ON tbl1.TABLE_1(TABLE_ID,FIELD)
```
This patch fix table name case sensitivity on index creation

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
