### PR TITLE
Write ledger header

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -225,17 +225,22 @@ public class BookkeeperCommitLog extends CommitLog {
             }
             // write a dummy entry, this will force Bookies to know about the ledger
             try {
-                log(LogEntryFactory.noop(), true).getLogSequenceNumber();
+                LogSequenceNumber lsn = writeEntry(LogEntryFactory.noop()).get();
+                LOGGER.log(Level.INFO, "{0} ledger header written at {1}",
+                        new Object[]{tableSpaceDescription(), lsn});
             } catch (LogNotAvailableException t) {
                 LOGGER.log(Level.SEVERE, "error", t);
                 throw t;
+            } catch (Exception t) {
+                LOGGER.log(Level.SEVERE, "error", t);
+                throw new LogNotAvailableException(t);
             }
         }
 
         private void writeNoop() {
             // write a dummy entry, this will force LastAddConfirmed to be piggybacked
             try {
-                log(LogEntryFactory.noop(), false);
+                writeEntry(LogEntryFactory.noop());
             } catch (LogNotAvailableException t) {
                 LOGGER.log(Level.SEVERE, "error", t);
             }

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -217,6 +217,16 @@ public class BookkeeperCommitLog extends CommitLog {
             return out;
         }
 
+        private void writeLedgerHeader() throws LogNotAvailableException {
+            // write a dummy entry, this will force Bookies to know about the ledger
+            try {
+                log(LogEntryFactory.noop(), true).getLogSequenceNumber();
+            } catch (LogNotAvailableException t) {
+                LOGGER.log(Level.SEVERE, "error", t);
+                throw t;
+            }
+        }
+
         private void writeNoop() {
             // write a dummy entry, this will force LastAddConfirmed to be piggybacked
             try {
@@ -419,6 +429,7 @@ public class BookkeeperCommitLog extends CommitLog {
             // if a pending write fails we are failing the creation of the new ledger
             closeCurrentWriter(true);
             writer = new CommitFileWriter();
+            writer.writeLedgerHeader();
             currentLedgerId = writer.getLedgerId();
             LOGGER.log(Level.INFO, "Tablespace {1}, opened new ledger:{0}",
                     new Object[]{currentLedgerId, tableSpaceDescription()});

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -152,6 +152,8 @@ public class BookkeeperCommitLog extends CommitLog {
                         .withCustomMetadata(metadata)
                         .execute(), BKException.HANDLER);
                 this.ledgerId = this.out.getId();
+                LOGGER.log(Level.INFO, "{0} created ledger {1} (" + ensemble + "/" + writeQuorumSize + "/" + ackQuorumSize + ") bookies: {2}",
+                        new Object[]{tableSpaceDescription(), ledgerId, this.out.getLedgerMetadata().getAllEnsembles()});
                 lastLedgerId = ledgerId;
                 lastSequenceNumber.set(-1);
             } catch (BKException err) {

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -94,6 +94,7 @@ public class BookkeeperCommitLog extends CommitLog {
     private long ledgersRetentionPeriod = 1000 * 60 * 60 * 24;
     private long maxLedgerSizeBytes = 1024 * 1024 * 1024;
     private long maxIdleTime = 0;
+    private boolean writeLedgerHeader = true;
 
     private volatile boolean closed = false;
     private volatile boolean failed = false;
@@ -218,6 +219,10 @@ public class BookkeeperCommitLog extends CommitLog {
         }
 
         private void writeLedgerHeader() throws LogNotAvailableException {
+            if (!writeLedgerHeader) {
+                // useful only for tests
+                return;
+            }
             // write a dummy entry, this will force Bookies to know about the ledger
             try {
                 log(LogEntryFactory.noop(), true).getLogSequenceNumber();
@@ -312,6 +317,14 @@ public class BookkeeperCommitLog extends CommitLog {
 
     public void setMaxIdleTime(long maxIdleTime) {
         this.maxIdleTime = maxIdleTime;
+    }
+
+    public boolean isWriteLedgerHeader() {
+        return writeLedgerHeader;
+    }
+
+    public void setWriteLedgerHeader(boolean writeLedgerHeader) {
+        this.writeLedgerHeader = writeLedgerHeader;
     }
 
     private CommitFileWriter getValidWriter() {
@@ -422,6 +435,7 @@ public class BookkeeperCommitLog extends CommitLog {
     }
 
     private CommitFileWriter openNewLedger() throws LogNotAvailableException {
+        Long pendingLedgerId = null;
         lock.writeLock().lock();
         try {
             // wait for all previous writes to succeed and then close the ledger
@@ -429,7 +443,9 @@ public class BookkeeperCommitLog extends CommitLog {
             // if a pending write fails we are failing the creation of the new ledger
             closeCurrentWriter(true);
             writer = new CommitFileWriter();
+            pendingLedgerId = writer.getLedgerId();
             writer.writeLedgerHeader();
+            pendingLedgerId = null;
             currentLedgerId = writer.getLedgerId();
             LOGGER.log(Level.INFO, "Tablespace {1}, opened new ledger:{0}",
                     new Object[]{currentLedgerId, tableSpaceDescription()});
@@ -443,6 +459,17 @@ public class BookkeeperCommitLog extends CommitLog {
             signalLogFailed();
             throw err;
         } finally {
+            if (pendingLedgerId != null) {
+                LOGGER.log(Level.SEVERE, "Trying to delete bad ledge from metadata {0}", pendingLedgerId);
+                try {
+                    bookKeeper.deleteLedger(pendingLedgerId);
+                } catch (InterruptedException ex) {
+                    LOGGER.log(Level.SEVERE, "Cannot delete bad ledge from metadata " + pendingLedgerId, ex);
+                    Thread.currentThread().interrupt();
+                } catch (BKException ex) {
+                    LOGGER.log(Level.SEVERE, "Cannot delete bad ledge from metadata " + pendingLedgerId, ex);
+                }
+            };
             lock.writeLock().unlock();
         }
     }

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLog.java
@@ -474,7 +474,7 @@ public class BookkeeperCommitLog extends CommitLog {
                 } catch (BKException ex) {
                     LOGGER.log(Level.SEVERE, "Cannot delete bad ledge from metadata " + pendingLedgerId, ex);
                 }
-            };
+            }
             lock.writeLock().unlock();
         }
     }

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -435,12 +435,12 @@ public class BookKeeperCommitLogTest {
         final String name = TableSpace.DEFAULT;
         final String nodeid = "nodeid";
         ServerConfiguration serverConfiguration = new ServerConfiguration();
-        serverConfiguration.set(ServerConfiguration.PROPERTY_BOOKKEEPER_ENSEMBLE, 2);
-        serverConfiguration.set(ServerConfiguration.PROPERTY_BOOKKEEPER_WRITEQUORUMSIZE, 2);
-        serverConfiguration.set(ServerConfiguration.PROPERTY_BOOKKEEPER_ACKQUORUMSIZE, 2);
         try (ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
                 testEnv.getTimeout(), testEnv.getPath());
                 BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE)) {
+            logManager.setEnsemble(2);
+            logManager.setWriteQuorumSize(2);
+            logManager.setAckQuorumSize(2);
             man.start();
             logManager.start();
 
@@ -449,7 +449,6 @@ public class BookKeeperCommitLogTest {
 
                 // create a ledger, up to 0.14.x no "logical" write happens, so Bookies are not aware of the
                 // the ledger
-
                 // stop one bookie
                 testEnv.stopBookie(secondBookie);
 

--- a/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
@@ -22,6 +22,8 @@ package herddb.utils;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.proto.BookieServer;
@@ -31,6 +33,8 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
 
 public class ZKTestEnv implements AutoCloseable {
+
+    private static final Logger LOG = Logger.getLogger(ZKTestEnv.class.getName());
 
     static {
         System.setProperty("zookeeper.admin.enableServer", "false");
@@ -88,7 +92,7 @@ public class ZKTestEnv implements AutoCloseable {
     private ServerConfiguration createBookieConf(int port) {
         ServerConfiguration conf = new ServerConfiguration();
         conf.setBookiePort(port++);
-        System.out.println("STARTING BOOKIE at port " + port);
+        LOG.log(Level.INFO, "STARTING BOOKIE at port {0}", String.valueOf(port));
         conf.setUseHostNameAsBookieID(true);
         // no need to preallocate journal and entrylog in tests
         conf.setEntryLogFilePreAllocationEnabled(false);

--- a/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
+++ b/herddb-core/src/test/java/herddb/utils/ZKTestEnv.java
@@ -64,11 +64,11 @@ public class ZKTestEnv implements AutoCloseable {
         startBookie(true);
     }
 
-    public void startNewBookie() throws Exception {
-        startBookie(false);
+    public String startNewBookie() throws Exception {
+        return startBookie(false);
     }
 
-    private void startBookie(boolean format) throws Exception {
+    private String startBookie(boolean format) throws Exception {
         if (format && !bookies.isEmpty()) {
             throw new Exception("cannot format, you aleady have bookies");
         }
@@ -82,6 +82,7 @@ public class ZKTestEnv implements AutoCloseable {
         BookieServer bookie = new BookieServer(conf);
         bookies.add(bookie);
         bookie.start();
+        return bookie.getLocalAddress().getSocketAddress().toString();
     }
 
     private ServerConfiguration createBookieConf(int port) {


### PR DESCRIPTION
- write an entry to the ledger before adding it to the list of active ledgers
- this is a workaround to a possible fault case in BookKeeper when there is no entry on the Bookie and one Bookie goes down