### PR TITLE
Fix truncate table with indexes on file storage fix #489

### DIFF
--- a/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
@@ -182,6 +182,20 @@ public abstract class AbstractIndexManager implements AutoCloseable {
         dataStorageManager.dropIndex(tableSpaceUUID, index.uuid);
     }
 
+    /**
+     * Truncate the index from persist storage
+     * <p>
+     * Differs from {@link #dropIndexData()} because it leaves in place every support structure needed by
+     * index runtime (for example if index is persisted into a directory it doesn't delete the directory
+     * itself). The index will continue to work but without current data that will be erased
+     * </p>
+     *
+     * @throws DataStorageManagerException
+     */
+    public void truncateIndexData() throws DataStorageManagerException {
+        dataStorageManager.truncateIndex(tableSpaceUUID, index.uuid);
+    }
+
     final void onTransactionCommit(Transaction transaction, boolean recovery) throws DataStorageManagerException {
         if (createdInTransaction > 0) {
             if (transaction.transactionId != createdInTransaction) {

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -479,7 +479,7 @@ public class BRINIndexManager extends AbstractIndexManager {
     @Override
     public void truncate() throws DataStorageManagerException {
         this.data.reset();
-        dropIndexData();
+        truncateIndexData();
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -542,6 +542,11 @@ public class MemoryDataStorageManager extends DataStorageManager {
     }
 
     @Override
+    public void truncateIndex(String tableSpaceUUID, String name) throws DataStorageManagerException {
+        dropIndex(tableSpaceUUID, name);
+    }
+
+    @Override
     public void dropIndex(String tablespace, String name) throws DataStorageManagerException {
         List<Index> indexes = indexesByTablespace.get(tablespace);
         if (indexes != null) {

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -247,6 +247,8 @@ public abstract class DataStorageManager implements AutoCloseable {
     public abstract void cleanupAfterBoot(String tablespace, String name, Set<Long> activePagesAtBoot)
             throws DataStorageManagerException;
 
+    public abstract void truncateIndex(String tableSpaceUUID, String name) throws DataStorageManagerException;
+
     public abstract void dropIndex(String tableSpaceUUID, String name) throws DataStorageManagerException;
 
     /* Map[tablespace_uuid,Map[pageid,pincounts] */

--- a/herddb-utils/src/main/java/herddb/utils/CleanDirectoryFileVisitor.java
+++ b/herddb-utils/src/main/java/herddb/utils/CleanDirectoryFileVisitor.java
@@ -1,0 +1,68 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.utils;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * A {@link FileVisitor} which delete every file o directory found (excluding starting directory).
+ * <p>
+ * If the visitor is executed on a path denoting a simple file it will just delete the file and exit.
+ * </p>
+ *
+ * @author diego.salvi
+ */
+public final class CleanDirectoryFileVisitor extends SimpleFileVisitor<Path> {
+
+    private int level;
+
+    public CleanDirectoryFileVisitor() {
+        level = 0;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        // Delete only if is the first directory (level 0) */
+        if (--level > 0) {
+            Files.delete(dir);
+        }
+
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+        ++level;
+        return FileVisitResult.CONTINUE;
+    }
+}

--- a/herddb-utils/src/main/java/herddb/utils/DeleteFileVisitor.java
+++ b/herddb-utils/src/main/java/herddb/utils/DeleteFileVisitor.java
@@ -1,0 +1,53 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.utils;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * A {@link FileVisitor} which delete every file o directory found (including starting directory).
+ *
+ * @author diego.salvi
+ */
+public class DeleteFileVisitor extends SimpleFileVisitor<Path> {
+
+    public static final SimpleFileVisitor<Path> INSTANCE = new DeleteFileVisitor();
+
+    private DeleteFileVisitor() {}
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+    }
+}

--- a/herddb-utils/src/main/java/herddb/utils/FileUtils.java
+++ b/herddb-utils/src/main/java/herddb/utils/FileUtils.java
@@ -25,12 +25,9 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.BasicFileAttributes;
 
 /**
  * Utilities
@@ -46,20 +43,7 @@ public class FileUtils {
         if (!Files.isDirectory(directory)) {
             return;
         }
-        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                Files.delete(dir);
-                return FileVisitResult.CONTINUE;
-            }
-
-        });
+        Files.walkFileTree(directory, DeleteFileVisitor.INSTANCE);
     }
 
     public static byte[] fastReadFile(Path f) throws IOException {


### PR DESCRIPTION
Fixes #489 correcting index directory deletion on table truncate.
Add 2 utility classes to unify deletions and cleanups on directories


 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
