### PR TITLE
Wait for FollowerThread to exit and add more logs

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -299,7 +299,7 @@ public class BookkeeperCommitLog extends CommitLog {
             res = new CompletableFuture();
             res.completeExceptionally(
                     new LogNotAvailableException(new Exception("this commitlog has been closed for tablespace "
-                            + tableSpaceDescription()+", node "+this.localNodeId))
+                            + tableSpaceDescription() + ", node " + this.localNodeId))
                             .fillInStackTrace());
         } else {
             res = _writer.writeEntry(edit);
@@ -458,7 +458,7 @@ public class BookkeeperCommitLog extends CommitLog {
                     long lastAddConfirmed = handle.getLastAddConfirmed();
                     String ledgerLeader = extractLeaderFromMetadata(handle.getLedgerMetadata().getCustomMetadata());
                     LOGGER.log(Level.INFO, "Tablespace " + tableSpaceDescription + ", Recovering from ledger "
-                            + ledgerId + ", first=" + first + " lastAddConfirmed=" + lastAddConfirmed+" written by "+ledgerLeader);
+                            + ledgerId + ", first=" + first + " lastAddConfirmed=" + lastAddConfirmed + " written by " + ledgerLeader);
 
                     if (lastAddConfirmed >= 0) {
 
@@ -698,9 +698,8 @@ public class BookkeeperCommitLog extends CommitLog {
             if (currentLedger == null) {
                 currentLedger = bookKeeper.openLedgerNoRecovery(ledgerToTail,
                         BookKeeper.DigestType.CRC32C, SHARED_SECRET.getBytes(StandardCharsets.UTF_8));
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine(tableSpaceDescription() + " opened direct ledger " + ledgerToTail);
-                }
+                String ledgerLeader = extractLeaderFromMetadata(currentLedger.getLedgerMetadata().getCustomMetadata());
+                LOGGER.log(Level.INFO, "{0} opened direct ledger {1} was created by {2}", new Object[]{tableSpaceDescription(), ledgerToTail, ledgerLeader});
                 nextEntryToRead = currentPosition.offset + 1;
                 return;
             }
@@ -731,11 +730,10 @@ public class BookkeeperCommitLog extends CommitLog {
             }
             currentLedger = bookKeeper.openLedgerNoRecovery(ledgerToTail,
                     BookKeeper.DigestType.CRC32C, SHARED_SECRET.getBytes(StandardCharsets.UTF_8));
-            
-            if (LOGGER.isLoggable(Level.FINE)) {
-                String ledgerLeader = extractLeaderFromMetadata(currentLedger.getLedgerMetadata().getCustomMetadata());
-                LOGGER.fine(tableSpaceDescription() + " ledger " + ledgerToTail + " was created by " + ledgerLeader);
-            }
+
+            String ledgerLeader = extractLeaderFromMetadata(currentLedger.getLedgerMetadata().getCustomMetadata());
+            LOGGER.log(Level.INFO, "{0} ledger {1} was created by {2}", new Object[]{tableSpaceDescription(), ledgerToTail, ledgerLeader});
+
             nextEntryToRead = 0;
         }
 

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -529,7 +529,7 @@ public class BookkeeperCommitLog extends CommitLog {
         }
     }
 
