### PR TITLE
Prevent a follower with too few data to become a leader

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -911,7 +911,8 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         return nodeId.replace(":", "").replace(".", "").toLowerCase();
     }
 
-    private boolean isTableSpaceLocallyRecoverable(TableSpace tableSpace) {
+    // visible for testing
+    public boolean isTableSpaceLocallyRecoverable(TableSpace tableSpace) {
         LogSequenceNumber logSequenceNumber = dataStorageManager.getLastcheckpointSequenceNumber(tableSpace.uuid);
         try (CommitLog tmpCommitLog = commitLogManager.createCommitLog(tableSpace.uuid, tableSpace.name, nodeId);) {
             return tmpCommitLog.isRecoveryAvailable(logSequenceNumber);

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -30,6 +30,7 @@ import herddb.jmx.JMXUtils;
 import herddb.log.CommitLog;
 import herddb.log.CommitLogManager;
 import herddb.log.LogNotAvailableException;
+import herddb.log.LogSequenceNumber;
 import herddb.mem.MemoryMetadataStorageManager;
 import herddb.metadata.MetadataChangeListener;
 import herddb.metadata.MetadataStorageManager;
@@ -910,7 +911,20 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         return nodeId.replace(":", "").replace(".", "").toLowerCase();
     }
 
-    private void tryBecomeLeaderFor(TableSpace tableSpace) throws DDLException, MetadataStorageManagerException {
+    private boolean isTableSpaceLocallyRecoverable(TableSpace tableSpace) {
+        LogSequenceNumber logSequenceNumber = dataStorageManager.getLastcheckpointSequenceNumber(tableSpace.uuid);
+        try (CommitLog tmpCommitLog = commitLogManager.createCommitLog(tableSpace.uuid, tableSpace.name, nodeId);) {
+            return tmpCommitLog.isRecoveryAvailable(logSequenceNumber);
+        }
+    }
+
+    private boolean tryBecomeLeaderFor(TableSpace tableSpace) throws DDLException, MetadataStorageManagerException {
+        if (!isTableSpaceLocallyRecoverable(tableSpace)) {
+            LOGGER.log(Level.INFO, "local node {0} cannot become leader of {1} (current is {2})."
+                    + "Cannot boot tablespace locally (not enough data, last checkpoint + log)",
+                    new Object[]{nodeId, tableSpace.name, tableSpace.leaderId});
+            return false;
+        }
         LOGGER.log(Level.INFO, "node {0}, try to become leader of {1} (prev was {2})", new Object[]{nodeId, tableSpace.name, tableSpace.leaderId});
         TableSpace.Builder newTableSpaceBuilder =
                 TableSpace
@@ -921,8 +935,10 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         boolean ok = metadataStorageManager.updateTableSpace(newTableSpace, tableSpace);
         if (!ok) {
             LOGGER.log(Level.SEVERE, "node {0} updating tableSpace {1} try to become leader failed", new Object[]{nodeId, tableSpace.name});
+            return false;
         } else {
-            LOGGER.log(Level.SEVERE, "node {0} updating tableSpace {1} try to become leader succeed", new Object[]{nodeId, tableSpace.name});
+            LOGGER.log(Level.SEVERE, "node {0} updating tableSpace {1} try to become leader succeeded", new Object[]{nodeId, tableSpace.name});
+            return true;
         }
     }
 
@@ -1215,10 +1231,11 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                                     + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is healty");
                         } else {
                             LOGGER.log(Level.SEVERE, "Leader for " + tableSpaceUuid + " is " + tableSpaceInfo.leaderId
-                                    + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is failed. " + nodeId + " now trying to take leadership");
-                            tryBecomeLeaderFor(tableSpaceInfo);
-                            // only one change at a time
-                            break;
+                                    + ", last ping " + new java.sql.Timestamp(leaderState.timestamp) + ". leader is failed.");
+                            if (tryBecomeLeaderFor(tableSpaceInfo)) {
+                                // only one change at a time
+                                break;
+                            }
                         }
 
                     }

--- a/herddb-core/src/main/java/herddb/log/CommitLog.java
+++ b/herddb-core/src/main/java/herddb/log/CommitLog.java
@@ -45,6 +45,16 @@ public abstract class CommitLog implements AutoCloseable {
 
     public abstract void recovery(LogSequenceNumber snapshotSequenceNumber, BiConsumer<LogSequenceNumber, LogEntry> consumer, boolean fencing) throws LogNotAvailableException;
 
+    /**
+     * Checks if log contains enough data in order to recovery from a given snapshot sequence number.
+     *
+     * @param snapshotSequenceNumber
+     * @return true in case recovery is possible.
+     */
+    public boolean isRecoveryAvailable(LogSequenceNumber snapshotSequenceNumber) {
+        return true;
+    }
+
     public interface FollowerContext extends AutoCloseable {
 
         @Override

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
@@ -222,7 +222,7 @@ public class BootFollowerTest extends MultiServerBase {
             server_2.getManager().setActivatorPauseStatus(true);
             server_2.start();
 
-            assertFalse(server_2.getManager().isTableSpaceLocallyRecoverable(server_2.getMetadataStorageManager().describeTableSpace(TableSpace.DEFAULT)));
+            assertTrue(server_2.getManager().isTableSpaceLocallyRecoverable(server_2.getMetadataStorageManager().describeTableSpace(TableSpace.DEFAULT)));
 
             server_2.getManager().setActivatorPauseStatus(false);
 

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
@@ -20,6 +20,7 @@
 package herddb.cluster.follower;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.cluster.LedgersInfo;
@@ -115,7 +116,12 @@ public class BootFollowerTest extends MultiServerBase {
                     DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
+                server_2.getManager().setActivatorPauseStatus(true);
                 server_2.start();
+
+                assertTrue(server_2.getManager().isTableSpaceLocallyRecoverable(server_2.getMetadataStorageManager().describeTableSpace(TableSpace.DEFAULT)));
+
+                server_2.getManager().setActivatorPauseStatus(false);
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
                         new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
@@ -212,7 +218,13 @@ public class BootFollowerTest extends MultiServerBase {
         }
 
         try (Server server_2 = new Server(serverconfig_2)) {
+
+            server_2.getManager().setActivatorPauseStatus(true);
             server_2.start();
+
+            assertFalse(server_2.getManager().isTableSpaceLocallyRecoverable(server_2.getMetadataStorageManager().describeTableSpace(TableSpace.DEFAULT)));
+
+            server_2.getManager().setActivatorPauseStatus(false);
 
             assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
@@ -20,7 +20,6 @@
 package herddb.cluster.follower;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import herddb.cluster.BookkeeperCommitLog;
 import herddb.cluster.LedgersInfo;

--- a/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
@@ -252,6 +252,9 @@ public class SimpleFollowerTest extends MultiServerBase {
             // data will be downloaded from the server_1 (PROPERTY_BOOT_FORCE_DOWNLOAD_SNAPSHOT)
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();
+
+                assertTrue(server_2.getManager().isTableSpaceLocallyRecoverable(server_1.getMetadataStorageManager().describeTableSpace(TableSpace.DEFAULT)));
+
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
                         new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));


### PR DESCRIPTION
Any follower wants to pick up leadership in case of dead leader.
In case of a follower that has been offline for quite long time, it must not try to become leader otherwise it would fall into the case of needing to download a snapshot from itself.
With this patch we are checking full recovery availability before taking leadership.