### PR TITLE
Rework BookKeeperCommitLog and introduce server.bookkeeper.ledgers.max.size

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -341,16 +341,16 @@ public class BookkeeperCommitLog extends CommitLog {
         try {
             _writer = getValidWriter();
         } catch (LogNotAvailableException errorWhileRollingLedger) {
-            LOGGER.log(Level.SEVERE,"Cannot get a valid writer for "+tableSpaceDescription(), errorWhileRollingLedger);
+            LOGGER.log(Level.SEVERE, "Cannot get a valid writer for " + tableSpaceDescription(), errorWhileRollingLedger);
         }
         if (failed) {
-            res = FutureUtils.exception( new LogNotAvailableException(new Exception("this commitlog is failed, tablespace "
-                            + tableSpaceDescription() + ", node " + this.localNodeId))
-                            .fillInStackTrace());
+            res = FutureUtils.exception(new LogNotAvailableException(new Exception("this commitlog is failed, tablespace "
+                    + tableSpaceDescription() + ", node " + this.localNodeId))
+                    .fillInStackTrace());
         } else if (closed || _writer == null) {
-            res = FutureUtils.exception( new LogNotAvailableException(new Exception("this commitlog has been closed, tablespace "
-                            + tableSpaceDescription() + ", node " + this.localNodeId))
-                            .fillInStackTrace());
+            res = FutureUtils.exception(new LogNotAvailableException(new Exception("this commitlog has been closed, tablespace "
+                    + tableSpaceDescription() + ", node " + this.localNodeId))
+                    .fillInStackTrace());
         } else {
             res = _writer.writeEntry(edit);
 

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
@@ -61,6 +61,7 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
     private final StatsLogger statsLogger;
     private final ClientConfiguration config;
     private long ledgersRetentionPeriod = 1000 * 60 * 60 * 24;
+    private long maxLedgerSizeBytes = 100 * 1024 * 1024 * 1024;
     private long maxIdleTime = 0;
     private ConcurrentHashMap<String, BookkeeperCommitLog> activeLogs = new ConcurrentHashMap<>();
 
@@ -184,6 +185,14 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
         this.ledgersRetentionPeriod = ledgersRetentionPeriod;
     }
 
+    public long getMaxLedgerSizeBytes() {
+        return maxLedgerSizeBytes;
+    }
+
+    public void setMaxLedgerSizeBytes(long maxLedgerSizeBytes) {
+        this.maxLedgerSizeBytes = maxLedgerSizeBytes;
+    }
+
     public long getMaxIdleTime() {
         return maxIdleTime;
     }
@@ -193,10 +202,11 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
     }
 
     @Override
