### PR TITLE
Better log during recovery

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -573,6 +573,9 @@ public class BookkeeperCommitLog extends CommitLog {
                                     new Object[]{start, end, percent, (_stop - _start) + " ms", tableSpaceDescription});
                         }
                     }
+                } catch (RuntimeException err) {
+                    LOGGER.log(Level.SEVERE, "Internal error while recovering tablespace " + tableSpaceDescription() + ": " + err, err);
+                    throw err;
                 } finally {
                     handle.close();
                 }


### PR DESCRIPTION
Catch any RuntimeException and log it in BookKeeperCommitLog logger, this way we can have the error in BookKeeperCommitLog log files, this allows better debugging in case of error in production.