### PR TITLE
Remove duplicates while sending dump to followers in case of slow system

### DIFF
--- a/herddb-core/src/main/java/herddb/core/SingleTableDumper.java
+++ b/herddb-core/src/main/java/herddb/core/SingleTableDumper.java
@@ -30,7 +30,6 @@ import herddb.proto.Pdu;
 import herddb.proto.PduCodec;
 import herddb.storage.FullTableScanConsumer;
 import herddb.storage.TableStatus;
-import herddb.utils.Bytes;
 import herddb.utils.KeyValue;
 import java.util.ArrayList;
 import java.util.List;

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -2503,7 +2503,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         }
 
         final long fillPageThreshold = (long) (fillThreshold * maxLogicalPageSize);
-        final long dirtyPageThreshold = (long) (dirtyThreshold * maxLogicalPageSize);
+        final long dirtyPageThreshold = dirtyThreshold >0 ? (long) (dirtyThreshold * maxLogicalPageSize) : -1;
 
         long start = System.currentTimeMillis();
         long end;

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -494,9 +494,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
                         @Override
                         public void acceptPage(long pageId, List<Record> records) {
-                            for (Record record :records) {
+                            for (Record record : records) {
                                 keyToPage.put(record.key.nonShared(), pageId, null /* PK is empty */);
-                            };
+                            }
                         }
 
                         @Override
@@ -1869,7 +1869,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         checkpointLock.asReadLock().lock();
         try {
             for (Record r : record) {
-                System.out.println("GOT "+r.key);
                 applyInsert(r.key, r.value, false);
             }
         } finally {

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -2503,7 +2503,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         }
 
         final long fillPageThreshold = (long) (fillThreshold * maxLogicalPageSize);