-    public CommitLog createCommitLog(String tableSpaceUUID, String tableSpaceName, String localNodeId) throws LogNotAvailableException {
+    public BookkeeperCommitLog createCommitLog(String tableSpaceUUID, String tableSpaceName, String localNodeId) throws LogNotAvailableException {
         BookkeeperCommitLog res = new BookkeeperCommitLog(tableSpaceUUID, tableSpaceName, localNodeId, metadataStorageManager, bookKeeper, this);
         res.setAckQuorumSize(ackQuorumSize);
         res.setEnsemble(ensemble);
+        res.setMaxLedgerSizeBytes(maxLedgerSizeBytes);
         res.setLedgersRetentionPeriod(ledgersRetentionPeriod);
         res.setMaxIdleTime(maxIdleTime);
         res.setWriteQuorumSize(writeQuorumSize);

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
@@ -20,7 +20,6 @@
 
 package herddb.cluster;
 
-import herddb.log.CommitLog;
 import herddb.log.CommitLogManager;
 import herddb.log.LogEntry;
 import herddb.log.LogNotAvailableException;

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -341,6 +341,8 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 bkmanager.setWriteQuorumSize(configuration.getInt(ServerConfiguration.PROPERTY_BOOKKEEPER_WRITEQUORUMSIZE, ServerConfiguration.PROPERTY_BOOKKEEPER_WRITEQUORUMSIZE_DEFAULT));
                 long ledgersRetentionPeriod = configuration.getLong(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD, ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD_DEFAULT);
                 bkmanager.setLedgersRetentionPeriod(ledgersRetentionPeriod);
+                long maxLedgerSizeBytes = configuration.getLong(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE, ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE_DEFAULT);
+                bkmanager.setMaxLedgerSizeBytes(maxLedgerSizeBytes);
                 long maxIdleTime = configuration.getLong(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME_DEFAULT);
                 bkmanager.setMaxIdleTime(maxIdleTime);
                 long checkPointperiod = configuration.getLong(ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD, ServerConfiguration.PROPERTY_CHECKPOINT_PERIOD_DEFAULT);

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -139,6 +139,9 @@ public final class ServerConfiguration {
     public static final String PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD = "server.bookkeeper.ledgers.retention.period";
     public static final long PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD_DEFAULT = 1000L * 60 * 60 * 24 * 2;
 
+    public static final String PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE = "server.bookkeeper.ledgers.max.size";
+    public static final long PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE_DEFAULT = 1024L * 1024 * 1024;
+
     public static final String PROPERTY_BOOKKEEPER_MAX_IDLE_TIME = "server.bookkeeper.max.idle.time";
     public static final long PROPERTY_BOOKKEEPER_MAX_IDLE_TIME_DEFAULT = 1000L * 10;
 

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.cluster.bookkeeper;
+
+import herddb.cluster.BookkeeperCommitLog;
+import herddb.cluster.BookkeeperCommitLogManager;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.log.CommitLogResult;
+import herddb.log.LogEntry;
+import herddb.log.LogEntryFactory;
+import herddb.log.LogNotAvailableException;
+import herddb.log.LogSequenceNumber;
+import herddb.model.TableSpace;
+import herddb.server.ServerConfiguration;
+import herddb.utils.TestUtils;
+import herddb.utils.ZKTestEnv;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class BookKeeperCommitLogTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        testEnv.startBookie();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Test
+    public void testSimpleReadWrite() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            man.start();
+            logManager.start();
+
+            LogSequenceNumber lsn1;
+            LogSequenceNumber lsn2;
+            LogSequenceNumber lsn3;
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting();
+                lsn1 = writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
+                lsn2 = writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber();
+                lsn3 = writer.log(LogEntryFactory.beginTransaction(3), true).getLogSequenceNumber();
+                assertTrue(lsn1.after(LogSequenceNumber.START_OF_TIME));
+                assertTrue(lsn2.after(lsn1));
+                assertTrue(lsn3.after(lsn2));
+            }
+
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {
+                    list.add(new AbstractMap.SimpleImmutableEntry<>(a, b));
+                }, false);
+                assertEquals(3, list.size());
+                assertEquals(lsn1, list.get(0).getKey());
+                assertEquals(lsn2, list.get(1).getKey());
+                assertEquals(lsn3, list.get(2).getKey());
+            }
+
+        }
+    }
+
+    @Test
+    public void testSimpleFence() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            man.start();
+            logManager.start();
+
+            LogSequenceNumber lsn1;
+            LogSequenceNumber lsn2;
+            LogSequenceNumber lsn3;
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting();
+                lsn1 = writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
+                lsn2 = writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber();
+
+                // a new leader starts, from START_OF_TIME
+                try (BookkeeperCommitLog writer2 = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                    List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                    writer2.recovery(LogSequenceNumber.START_OF_TIME, (a, b)
+                            -> list.add(new AbstractMap.SimpleImmutableEntry<>(a, b)),
+                            true);
+                    writer2.startWriting();
+                    lsn3 = writer2.log(LogEntryFactory.beginTransaction(3), true).getLogSequenceNumber();
+                }
+
+                TestUtils.assertThrows(LogNotAvailableException.class, ()
+                        -> FutureUtils.result(writer.log(LogEntryFactory.beginTransaction(3), true).logSequenceNumber));
+
+                assertTrue(writer.isFailed());
+
+                assertTrue(lsn1.after(LogSequenceNumber.START_OF_TIME));
+                assertTrue(lsn2.after(lsn1));
+
+                // written by second writer
+                assertTrue(lsn3.after(lsn2));
+            }
+
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b)
+                        -> list.add(new AbstractMap.SimpleImmutableEntry<>(a, b)),
+                        false);
+                assertEquals(3, list.size());
+                assertEquals(lsn1, list.get(0).getKey());
+                assertEquals(lsn2, list.get(1).getKey());
+                assertEquals(lsn3, list.get(2).getKey());
+            }
+
+        }
+    }
+
+    @Test
+    public void testWriteAsync() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            man.start();
+            logManager.start();
+
+            CommitLogResult res1;
+            CommitLogResult res2;
+            CommitLogResult res3;
+
+            LogSequenceNumber lsn3;
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting();
+                res1 = writer.log(LogEntryFactory.beginTransaction(1), false);
+                res2 = writer.log(LogEntryFactory.beginTransaction(2), false);
+                res3 = writer.log(LogEntryFactory.beginTransaction(3), true);
+                assertTrue(res1.deferred);
+                assertFalse(res1.sync);
+                assertTrue(res2.deferred);
+                assertFalse(res2.sync);
+                assertFalse(res3.deferred);
+                assertTrue(res3.sync);
+                assertNull(res1.getLogSequenceNumber());
+                assertNull(res2.getLogSequenceNumber());
+                assertNotNull(res3.getLogSequenceNumber());
+            }
+
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {
+                    list.add(new AbstractMap.SimpleImmutableEntry<>(a, b));
+                }, false);
+                assertEquals(3, list.size());
+
+                assertTrue(list.get(0).getKey().after(LogSequenceNumber.START_OF_TIME));
+                assertTrue(list.get(1).getKey().after(list.get(0).getKey()));
+                assertTrue(list.get(2).getKey().after(list.get(1).getKey()));
+            }
+
+        }
+    }
+
+    @Test
+    public void testBookieFailureSyncWrites() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            man.start();
+            logManager.start();
+
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting();
+
+                writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
+
+                this.testEnv.pauseBookie();
+                // this is deemed to fail and we will close the log
+                TestUtils.assertThrows(LogNotAvailableException.class, ()
+                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
+                );
+                assertTrue(writer.isFailed());
+
+                // this one will fail as well
+                TestUtils.assertThrows(LogNotAvailableException.class, ()
+                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
+                );
+
+                // no way to recover this instance of BookkeeperCommitLog
+                // we will bounce the leader and it will restart with a full recovery
+                // in a production env you do not have only one bookie, and the failure
+                // of a single bookie will be handled with an ensemble change
+                this.testEnv.resumeBookie();
+
+                TestUtils.assertThrows(LogNotAvailableException.class, ()
+                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
+                );
+            }
+
+            // check expected reads
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {
+                    list.add(new AbstractMap.SimpleImmutableEntry<>(a, b));
+                }, false);
+                assertEquals(1, list.size());
+
+                assertTrue(list.get(0).getKey().after(LogSequenceNumber.START_OF_TIME));
+            }
+
+        }
+    }
+
+    @Test
+    public void testBookieFailureAsyncWrites() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            man.start();
+            logManager.start();
+
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting();
+
+                // many async writes
+                writer.log(LogEntryFactory.beginTransaction(1), false).getLogSequenceNumber();
+                writer.log(LogEntryFactory.beginTransaction(1), false).getLogSequenceNumber();
+                writer.log(LogEntryFactory.beginTransaction(1), false).getLogSequenceNumber();
+                // one sync write
+                writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
+
+                this.testEnv.pauseBookie();
+                // this is deemed to fail and we will close the log
+
+                // writer won't see the failure, because this is a deferred write
+                writer.log(LogEntryFactory.beginTransaction(2), false).getLogSequenceNumber();
+
+                // this one will fail as well, and we will catch the error, because this is a sync write
+                // like a "transaction commit"
+                TestUtils.assertThrows(LogNotAvailableException.class, ()
+                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
+                );
+
+                // no way to recover this instance of BookkeeperCommitLog
+                // we will bounce the leader and it will restart with a full recovery
+                // in a production env you do not have only one bookie, and the failure
+                // of a single bookie will be handled with an ensemble change
+                this.testEnv.resumeBookie();
+
+                TestUtils.assertThrows(LogNotAvailableException.class, ()
+                        -> writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber()
+                );
+            }
+
+            // check expected reads
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {
+                    list.add(new AbstractMap.SimpleImmutableEntry<>(a, b));
+                }, false);
+                assertEquals(4, list.size());
+            }
+
+        }
+    }
+
+    @Test
+    public void testMaxLedgerSize() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        final int maxLedgerSize = 1024;
+        final LogEntry entry = LogEntryFactory.beginTransaction(1);
+        final int estimateSize = entry.serialize().length;
+        final int numberOfLedgers = 10;
+        final int numberOfEntries = 1 + numberOfLedgers * maxLedgerSize / estimateSize;
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            logManager.setMaxLedgerSizeBytes(maxLedgerSize);
+            man.start();
+            logManager.start();
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting();
+                for (int i = 0; i < numberOfEntries; i++) {
+                    writer.log(entry, false);
+                }
+                writer.log(entry, true).getLogSequenceNumber();
+            }
+
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                Set<Long> ledgerIds = new HashSet<>();
+                reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {
+                    list.add(new AbstractMap.SimpleImmutableEntry<>(a, b));
+                    ledgerIds.add(a.ledgerId);
+                }, false);
+                assertEquals(numberOfEntries + 1, list.size());
+                assertEquals(numberOfLedgers, ledgerIds.size());
+            }
+
+        }
+    }
+
+    @Test
+    public void testMaxLedgerSizeWithTemporaryError() throws Exception {
+        final String tableSpaceUUID = UUID.randomUUID().toString();
+        final String name = TableSpace.DEFAULT;
+        final String nodeid = "nodeid";
+        final int maxLedgerSize = 1024;
+        final LogEntry entry = LogEntryFactory.beginTransaction(1);
+        final int estimateSize = entry.serialize().length;
+        final int numberOfLedgers = 10;
+        final int numberOfEntries = 1 + numberOfLedgers * maxLedgerSize / estimateSize;
+        System.out.println("writing " + numberOfEntries + " entries");
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+                BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            logManager.setMaxLedgerSizeBytes(maxLedgerSize);
+            man.start();
+            logManager.start();
+
+            assertTrue(numberOfEntries > 70);
+
+            try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                writer.startWriting();
+                for (int i = 0; i < numberOfEntries; i++) {
+                    writer.log(entry, false);
+                    if (i == 70) {
+                        // stop bookie, but writes will continue to be acklowledged
+                        testEnv.pauseBookie();
+                    }
+                }
+
+                // even if we restart the bookie we must not be able to acknowledge the write
+                testEnv.resumeBookie();
+                TestUtils.assertThrows(LogNotAvailableException.class, ()
+                        -> writer.log(entry, true).getLogSequenceNumber()
+                );
+            }
+
+            try (BookkeeperCommitLog reader = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
+                List<Map.Entry<LogSequenceNumber, LogEntry>> list = new ArrayList<>();
+                Set<Long> ledgerIds = new HashSet<>();
+                reader.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {
+                    list.add(new AbstractMap.SimpleImmutableEntry<>(a, b));
+                    ledgerIds.add(a.ledgerId);
+                }, false);
+                assertTrue("unexpected number of entries on reader: " + list.size(), list.size() <= 70);
+            }
+
+        }
+    }
+}

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -19,14 +19,14 @@
  */
 package herddb.cluster.bookkeeper;
 
