### PR TITLE
Handle BK/ZK errors during automatic transaction rollback in clients.

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -500,13 +500,11 @@ public class BookkeeperCommitLog extends CommitLog {
                                     localEntryCount++;
                                 }
                             }
-                            LOGGER.log(Level.FINER, tableSpaceDescription()+" read " + localEntryCount + " entries from ledger " + ledgerId
+                            LOGGER.log(Level.FINER, tableSpaceDescription() + " read " + localEntryCount + " entries from ledger " + ledgerId
                                     + ", expected " + entriesToRead);
 
-                            LOGGER.log(Level.FINER, tableSpaceDescription()+" finished waiting for " + entriesToRead
-                                    + " entries to be read from ledger " + ledgerId);
                             if (localEntryCount != entriesToRead) {
-                                throw new LogNotAvailableException(tableSpaceDescription()+" Read " + localEntryCount + " entries, expected "
+                                throw new LogNotAvailableException(tableSpaceDescription() + " Read " + localEntryCount + " entries, expected "
                                         + entriesToRead);
                             }
                             lastLedgerId = ledgerId;

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -101,6 +101,12 @@ public class BookkeeperCommitLog extends CommitLog {
         failed = true;
     }
 
+    // only for testsm this is needed to undo the automatic close of the log
+    // in case of failures
+    public void resetClosedFlagForTests() {
+        closed = false;
+    }
+
     public void rollNewLedger() {
         openNewLedger();
     }
@@ -346,7 +352,7 @@ public class BookkeeperCommitLog extends CommitLog {
             LOGGER.log(Level.SEVERE, "this server was fenced for tablespace " + tableSpaceDescription() + " !", cause);
             close();
             signalLogFailed();
-        } else if (cause instanceof BKException.BKNotEnoughBookiesException) {
+        } else if (cause instanceof org.apache.bookkeeper.client.api.BKException) {
             LOGGER.log(Level.SEVERE, "bookkeeper failure for tablespace " + tableSpaceDescription(), cause);
             close();
             signalLogFailed();
@@ -465,7 +471,7 @@ public class BookkeeperCommitLog extends CommitLog {
                             double percent = ((start - first) * 100.0 / (lastAddConfirmed + 1));
                             int entriesToRead = (int) (1 + end - start);
                             if (LOGGER.isLoggable(Level.FINE)) {
-                                LOGGER.log(Level.FINE, "From entry {0}, to entry {1} ({2} %)",
+                                LOGGER.log(Level.FINE, "{3} From entry {0}, to entry {1} ({2} %)",
                                         new Object[]{start, end, percent, tableSpaceDescription});
                             }
                             long _start = System.currentTimeMillis();
@@ -481,26 +487,26 @@ public class BookkeeperCommitLog extends CommitLog {
                                     lastSequenceNumber.set(entryId);
                                     if (number.after(snapshotSequenceNumber)) {
                                         if (LOGGER.isLoggable(Level.FINEST)) {
-                                            LOGGER.log(Level.FINEST, "RECOVER ENTRY #" + localEntryCount + " {0}, {1}",
+                                            LOGGER.log(Level.FINEST, "RECOVER ENTRY "+tableSpaceName+" #" + localEntryCount + " {0}, {1}",
                                                     new Object[]{number, statusEdit});
                                         }
                                         consumer.accept(number, statusEdit);
                                     } else {
                                         if (LOGGER.isLoggable(Level.FINEST)) {
-                                            LOGGER.log(Level.FINEST, "SKIP ENTRY #" + localEntryCount + " {0}<{1}, {2}",
+                                            LOGGER.log(Level.FINEST, "SKIP ENTRY "+tableSpaceName+" #" + localEntryCount + " {0}<{1}, {2}",
                                                     new Object[]{number, snapshotSequenceNumber, statusEdit});
                                         }
                                     }
                                     localEntryCount++;
                                 }
                             }
-                            LOGGER.log(Level.FINER, "read " + localEntryCount + " entries from ledger " + ledgerId
+                            LOGGER.log(Level.FINER, tableSpaceDescription()+" read " + localEntryCount + " entries from ledger " + ledgerId
                                     + ", expected " + entriesToRead);
 
-                            LOGGER.log(Level.FINER, "finished waiting for " + entriesToRead
+                            LOGGER.log(Level.FINER, tableSpaceDescription()+" finished waiting for " + entriesToRead
                                     + " entries to be read from ledger " + ledgerId);
                             if (localEntryCount != entriesToRead) {
-                                throw new LogNotAvailableException("Read " + localEntryCount + " entries, expected "
+                                throw new LogNotAvailableException(tableSpaceDescription()+" Read " + localEntryCount + " entries, expected "
                                         + entriesToRead);
                             }
                             lastLedgerId = ledgerId;
@@ -518,7 +524,7 @@ public class BookkeeperCommitLog extends CommitLog {
                     new Object[]{tableSpaceDescription, getLastSequenceNumber()});
         } catch (LogNotAvailableException | IOException | InterruptedException
                 | org.apache.bookkeeper.client.api.BKException err) {
-            LOGGER.log(Level.SEVERE, "Fatal error during recovery of " + tableSpaceDescription, err);
+            LOGGER.log(Level.SEVERE, "Fatal error during recovery of " + tableSpaceDescription(), err);
             signalLogFailed();
             throw new LogNotAvailableException(err);
         }

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -487,13 +487,13 @@ public class BookkeeperCommitLog extends CommitLog {
                                     lastSequenceNumber.set(entryId);
                                     if (number.after(snapshotSequenceNumber)) {
                                         if (LOGGER.isLoggable(Level.FINEST)) {
-                                            LOGGER.log(Level.FINEST, "RECOVER ENTRY "+tableSpaceName+" #" + localEntryCount + " {0}, {1}",
+                                            LOGGER.log(Level.FINEST, "rec " + tableSpaceName + " #" + localEntryCount + " {0}, {1}",
                                                     new Object[]{number, statusEdit});
                                         }
                                         consumer.accept(number, statusEdit);
                                     } else {
                                         if (LOGGER.isLoggable(Level.FINEST)) {
-                                            LOGGER.log(Level.FINEST, "SKIP ENTRY "+tableSpaceName+" #" + localEntryCount + " {0}<{1}, {2}",
+                                            LOGGER.log(Level.FINEST, "skip " + tableSpaceName + " #" + localEntryCount + " {0}<{1}, {2}",
                                                     new Object[]{number, snapshotSequenceNumber, statusEdit});
                                         }
                                     }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -320,11 +320,11 @@ public class TableSpaceManager {
             // this will wait for the write to be acknowledged by the log
             // it can throw LogNotAvailableException
             this.actualLogSequenceNumber = position.getLogSequenceNumber();
-            if (LOGGER.isLoggable(Level.FINEST)) {            
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.log(Level.FINEST, "apply {0} {1}", new Object[]{position.getLogSequenceNumber(), entry});
             }
         } else {
-            if (LOGGER.isLoggable(Level.FINEST)) {            
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.log(Level.FINEST, "apply {0} {1}", new Object[]{position, entry});
             }
         }

--- a/herddb-core/src/main/java/herddb/log/LogEntry.java
+++ b/herddb-core/src/main/java/herddb/log/LogEntry.java
@@ -223,7 +223,8 @@ public class LogEntry {
 
     @Override
     public String toString() {
-        return "LogEntry{" + "type=" + type + ", transactionId=" + transactionId + ", tableName=" + tableName + ", key=" + key + ", value=" + value + ", timestamp=" + timestamp + '}';
+        // this string is printed on logs during debug...better to save space
+        return "LE{" + "t=" + type + ",tx=" + transactionId + ",tn=" + tableName + ",k=" + key + ",v=" + value + ",ts=" + timestamp + '}';
     }
 
 }

--- a/herddb-core/src/test/java/herddb/cluster/BookkeeperFailuresTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/BookkeeperFailuresTest.java
@@ -42,6 +42,7 @@ import herddb.model.commands.AlterTableSpaceStatement;
 import herddb.model.commands.CommitTransactionStatement;
 import herddb.model.commands.CreateTableStatement;
 import herddb.model.commands.InsertStatement;
+import herddb.model.commands.RollbackTransactionStatement;
 import herddb.server.Server;
 import herddb.server.ServerConfiguration;
 import herddb.utils.DataAccessor;
@@ -51,10 +52,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.junit.After;
 import org.junit.Assert;
@@ -539,6 +542,133 @@ public class BookkeeperFailuresTest {
 
             try (DataScanner scan = scan(server.getManager(), "select * from t1", Collections.emptyList())) {
                 assertEquals(1, scan.consume().size());
+            }
+        }
+    }
+
+    @Test
+    public void testBookieNotAvailableDuringTransactionWithRollback() throws Exception {
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
+
+        try (Server server = new Server(serverconfig_1)) {
+            server.start();
+            server.waitForStandaloneBoot();
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .primaryKey("c")
+                    .build();
+
+            // create table is done out of the transaction (this is very like autocommit=true)
+            server.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.
+                    DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+             // we do not want auto-recovery
+            server.getManager().setActivatorPauseStatus(true);
+
+            // no bookie
+            // but the client will fill the transaction with data and see the error only during commit
+            testEnv.stopBookie();
+
+            // start a transaction
+            StatementExecutionResult executeStatement = server.getManager().executeUpdate(new InsertStatement(
+                    TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1)), StatementEvaluationContext.
+                    DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION);
+            long transactionId = executeStatement.transactionId;
+
+            server.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(
+                    table, "c", 2)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(
+                    transactionId));
+
+            server.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(
+                    table, "c", 3)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), new TransactionContext(
+                    transactionId));
+            TableSpaceManager tableSpaceManager = server.getManager().getTableSpaceManager(TableSpace.DEFAULT);
+            BookkeeperCommitLog log = (BookkeeperCommitLog) tableSpaceManager.getLog();
+            long ledgerId = log.getLastSequenceNumber().ledgerId;
+            assertTrue(ledgerId >= 0);
+
+            try {
+                server.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.
+                                makeRecord(table, "c", 4)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        new TransactionContext(transactionId));
+                System.out.println("Insert of c,4 OK"); // this will piggyback the LAC for the transaction
+            } catch (StatementExecutionException expected) {
+                System.out.println("Insert of c,4 failed " + expected);
+                // in can happen that the log gets closed
+                assertEquals(herddb.log.LogNotAvailableException.class, expected.getCause().getClass());
+            }
+            try {
+                server.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.
+                                makeRecord(table, "c", 5)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        new TransactionContext(transactionId));
+                System.out.println("Insert of c,5 OK");  // this will piggyback the LAC for the transaction
+            } catch (StatementExecutionException expected) {
+                System.out.println("Insert of c,5 failed " + expected);
+                // in can happen that the log gets closed
+                assertEquals(herddb.log.LogNotAvailableException.class, expected.getCause().getClass());
+            }
+            try {
+                server.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.
+                                makeRecord(table, "c", 6)), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                        new TransactionContext(transactionId));
+                System.out.println("Insert of c,6 OK");  // this will piggyback the LAC for the transaction
+            } catch (StatementExecutionException expected) {
+                System.out.println("Insert of c,6 failed " + expected);
+                // in can happen that the log gets closed
+                assertEquals(herddb.log.LogNotAvailableException.class, expected.getCause().getClass());
+            }
+
+             // verify that the commit operation is reported as failed to the client
+            try {
+                server.getManager().executeStatement(new CommitTransactionStatement(TableSpace.DEFAULT, transactionId),
+                            StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                fail();
+            } catch (StatementExecutionException expected) {
+                System.out.println("Commit failed as expected:" + expected);
+            }
+
+            // start the bookie
+            testEnv.startBookie(false);
+
+            // this is a bit hacky but there is a race and BookKeeperCommit automatically closes
+            // itself in background when BK write errors occour
+            log.resetClosedFlagForTests();
+            log.rollNewLedger();
+
+            // the client sees an error, and blindly sends a rollback
+            // this rollback should not go to the log
+            // otherwise during recovery we will see a rollback for a transaction that never began
+            try {
+                server.getManager().executeStatement(new RollbackTransactionStatement(TableSpace.DEFAULT, transactionId),
+                        StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+             } catch (StatementExecutionException expected) {
+                System.out.println("Rollback failed as expected:" + expected);
+                assertEquals("no such transaction "+transactionId+" in tablespace "+TableSpace.DEFAULT, expected.getMessage());
+            }
+
+             // start a follower, it must be able to boot
+            server.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
+                            new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            ServerConfiguration serverconfig_2 = new ServerConfiguration(folder.newFolder().toPath());
+            serverconfig_2.set(ServerConfiguration.PROPERTY_NODEID, "server2");
+            serverconfig_2.set(ServerConfiguration.PROPERTY_PORT, 7868);
+            serverconfig_2.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+            serverconfig_2.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+            serverconfig_2.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+            serverconfig_2.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+            try (Server server2 = new Server(serverconfig_2)) {
+                server2.start();
+                server2.waitForTableSpaceBoot(TableSpace.DEFAULT, false);
             }
         }
     }

--- a/herddb-core/src/test/java/herddb/cluster/BookkeeperFailuresTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/BookkeeperFailuresTest.java
@@ -52,12 +52,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
-import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.junit.After;
 import org.junit.Assert;
@@ -651,7 +649,7 @@ public class BookkeeperFailuresTest {
                         StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
              } catch (StatementExecutionException expected) {
                 System.out.println("Rollback failed as expected:" + expected);
-                assertEquals("no such transaction "+transactionId+" in tablespace "+TableSpace.DEFAULT, expected.getMessage());
+                assertEquals("no such transaction " + transactionId + " in tablespace " + TableSpace.DEFAULT, expected.getMessage());
             }
 
              // start a follower, it must be able to boot


### PR DESCRIPTION
In case of BK/ZK error the client is not able to commit a transaction
it blindly issues a rollback command.
This command may go into a new ledger in case BookKeeperCommitLog
does not closes itself in time.

The fix is to automatically in-memory rollback transactions with a failed
write on the commit command.
This prevents any further command in the scope of the transaction
and expectially rollbacks to be validated.

The problem may occour even on FileCommitLog (standalone mode).

We are also broadening the handling of BK failures, in the case
of the issue we had a ZKException.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Rember to add the correct license header to new files.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