-    private String extractLeaderFromMetadata(Map<String, byte[]> metadata) {
+    private static String extractLeaderFromMetadata(Map<String, byte[]> metadata) {
         byte[] leaderInMetadata = metadata.get("leader");
         String ledgerLeader = leaderInMetadata != null ? new String(leaderInMetadata, StandardCharsets.UTF_8) : "?";
         return ledgerLeader;

--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -1,23 +1,22 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.cluster;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -70,7 +69,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         switch (event.getState()) {
             case SyncConnected:
             case SaslAuthenticated:
-                notifyMetadataChanged("zkevent "+event.getState()+" "+event.getType()+" "+event.getPath());
+                notifyMetadataChanged("zkevent " + event.getState() + " " + event.getType() + " " + event.getPath());
                 break;
             default:
                 // ignore
@@ -101,7 +100,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
                     case SyncConnected:
                     case SaslAuthenticated:
                         firstConnectionLatch.countDown();
-                        notifyMetadataChanged("zkevent "+event.getState()+" "+event.getType()+" "+event.getPath());
+                        notifyMetadataChanged("zkevent " + event.getState() + " " + event.getType() + " " + event.getPath());
                         break;
                     default:
                         // ignore

--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -70,7 +70,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         switch (event.getState()) {
             case SyncConnected:
             case SaslAuthenticated:
-                notifyMetadataChanged();
+                notifyMetadataChanged("zkevent "+event.getState()+" "+event.getType()+" "+event.getPath());
                 break;
             default:
                 // ignore
@@ -101,7 +101,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
                     case SyncConnected:
                     case SaslAuthenticated:
                         firstConnectionLatch.countDown();
-                        notifyMetadataChanged();
+                        notifyMetadataChanged("zkevent "+event.getState()+" "+event.getType()+" "+event.getPath());
                         break;
                     default:
                         // ignore
@@ -299,7 +299,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
     private boolean updateTableSpaceNode(TableSpace tableSpace, int metadataStorageVersion) throws KeeperException, InterruptedException, IOException, TableSpaceDoesNotExistException {
         try {
             ensureZooKeeper().setData(tableSpacesPath + "/" + tableSpace.name.toLowerCase(), tableSpace.serialize(), metadataStorageVersion);
-            notifyMetadataChanged();
+            notifyMetadataChanged("updateTableSpaceNode " + tableSpace + " metadataStorageVersion " + metadataStorageVersion);
             return true;
         } catch (KeeperException.BadVersionException changed) {
             return false;
@@ -311,7 +311,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
     private boolean deleteTableSpaceNode(String tableSpaceName, int metadataStorageVersion) throws KeeperException, InterruptedException, IOException, TableSpaceDoesNotExistException {
         try {
             ensureZooKeeper().delete(tableSpacesPath + "/" + tableSpaceName.toLowerCase(), metadataStorageVersion);
-            notifyMetadataChanged();
+            notifyMetadataChanged("deleteTableSpaceNode " + tableSpaceName + " metadataStorageVersion " + metadataStorageVersion);
             return true;
         } catch (KeeperException.BadVersionException changed) {
             return false;
@@ -392,7 +392,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
 
         try {
             createTableSpaceNode(tableSpace);
-            notifyMetadataChanged();
+            notifyMetadataChanged("registerTableSpace " + tableSpace);
         } catch (KeeperException | InterruptedException | IOException ex) {
             handleSessionExpiredError(ex);
             throw new MetadataStorageManagerException(ex);
@@ -407,7 +407,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         try {
             boolean result = updateTableSpaceNode(tableSpace, (Integer) previous.metadataStorageVersion);
             if (result) {
-                notifyMetadataChanged();
+                notifyMetadataChanged("updateTableSpace " + tableSpace);
             }
             return result;
         } catch (KeeperException | InterruptedException | IOException ex) {
@@ -424,7 +424,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         try {
             boolean result = deleteTableSpaceNode(name, (Integer) previous.metadataStorageVersion);
             if (result) {
-                notifyMetadataChanged();
+                notifyMetadataChanged("dropTableSpace " + name);
             }
         } catch (KeeperException | InterruptedException | IOException ex) {
             handleSessionExpiredError(ex);
@@ -490,7 +490,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
                 LOGGER.severe("registerNode at " + path + " " + ok);
                 ensureZooKeeper().setData(path, data, -1);
             }
-            notifyMetadataChanged();
+            notifyMetadataChanged("registerNode " + nodeMetadata);
         } catch (IOException | InterruptedException | KeeperException err) {
             handleSessionExpiredError(err);
             throw new MetadataStorageManagerException(err);

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -1290,7 +1290,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
     @Override
     public void metadataChanged(String description) {
-        LOGGER.log(Level.INFO, "metadata changed: "+description);
+        LOGGER.log(Level.INFO, "metadata changed: " + description);
         triggerActivator(ActivatorRunRequest.TABLESPACEMANAGEMENT);
     }
 

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -368,7 +368,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
      * @throws herddb.metadata.MetadataStorageManagerException
      */
     public void start() throws DataStorageManagerException, LogNotAvailableException, MetadataStorageManagerException {
-
+        LOGGER.log(Level.INFO, "Starting DBManager at {0}", nodeId);
         if (serverConfiguration.getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT)) {
             JMXUtils.registerDBManagerStatsMXBean(stats);
         }
@@ -535,7 +535,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
             TableSpaceManager manager = new TableSpaceManager(nodeId, tableSpaceName, tableSpace.uuid, metadataStorageManager, dataStorageManager, commitLog, this, false);
             try {
                 manager.start();
-                LOGGER.log(Level.INFO, "Boot success tablespace {0} on {1}, uuid {2}, time {3} ms", new Object[]{tableSpaceName, nodeId, tableSpace.uuid, (System.currentTimeMillis() - _start) + ""});
+                LOGGER.log(Level.INFO, "Boot success tablespace {0} on {1}, uuid {2}, time {3} ms leader:{4}", new Object[]{tableSpaceName, nodeId, tableSpace.uuid, (System.currentTimeMillis() - _start) + "", manager.isLeader()});
                 tablesSpaces.put(tableSpaceName, manager);
                 if (serverConfiguration.getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT)) {
                     JMXUtils.registerTableSpaceManagerStatsMXBean(tableSpaceName, manager.getStats());
@@ -578,6 +578,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                                 .cloning(tableSpace);
                 while (!availableOtherNodes.isEmpty() && countMissing > 0) {
                     String node = availableOtherNodes.remove(0);
+                    LOGGER.log(Level.WARNING, "Tablespace {0} adding {1} node as replica", new Object[]{tableSpaceName, node});
                     newTableSpaceBuilder.replica(node);
                 }
                 TableSpace newTableSpace = newTableSpaceBuilder.build();
@@ -1288,8 +1289,8 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     }
 
     @Override
-    public void metadataChanged() {
-        LOGGER.log(Level.INFO, "metadata changed");
+    public void metadataChanged(String description) {
+        LOGGER.log(Level.INFO, "metadata changed: "+description);
         triggerActivator(ActivatorRunRequest.TABLESPACEMANAGEMENT);
     }
 

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1025,14 +1025,14 @@ public class TableSpaceManager {
                 while (!isLeader() && !closed) {
                     long readLock = acquireReadLock("follow");
                     try {
-                    log.followTheLeader(actualLogSequenceNumber, (LogSequenceNumber num, LogEntry u) -> {
-                        try {
-                            apply(new CommitLogResult(num, false, true), u, false);
-                        } catch (Throwable t) {
-                            throw new RuntimeException(t);
-                        }
-                        return !isLeader() && !closed;
-                    }, context);
+                        log.followTheLeader(actualLogSequenceNumber, (LogSequenceNumber num, LogEntry u) -> {
+                            try {
+                                apply(new CommitLogResult(num, false, true), u, false);
+                            } catch (Throwable t) {
+                                throw new RuntimeException(t);
+                            }
+                            return !isLeader() && !closed;
+                        }, context);
                     } finally {
                         releaseReadLock(readLock, "follow");
                     }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1013,14 +1013,14 @@ public class TableSpaceManager {
     private class FollowerThread implements Runnable {
 
         private volatile CountDownLatch running = new CountDownLatch(1);
-                
+
         @Override
         public String toString() {
             return "FollowerThread{" + tableSpaceName + '}';
         }
 
         @Override
-        public void run() {            
+        public void run() {
             try (CommitLog.FollowerContext context = log.startFollowing(actualLogSequenceNumber)) {
                 while (!isLeader() && !closed) {
                     long readLock = acquireReadLock("follow");
@@ -1044,7 +1044,7 @@ public class TableSpaceManager {
                 running.countDown();
             }
         }
-        
+
         void waitForStop() throws InterruptedException {
             LOGGER.log(Level.INFO, "Waiting for FollowerThread of {0} to stop", tableSpaceName);
             running.await(1, TimeUnit.HOURS);
@@ -1635,13 +1635,13 @@ public class TableSpaceManager {
     public void close() throws LogNotAvailableException {
         boolean useJmx = dbmanager.getServerConfiguration().getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT);
         closed = true;
-        
+
         if (followerThread != null) {
             try {
                 followerThread.waitForStop();
             } catch (InterruptedException err) {
                 Thread.currentThread().interrupt();
-                LOGGER.log(Level.SEVERE,"Cannot wait for FollowerThread to stop", err);
+                LOGGER.log(Level.SEVERE, "Cannot wait for FollowerThread to stop", err);
             }
         }
         if (!virtual) {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -116,6 +116,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -156,6 +157,7 @@ public class TableSpaceManager {
     private final StampedLock generalLock = new StampedLock();
     private final AtomicLong newTransactionId = new AtomicLong();
     private final DBManager dbmanager;
+    private volatile FollowerThread followerThread;
     private final ExecutorService callbacksExecutor;
     private final boolean virtual;
 
@@ -1010,13 +1012,15 @@ public class TableSpaceManager {
 
     private class FollowerThread implements Runnable {
 
+        private volatile CountDownLatch running = new CountDownLatch(1);
+                
         @Override
         public String toString() {
             return "FollowerThread{" + tableSpaceName + '}';
         }
 
         @Override
-        public void run() {
+        public void run() {            
             try (CommitLog.FollowerContext context = log.startFollowing(actualLogSequenceNumber)) {
                 while (!isLeader() && !closed) {
                     long readLock = acquireReadLock("follow");
@@ -1036,9 +1040,16 @@ public class TableSpaceManager {
             } catch (Throwable t) {
                 LOGGER.log(Level.SEVERE, "follower error " + tableSpaceName, t);
                 setFailed();
+            } finally {
+                running.countDown();
             }
         }
-
+        
+        void waitForStop() throws InterruptedException {
+            LOGGER.log(Level.INFO, "Waiting for FollowerThread of {0} to stop", tableSpaceName);
+            running.await(1, TimeUnit.HOURS);
+            LOGGER.log(Level.INFO, "FollowerThread of {0} stopped", tableSpaceName);
+        }
     }
 
     void setFailed() {
@@ -1053,7 +1064,8 @@ public class TableSpaceManager {
     }
 
     void startAsFollower() throws DataStorageManagerException, DDLException, LogNotAvailableException {
-        dbmanager.submit(new FollowerThread());
+        followerThread = new FollowerThread();
+        dbmanager.submit(followerThread);
     }
 
     void startAsLeader() throws DataStorageManagerException, DDLException, LogNotAvailableException {
@@ -1623,6 +1635,15 @@ public class TableSpaceManager {
     public void close() throws LogNotAvailableException {
         boolean useJmx = dbmanager.getServerConfiguration().getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT);
         closed = true;
+        
+        if (followerThread != null) {
+            try {
+                followerThread.waitForStop();
+            } catch (InterruptedException err) {
+                Thread.currentThread().interrupt();
+                LOGGER.log(Level.SEVERE,"Cannot wait for FollowerThread to stop", err);
+            }
+        }
         if (!virtual) {
             long lockStamp = acquireWriteLock("closeTablespace");
             try {

--- a/herddb-core/src/main/java/herddb/metadata/MetadataChangeListener.java
+++ b/herddb-core/src/main/java/herddb/metadata/MetadataChangeListener.java
@@ -27,5 +27,5 @@ package herddb.metadata;
  */
 public interface MetadataChangeListener {
 
-    void metadataChanged();
+    void metadataChanged(String description);
 }

--- a/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
@@ -128,9 +128,10 @@ public abstract class MetadataStorageManager implements AutoCloseable {
         return listener;
     }
 
-    protected void notifyMetadataChanged() {
+
+    protected final void notifyMetadataChanged(String description) {
         if (listener != null) {
-            listener.metadataChanged();
+            listener.metadataChanged(description);
         }
     }
 


### PR DESCRIPTION
- Ensure that FollowerThread is really stopped because spawning a new instance of TableSpaceManager
- Add more logs about metadata changes
- Add more logs about general lifecycle
