### PR TITLE
Retry connection and refresh metadata cache on timeout failures during connection opening

### DIFF
--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -24,6 +24,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.backup.BackupFileConstants;
 import herddb.backup.DumpedLogEntry;
 import herddb.backup.DumpedTableMetadata;
+import herddb.client.impl.ConnectionOpenTimeoutException;
 import herddb.client.impl.LeaderChangedException;
 import herddb.client.impl.RetryRequestException;
 import herddb.client.impl.UnreachableServerException;
@@ -294,7 +295,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
                     if (channel != null) {
                         channel.close();
                     }
-                    throw new HDBOperationTimeoutException(err);
+                    throw new ConnectionOpenTimeoutException(err);
                 } catch (Exception err) {
                     LOGGER.log(Level.SEVERE, "Error", err);
                     if (channel != null) {
@@ -341,7 +342,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -374,7 +375,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -389,7 +390,11 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             channel.sendRequestWithAsyncReply(requestId, message, timeout,
                     (msg, error) -> {
                         if (error != null) {
-                            res.completeExceptionally(error);
+                            if (error instanceof TimeoutException) {
+                                res.completeExceptionally(new HDBOperationTimeoutException(error));
+                            } else {
+                                res.completeExceptionally(new HDBException(error));
+                            }
                             return;
                         }
                         try (Pdu reply = msg) {
@@ -467,7 +472,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -486,7 +491,11 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             channel.sendRequestWithAsyncReply(requestId, message, timeout,
                     (msg, error) -> {
                         if (error != null) {
-                            res.completeExceptionally(error);
+                            if (error instanceof TimeoutException) {
+                                res.completeExceptionally(new HDBOperationTimeoutException(error));
+                            } else {
+                                res.completeExceptionally(new HDBException(error));
+                            }
                             return;
                         }
                         try (Pdu reply = msg) {
@@ -564,7 +573,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -601,7 +610,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -622,7 +631,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -643,7 +652,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -711,7 +720,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             if (reply != null) {
                 reply.close();
             }
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -735,7 +744,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 
@@ -814,7 +823,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             Thread.currentThread().interrupt();
             throw new HDBException(err);
         } catch (TimeoutException err) {
-            throw new HDBException(err);
+            throw new HDBOperationTimeoutException(err);
         }
     }
 

--- a/herddb-core/src/main/java/herddb/client/impl/ConnectionOpenTimeoutException.java
+++ b/herddb-core/src/main/java/herddb/client/impl/ConnectionOpenTimeoutException.java
@@ -1,0 +1,50 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.client.impl;
+
+/**
+ * A retry is needed. The connection has timed out before completing opening process
+ *
+ * @author diego.salvi
+ */
+public class ConnectionOpenTimeoutException extends RetryRequestException {
+
+    /** Default Serial Version UID */
+    private static final long serialVersionUID = 1L;
+
+    public ConnectionOpenTimeoutException(String message) {
+        super(message);
+    }
+
+    public ConnectionOpenTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public ConnectionOpenTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public boolean isRequireMetadataRefresh() {
+        return true;
+    }
+
+}


### PR DESCRIPTION
On timeout failures during performAuthentication the attempt is totaly aborted but cached routes aren refreshed. In such cases remote server opened the connection but still cannot answer the client about leadership state. If the server lost leadership on a tablespace the client will still attempt forever to connect there instead checking the right tablespace leader.

In addition used already existing exception HDBOperationTimeoutException to mark timeout exceptions during normal executions and a new exception ConnectionOpenTimeoutException to mark timeout failure while performing connection opening

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
