### PR TITLE
Allow to configure the replica count from the configuration file

### DIFF
--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -141,6 +141,9 @@ public final class ServerConfiguration {
     public static final String PROPERTY_CHECKPOINT_PERIOD = "server.checkpoint.period";
     public static final long PROPERTY_CHECKPOINT_PERIOD_DEFAULT = 1000L * 60 * 15;
 
+    public static final String PROPERTY_DEFAULT_REPLICA_COUNT = "tablespace.default.replica.count";
+    public static final int PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT = 1;
+
     public static final String PROPERTY_ABANDONED_TRANSACTIONS_TIMEOUT = "server.abandoned.transactions.timeout";
     public static final long PROPERTY_ABANDONED_TRANSACTIONS_TIMEOUT_DEFAULT = 1000L * 60 * 15; // 15 min, use 0 to disable
 

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -654,9 +654,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                 Object tableSpaceName = resolveValue(execute.getExprList().getExpressions().get(0), true);
                 String leader = null;
                 Set<String> replica = new HashSet<>();
-                int expectedreplicacount = this.manager.getServerConfiguration() != null
-                        ? this.manager.getServerConfiguration().getInt(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT)
-                        : 1;
+                int expectedreplicacount = this.manager.getServerConfiguration().getInt(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT);
                 long maxleaderinactivitytime = 0;
                 int wait = 0;
                 for (int i = 1; i < execute.getExprList().getExpressions().size(); i++) {

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -45,6 +45,7 @@ import herddb.model.commands.DropTableSpaceStatement;
 import herddb.model.commands.DropTableStatement;
 import herddb.model.commands.RollbackTransactionStatement;
 import herddb.model.commands.TruncateTableStatement;
+import herddb.server.ServerConfiguration;
 import herddb.utils.SQLUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -653,7 +654,9 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                 Object tableSpaceName = resolveValue(execute.getExprList().getExpressions().get(0), true);
                 String leader = null;
                 Set<String> replica = new HashSet<>();
-                int expectedreplicacount = 1;
+                int expectedreplicacount = this.manager.getServerConfiguration() != null
+                        ? this.manager.getServerConfiguration().getInt(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT)
+                        : 1;
                 long maxleaderinactivitytime = 0;
                 int wait = 0;
                 for (int i = 1; i < execute.getExprList().getExpressions().size(); i++) {

--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -61,12 +61,21 @@ server.ssl=false
 # Enable/Disable network acceptor
 # server.network.enabled=true
 
-# for server.mode=cluster
+# for server.mode=cluster you have to set a connection string to your ZooKeeper cluster
+# you have to write here the list of all of the zookeeper servers, not only one
 server.zookeeper.address=localhost:2181
 server.zookeeper.session.timeout=40000
 server.zookeeper.path=/herd
 
+# data replication settings
+# this is the default value for 'expectedreplicacount' for CREATE TABLESPACE command
+# this is the number of nodes that will eventually hold a copy of data
+# configuring this value is not enough in order to achive fault tolerance
+# you also have to configure at least server.bookkeeper.write.quorum.size
+# that drives the numbers of guaranteed copies of the commit log
+tablespace.default.replica.count=1
 
+# commit log replication settings
 # bookkeeper client parameters
 server.bookkeeper.ensemble.size=1
 server.bookkeeper.write.quorum.size=1


### PR DESCRIPTION
- add a new configuration parameter tablespace.default.replica.count=1 that is the default number of replicas
- enhance the default server.properties file