-        final long dirtyPageThreshold = dirtyThreshold >0 ? (long) (dirtyThreshold * maxLogicalPageSize) : -1;
+        final long dirtyPageThreshold = dirtyThreshold > 0 ? (long) (dirtyThreshold * maxLogicalPageSize) : -1;
 
         long start = System.currentTimeMillis();
         long end;

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -291,7 +291,7 @@ public class TableSpaceManager {
         });
 
         if (dbmanager.getServerConfiguration().getBoolean(ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT, ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT_DEFAULT)) {
-            LOGGER.log(Level.SEVERE, nodeId + " full recovery of data is forced ("+ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT+"=true) for tableSpace " + tableSpaceName);
+            LOGGER.log(Level.SEVERE, nodeId + " full recovery of data is forced (" + ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT + "=true) for tableSpace " + tableSpaceName);
             downloadTableSpaceData();
             log.recovery(actualLogSequenceNumber, new ApplyEntryOnRecovery(), false);
         } else {

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -432,18 +432,14 @@ public class FileDataStorageManager extends DataStorageManager {
     }
 
     private void fullTableScan(String tableSpace, String tableUuid, TableStatus status, FullTableScanConsumer consumer) {
-        LOGGER.log(Level.FINER, "fullTableScan table " + tableSpace + "." + tableUuid + ", status: " + status);
+        LOGGER.log(Level.INFO, "fullTableScan table {0}.{1}, status: {2}", new Object[]{tableSpace, tableUuid, status});
         consumer.acceptTableStatus(status);
         List<Long> activePages = new ArrayList<>(status.activePages.keySet());
         activePages.sort(null);
         for (long idpage : activePages) {
             List<Record> records = readPage(tableSpace, tableUuid, idpage);
-            consumer.startPage(idpage);
-            LOGGER.log(Level.FINER, "fullTableScan table " + tableSpace + "." + tableUuid + ", page " + idpage + ", contains " + records.size() + " records");
-            for (Record record : records) {
-                consumer.acceptRecord(record);
-            }
-            consumer.endPage();
+            LOGGER.log(Level.FINE, "fullTableScan table {0}.{1}, page {2}, contains {3} records", new Object[]{tableSpace, tableUuid, idpage, records.size()});
+            consumer.acceptPage(idpage, records);
         }
         consumer.endTable();
     }

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -265,12 +265,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
         activePages.sort(null);
         for (long idpage : activePages) {
             List<Record> records = readPage(tableSpace, tableName, idpage);
-            consumer.startPage(idpage);
-            LOGGER.log(Level.FINER, "fullTableScan table " + tableSpace + "." + tableName + ", page " + idpage + ", contains " + records.size() + " records");
-            for (Record record : records) {
-                consumer.acceptRecord(record);
-            }
-            consumer.endPage();
+            consumer.acceptPage(idpage, records);
         }
         consumer.endTable();
     }

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -138,6 +138,9 @@ public final class ServerConfiguration {
     public static final String PROPERTY_BOOKKEEPER_MAX_IDLE_TIME = "server.bookkeeper.max.idle.time";
     public static final long PROPERTY_BOOKKEEPER_MAX_IDLE_TIME_DEFAULT = 1000L * 10;
 
+    public static final String PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT = "server.boot.force.download.snapshot";
+    public static final boolean PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT_DEFAULT = false;
+
     public static final String PROPERTY_CHECKPOINT_PERIOD = "server.checkpoint.period";
     public static final long PROPERTY_CHECKPOINT_PERIOD_DEFAULT = 1000L * 60 * 15;
 

--- a/herddb-core/src/main/java/herddb/storage/FullTableScanConsumer.java
+++ b/herddb-core/src/main/java/herddb/storage/FullTableScanConsumer.java
@@ -21,6 +21,7 @@
 package herddb.storage;
 
 import herddb.model.Record;
+import java.util.List;
 
 /**
  * Receives all data from a table
@@ -29,13 +30,12 @@ import herddb.model.Record;
  */
 public interface FullTableScanConsumer {
 
-    void acceptTableStatus(TableStatus tableStatus);
+    default void acceptTableStatus(TableStatus tableStatus) {
+    }
 
-    void startPage(long pageId);
+    default void acceptPage(long pageId, List<Record> records) {
+    }
 
-    void acceptRecord(Record record);
-
-    void endPage();
-
-    void endTable();
+    default void endTable() {
+    }
 }

--- a/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
@@ -50,7 +50,6 @@ import herddb.server.Server;
 import herddb.server.ServerConfiguration;
 import herddb.sql.TranslatedQuery;
 import herddb.storage.FullTableScanConsumer;
-import herddb.storage.TableStatus;
 import herddb.utils.BooleanHolder;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;

--- a/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/MultiServerTest.java
@@ -32,6 +32,7 @@ import herddb.model.DMLStatementExecutionResult;
 import herddb.model.DataScanner;
 import herddb.model.GetResult;
 import herddb.model.Index;
+import herddb.model.Record;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.Table;
 import herddb.model.TableSpace;
@@ -44,17 +45,23 @@ import herddb.model.commands.CreateTableStatement;
 import herddb.model.commands.GetStatement;
 import herddb.model.commands.InsertStatement;
 import herddb.model.commands.ScanStatement;
+import herddb.model.commands.UpdateStatement;
 import herddb.server.Server;
 import herddb.server.ServerConfiguration;
 import herddb.sql.TranslatedQuery;
+import herddb.storage.FullTableScanConsumer;
+import herddb.storage.TableStatus;
+import herddb.utils.BooleanHolder;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import herddb.utils.TestUtils;
 import herddb.utils.ZKTestEnv;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
@@ -863,6 +870,92 @@ public class MultiServerTest {
 
             }
 
+        }
+    }
+
+    @Test
+    public void test_leader_online_log_available_multiple_versions_active_pages() throws Exception {
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MAX_LOGICAL_PAGE_SIZE, 1000);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD, 1); // delete ledgers soon
+        serverconfig_1.set(ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD, 0);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
+        /*
+         * Disable page compaction (avoid compaction of dirty page)
+         */
+        serverconfig_1.set(ServerConfiguration.PROPERTY_FILL_PAGE_THRESHOLD, 0.0D);
+
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+                .set(ServerConfiguration.PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT, true)
+                .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
+                .set(ServerConfiguration.PROPERTY_PORT, 7868);
+        Table table = Table.builder()
+                .name("t1")
+                .column("c", ColumnTypes.INTEGER)
+                .column("s", ColumnTypes.STRING)
+                .primaryKey("c")
+                .build();
+
+        try (Server server_1 = new Server(serverconfig_1)) {
+            server_1.start();
+            server_1.waitForStandaloneBoot();
+
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            TableSpaceManager tableSpaceManager = server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT);
+            AbstractTableManager tableManager = tableSpaceManager.getTableManager("t1");
+            // fill table
+            long tx = herddb.core.TestUtils.beginTransaction(server_1.getManager(), TableSpace.DEFAULT);
+            for (int i = 0; i < 1000; i++) {
+                server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", i, "s", "1")), StatementEvaluationContext.
+                        DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(tx));
+            }
+            herddb.core.TestUtils.commitTransaction(server_1.getManager(), TableSpace.DEFAULT, tx);
+
+
+            // we want to be in the case that the same key is present on more than one active datapage
+            // when we send the dump to the follower we must send only the latest version of the record
+            for (int i = 0; i < 10; i++) {
+                tableManager.flush();
+                server_1.getManager().executeUpdate(new UpdateStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "s", "2" + i), null), StatementEvaluationContext.
+                        DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            }
+
+            BooleanHolder foundDuplicate = new BooleanHolder(false);
+            server_1.getManager().getDataStorageManager().fullTableScan(tableSpaceManager.getTableSpaceUUID(), tableManager.getTable().uuid, new FullTableScanConsumer() {
+
+                Map<Bytes, Long> recordPage = new HashMap<>();
+
+                @Override
+                public void acceptPage(long pageId, List<Record> records) {
+                    for (Record record : records) {
+                        Long prev = recordPage.put(record.key, pageId);
+                        if (prev != null) {
+                            foundDuplicate.value = true;
+                        }
+                    }
+                }
+
+            });
+            assertTrue(foundDuplicate.value);
+
+
+            // data will be downloaded from the server_1 (PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT)
+            try (Server server_2 = new Server(serverconfig_2)) {
+                server_2.start();
+                server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
+            }
         }
     }
 }

--- a/herddb-core/src/test/java/herddb/core/SimpleClusterTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleClusterTest.java
@@ -165,25 +165,6 @@ public class SimpleClusterTest extends BaseTestcase {
             public void acceptTableStatus(TableStatus tableStatus) {
                 _tableStatus.value = tableStatus;
             }
-
-            @Override
-            public void startPage(long pageId) {
-
-            }
-
-            @Override
-            public void acceptRecord(Record record) {
-
-            }
-
-            @Override
-            public void endPage() {
-            }
-
-            @Override
-            public void endTable() {
-            }
-
         });
         for (long pageId : _tableStatus.value.activePages.keySet()) {
             List<Record> records = dataStorageManager.readPage(tableSpaceUUID, tableUuid, pageId);


### PR DESCRIPTION
- do not assume that a full checkpoint has been done and the phisical page set contains only non dirty data
- do not force a full checkpoint during followers boot and during backups
- clean up FullTableScanConsumer, leaving space for further optimization (batch processing) in the future
- introduce new configuration server.boot.force.download.snapshot to force the download of a fresh new snapshot from the leader (useful for tests)