-import herddb.cluster.BookkeeperCommitLog;
-import herddb.cluster.BookkeeperCommitLogManager;
-import herddb.cluster.ZookeeperMetadataStorageManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import herddb.cluster.BookkeeperCommitLog;
+import herddb.cluster.BookkeeperCommitLogManager;
+import herddb.cluster.ZookeeperMetadataStorageManager;
 import herddb.log.CommitLogResult;
 import herddb.log.LogEntry;
 import herddb.log.LogEntryFactory;

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookieNotAvailableTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookieNotAvailableTest.java
@@ -91,7 +91,7 @@ public class BookieNotAvailableTest extends BookkeeperFailuresBase {
             // we do not want auto-recovery
             server.getManager().setActivatorPauseStatus(true);
 
-            testEnv.stopBookie();
+            testEnv.pauseBookie();
 
             try {
                 server.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.
@@ -101,7 +101,7 @@ public class BookieNotAvailableTest extends BookkeeperFailuresBase {
             } catch (StatementExecutionException expected) {
             }
 
-            testEnv.startBookie(false);
+            testEnv.resumeBookie();
 
             while (true) {
                 System.out.println("status leader:" + tableSpaceManager.isLeader() + " failed:" + tableSpaceManager.

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/FencingTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/FencingTest.java
@@ -103,12 +103,11 @@ public class FencingTest extends BookkeeperFailuresBase {
             }
 
             while (true) {
-                System.out.println("status leader:" + tableSpaceManager.isLeader() + " failed:" + tableSpaceManager.
-                        isFailed());
+                System.out.println("status leader:" + tableSpaceManager.isLeader() + " failed:" + tableSpaceManager.isFailed());
                 if (tableSpaceManager.isFailed()) {
                     break;
                 }
-                Thread.sleep(100);
+                Thread.sleep(1000);
             }
 
             server.getManager().setActivatorPauseStatus(false);

--- a/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
@@ -70,8 +70,9 @@ public class ZKTestEnv implements AutoCloseable {
         conf.setBookiePort(5621);
         conf.setUseHostNameAsBookieID(true);
 
-        // no need to preallocate journal in tests
+        // no need to preallocate journal and entrylog in tests
         conf.setEntryLogFilePreAllocationEnabled(false);
+        conf.setProperty("journalPreAllocSizeMB", 1);
 
         Path targetDir = path.resolve("bookie_data");
         conf.setMetadataServiceUri("zk+null://localhost:1282" + herddb.server.ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT);

--- a/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
@@ -69,7 +69,7 @@ public class ZKTestEnv implements AutoCloseable {
         ServerConfiguration conf = new ServerConfiguration();
         conf.setBookiePort(5621);
         conf.setUseHostNameAsBookieID(true);
-        
+
         // no need to preallocate journal in tests
         conf.setEntryLogFilePreAllocationEnabled(false);
 
@@ -86,7 +86,7 @@ public class ZKTestEnv implements AutoCloseable {
         // no need for real network in tests
         conf.setEnableLocalTransport(true);
         conf.setDisableServerSocketBind(true);
-        
+
         // no need to fsync in tests
         conf.setJournalSyncData(false);
 

--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -106,6 +106,11 @@ server.bookkeeper.ack.quorum.size=1
 # retention period, in milliseconds, of bookkeeper ledgers
 server.bookkeeper.ledgers.retention.period=34560000
 
+# maximum size of a single ledger
+# if you have huge ledgers than you cannot recover Bookie disk space during checkpoints
+# so it is better to roll a new ledger after a given amount of written bytes
+server.bookkeeper.ledgers.max.size=1073741824
+
 # max time to wait before forcing sync to follower nodes, set 0 to disable this feature (if you do not have followers at all)
 server.bookkeeper.max.idle.time=10000
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <libs.jersey>2.26</libs.jersey>
         <libs.jcipi-annotations>1.0</libs.jcipi-annotations>
         <libs.spotbugsannotations>3.1.8</libs.spotbugsannotations>
-        <libs.spotbugsmaven>3.1.8</libs.spotbugsmaven>
+        <libs.spotbugsmaven>3.1.12.2</libs.spotbugsmaven>
         <fbs.version>1.9.0</fbs.version>
         <checkstyle.version>8.23</checkstyle.version>
     </properties>


### PR DESCRIPTION
 - introduce server.bookkeeper.ledgers.max.size
 - rework BookKeeper failure handler
 - add direct unit tests over BookKeeperCommitLog
 - ensure that every write has been completed before rolling a new ledger
- clean up ZKTestEnv in order to start a more lightweight bookie