### PR TITLE
Check consistency at every recovery

### DIFF
--- a/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
@@ -145,6 +145,9 @@ public interface AbstractTableManager extends AutoCloseable {
 
     void scanForIndexRebuild(Consumer<Record> records) throws DataStorageManagerException;
 
+    default void verifyTableConsistency() throws DataStorageManagerException {
+    }
+
     final class TableCheckpoint {
 
         final String tableName;

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1843,15 +1843,17 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         });
         LOGGER.log(Level.INFO, "Verify table consistency {0}.{1}, scanned {2} records using PK", new Object[]{table.tablespace, table.name, countPk.value});
         Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
-        for (AbstractIndexManager index : indexes.values()) {
-            LOGGER.log(Level.INFO, "Verify table consistency {0}.{1} using index {2}", new Object[]{table.tablespace, table.name, index.index.name});
-            final LongHolder countIndex = new LongHolder();
-            index.scanner(new SecondaryIndexFullScan(index.index.name), new StatementEvaluationContext(), tableContext)
-                    .forEach(key -> {
-                        countIndex.value++;
-                    });
+        if (indexes != null) {
+            for (AbstractIndexManager index : indexes.values()) {
+                LOGGER.log(Level.INFO, "Verify table consistency {0}.{1} using index {2}", new Object[]{table.tablespace, table.name, index.index.name});
+                final LongHolder countIndex = new LongHolder();
+                index.scanner(new SecondaryIndexFullScan(index.index.name), new StatementEvaluationContext(), tableContext)
+                        .forEach(key -> {
+                            countIndex.value++;
+                        });
 
-            LOGGER.log(Level.INFO, "Verify table consistency {0}.{1}, scanned {2} records using index {3}", new Object[]{table.tablespace, table.name, countIndex.value, index.index.name});
+                LOGGER.log(Level.INFO, "Verify table consistency {0}.{1}, scanned {2} records using index {3}", new Object[]{table.tablespace, table.name, countIndex.value, index.index.name});
+            }
         }
         LOGGER.log(Level.INFO, "Verify table consistency {0}.{1} finished", new Object[]{table.tablespace, table.name});
     }

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -218,6 +218,12 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
                     .filter(predicate)
                     .map(entry -> entry.getValue())
                     .flatMap(l -> l.stream());
+        } else if (operation instanceof SecondaryIndexFullScan) {
+            return data
+                    .entrySet()
+                    .stream()
+                    .map(entry -> entry.getValue())
+                    .flatMap(l -> l.stream());
         } else {
             throw new UnsupportedOperationException("unsuppported index access type " + operation);
         }

--- a/herddb-core/src/main/java/herddb/index/SecondaryIndexFullScan.java
+++ b/herddb-core/src/main/java/herddb/index/SecondaryIndexFullScan.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.index;
+
+/**
+ * Full scan of a secondary index
+ *
+ * @author enrico.olivelli
+ */
+public class SecondaryIndexFullScan implements IndexOperation {
+
+    private final String indexName;
+
+    public SecondaryIndexFullScan(String indexName) {
+        this.indexName = indexName;
+    }
+
+    @Override
+    public String getIndexName() {
+        return indexName;
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -29,6 +29,7 @@ import herddb.core.PageReplacementPolicy;
 import herddb.core.PostCheckpointAction;
 import herddb.core.TableSpaceManager;
 import herddb.index.IndexOperation;
+import herddb.index.SecondaryIndexFullScan;
 import herddb.index.SecondaryIndexPrefixScan;
 import herddb.index.SecondaryIndexRangeScan;
 import herddb.index.SecondaryIndexSeek;
@@ -411,6 +412,9 @@ public class BRINIndexManager extends AbstractIndexManager {
             LOGGER.log(Level.FINE, "range scan on {0}.{1}, from {2} to {1}", new Object[]{index.table, index.name, firstKey, lastKey});
             return data.query(firstKey, lastKey);
 
+        } else if (operation instanceof SecondaryIndexFullScan) {
+            LOGGER.log(Level.FINE, "full scan on {0}.{1}", new Object[]{index.table, index.name});
+            return data.query(null, Bytes.POSITIVE_INFINITY);
         } else {
             throw new UnsupportedOperationException("unsuppported index access type " + operation);
         }

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -137,7 +137,7 @@ public final class ServerConfiguration {
     public static final String PROPERTY_BOOKKEEPER_ACKQUORUMSIZE = "server.bookkeeper.ack.quorum.size";
     public static final int PROPERTY_BOOKKEEPER_ACKQUORUMSIZE_DEFAULT = 1;
     public static final String PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD = "server.bookkeeper.ledgers.retention.period";
-    public static final long PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD_DEFAULT = 1000L * 60 * 60 * 24 * 2;
+    public static final long PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD_DEFAULT = 1000L * 60 * 60 * 24 * 7;
 
     public static final String PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE = "server.bookkeeper.ledgers.max.size";
     public static final long PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE_DEFAULT = 1024L * 1024 * 1024;
@@ -150,6 +150,9 @@ public final class ServerConfiguration {
 
     public static final String PROPERTY_CHECKPOINT_PERIOD = "server.checkpoint.period";
     public static final long PROPERTY_CHECKPOINT_PERIOD_DEFAULT = 1000L * 60 * 15;
+
+    public static final String PROPERTY_ENABLE_CONSISTENCY_CHECK = "server.localconsistencycheck.enabled";
+    public static final boolean PROPERTY_ENABLE_CONSISTENCY_CHECK_DEFAULT = true;
 
     public static final String PROPERTY_DEFAULT_REPLICA_COUNT = "tablespace.default.replica.count";
     public static final int PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT = 1;

--- a/herddb-core/src/test/java/herddb/core/CheckpointTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointTest.java
@@ -135,6 +135,9 @@ public class CheckpointTest {
         /* Disable page compaction (avoid compaction of dirty page) */
         config1.set(ServerConfiguration.PROPERTY_FILL_PAGE_THRESHOLD, 0.0D);
 
+        // local consistency check may load pages and make this test flaky
+        config1.set(ServerConfiguration.PROPERTY_ENABLE_CONSISTENCY_CHECK, false);
+
         try (DBManager manager = new DBManager("localhost",
                 new FileMetadataStorageManager(metadataPath),
                 new FileDataStorageManager(dataPath),


### PR DESCRIPTION
New configuration option *server.localconsistencycheck.enabled* that forces a full table and index scan on every table after every "recovery" operation for each tablespace.

Implement a new SecondaryIndexFullScan that is needed for a full scan of every secondary index.

Scanning a table loads every page into memory in a temporary buffer, and it verifies that the page pointed by the keyToPage index is valid and contains the record as expected.

