### PR TITLE
Ensure correct LastSequenceNumber is published on checkpoint files on slow machines

### DIFF
--- a/herddb-core/src/main/java/herddb/log/CommitLog.java
+++ b/herddb-core/src/main/java/herddb/log/CommitLog.java
@@ -87,7 +87,7 @@ public abstract class CommitLog implements AutoCloseable {
     protected synchronized void notifyListeners(LogSequenceNumber logPos, LogEntry edit) {
         if (listeners != null) {
             for (CommitLogListener l : listeners) {
-                LOG.log(Level.SEVERE, "notifyListeners {0}, {1}", new Object[]{logPos, edit});
+                LOG.log(Level.INFO, "notifyListeners {0}, {1}", new Object[]{logPos, edit});
                 l.logEntry(logPos, edit);
             }
         }


### PR DESCRIPTION
This patches fixes an error condition in case of slow system.
When we are doing the checkpoint we sample the LastSequenceNumber for BookKeeperCommitLog.
It can happen that we are observing a stale value.
This patches ensures that when an entry is visible as committed that the LogSequenceNumber is correctly seen by the TableSpaceManager.

I managed to reproduce an error with a test case but it needs to instrument BookKeeperCommitLog inside the code that I have changed (replace *theAccept* with *theApply*)
Just by adding a Thread.sleep(2000) inside the body of "theAccept" lambda function we can observe failures