### PR TITLE
Handle correctly hidden NPE during Multi Updates and Deletes

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1226,7 +1226,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                                 apply(pending.pos, pending.entry, false);
                             }
                         } finally {
-                            if (pending.lockHandle != null) {
+                            if (pending != null && pending.lockHandle != null) {
                                 locksManager.releaseLock(pending.lockHandle);
                             }
                         }
@@ -1246,9 +1246,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                                 }
                             }
                         } finally {
-                            for (PendingLogEntryWork pending : pendings) {
-                                if (pending.lockHandle != null) {
-                                    locksManager.releaseLock(pending.lockHandle);
+                            if (pendings != null) {
+                                for (PendingLogEntryWork pending : pendings) {
+                                    if (pending.lockHandle != null) {
+                                        locksManager.releaseLock(pending.lockHandle);
+                                    }
                                 }
                             }
                         }
@@ -1310,7 +1312,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                                 apply(pending.pos, pending.entry, false);
                             }
                         } finally {
-                            if (pending.lockHandle != null) {
+                            if (pending != null && pending.lockHandle != null) {
                                 locksManager.releaseLock(pending.lockHandle);
                             }
                         }
@@ -1330,9 +1332,11 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                                 }
                             }
                         } finally {
-                            for (PendingLogEntryWork pending : pendings) {
-                                if (pending.lockHandle != null) {
-                                    locksManager.releaseLock(pending.lockHandle);
+                            if (pendings != null) {
+                                for (PendingLogEntryWork pending : pendings) {
+                                    if (pending.lockHandle != null) {
+                                        locksManager.releaseLock(pending.lockHandle);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
In case of validation error an hidden NullPointerException is thrown, because of a missing null-check.
Add the missing null check in order to not trigger the NullPointerException