### PR TITLE
Wait for remove page from PageReplacementPolicy during compaction

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -2357,11 +2357,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
                     /* The page was found in memory. Currently built page should go into memory */
                     currentPageWasInMemory = true;
-
-                    /* Current dirty record page isn't known to page replacement policy */
-                    if (currentDirtyRecordsPage.get() != dataPage.pageId) {
-                        pageReplacementPolicy.remove(dataPage);
-                    }
                 }
 
                 for (Record record : records) {
@@ -2466,9 +2461,16 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
                 if (dataPage != null) {
 
+                    /* Current dirty record page isn't known to page replacement policy */
+                    if (currentDirtyRecordsPage.get() != dataPage.pageId) {
+                        pageReplacementPolicy.remove(dataPage);
+                    }
+
                     final DataPage removedDataPage = pages.remove(page.pageId);
 
-                    if (removedDataPage != null) {
+                    unloadedPagesCount.increment();
+
+                    if (removedDataPage != null && removedDataPage != dataPage) {
                         /*
                          * DataPage can be removed due to an unload request from PageReplacementPolicy and
                          * could be event reloaded again in the meantime due to a concurrent read.


### PR DESCRIPTION
During page compaction we remove the compated page from page replacement policy before handling it. After handling page records we have to check again if the page is in loaded pages and if it has been reloaded again for some reasons.

The check has to stay in place as is but we should move the removal of page knowledge only after record handling to avoid multiple reload of the same page.

Added missing unload page counter too.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
