### PR TITLE
Retry connection and refresh metadata cache on timeout failures during connection opening

### DIFF
--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -415,7 +415,7 @@ public class HDBConnection implements AutoCloseable {
         }
     }
 
-    public RoutedClientSideConnection getRouteToTableSpace(String tableSpace) throws ClientSideMetadataProviderException, HDBException {
+    protected RoutedClientSideConnection getRouteToTableSpace(String tableSpace) throws ClientSideMetadataProviderException, HDBException {
         if (closed) {
             throw new HDBException("connection is closed");
         }

--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -357,14 +357,18 @@ public class HDBConnection implements AutoCloseable {
         int sleepTimeout = client.getOperationRetryDelay();
         int maxTrials = client.getMaxOperationRetryCount();
         if (retry instanceof RetryRequestException) {
+            RetryRequestException retryError = (RetryRequestException) retry;
+            // Use implicit error max trials if override configuration
+            int errorMaxTrials = retryError.getMaxRetry();
+            if (errorMaxTrials != RetryRequestException.MAX_RETRY_NO_OVERRIDE) {
+                maxTrials = errorMaxTrials;
+            }
             if (retry instanceof LeaderChangedException) {
                 leaderChangedErrors.inc();
-                maxTrials = Integer.MAX_VALUE;
             }
             if (trialCount > maxTrials) {
                 throw new HDBException("Too many trials (" + trialCount + "/" + maxTrials + ") for " + retry, retry);
             }
-            RetryRequestException retryError = (RetryRequestException) retry;
             if (retryError.isRequireMetadataRefresh()) {
                 requestMetadataRefresh(retryError);
             }

--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -415,7 +415,7 @@ public class HDBConnection implements AutoCloseable {
         }
     }
 
-    private RoutedClientSideConnection getRouteToTableSpace(String tableSpace) throws ClientSideMetadataProviderException, HDBException {
+    public RoutedClientSideConnection getRouteToTableSpace(String tableSpace) throws ClientSideMetadataProviderException, HDBException {
         if (closed) {
             throw new HDBException("connection is closed");
         }

--- a/herddb-core/src/main/java/herddb/client/HDBOperationTimeoutException.java
+++ b/herddb-core/src/main/java/herddb/client/HDBOperationTimeoutException.java
@@ -19,14 +19,21 @@
  */
 package herddb.client;
 
+import herddb.client.impl.RetryRequestException;
+
 /**
  * A specific timeout exception
  * @author eolivelli
  */
-public class HDBOperationTimeoutException extends HDBException {
+public class HDBOperationTimeoutException extends RetryRequestException {
 
     public HDBOperationTimeoutException(Throwable cause) {
         super(cause);
+    }
+
+    @Override
+    public boolean isRequireMetadataRefresh() {
+        return true;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -93,6 +93,14 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         this.clientId = connection.getClient().getConfiguration().getString(ClientConfiguration.PROPERTY_CLIENTID, ClientConfiguration.PROPERTY_CLIENTID_DEFAULT);
     }
 
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
     private void performAuthentication(Channel channel, String serverHostname) throws Exception {
 
         SaslNettyClient saslNettyClient = new SaslNettyClient(

--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -24,6 +24,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.backup.BackupFileConstants;
 import herddb.backup.DumpedLogEntry;
 import herddb.backup.DumpedTableMetadata;
+import herddb.client.impl.HDBOperationTimeoutException;
 import herddb.client.impl.LeaderChangedException;
 import herddb.client.impl.RetryRequestException;
 import herddb.client.impl.UnreachableServerException;

--- a/herddb-core/src/main/java/herddb/client/impl/HDBOperationTimeoutException.java
+++ b/herddb-core/src/main/java/herddb/client/impl/HDBOperationTimeoutException.java
@@ -17,9 +17,7 @@
  under the License.
 
  */
-package herddb.client;
-
-import herddb.client.impl.RetryRequestException;
+package herddb.client.impl;
 
 /**
  * A specific timeout exception
@@ -34,6 +32,12 @@ public class HDBOperationTimeoutException extends RetryRequestException {
     @Override
     public boolean isRequireMetadataRefresh() {
         return true;
+    }
+
+    @Override
+    public int getMaxRetry() {
+        // One will be enough for refresh metadata
+        return 1;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/client/impl/LeaderChangedException.java
+++ b/herddb-core/src/main/java/herddb/client/impl/LeaderChangedException.java
@@ -44,4 +44,9 @@ public class LeaderChangedException extends RetryRequestException {
         return true;
     }
 
+    @Override
+    public int getMaxRetry() {
+        return Integer.MAX_VALUE;
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/client/impl/RetryRequestException.java
+++ b/herddb-core/src/main/java/herddb/client/impl/RetryRequestException.java
@@ -29,6 +29,8 @@ import herddb.client.HDBException;
  */
 public class RetryRequestException extends HDBException {
 
+    public static final int MAX_RETRY_NO_OVERRIDE = -1;
+
     public RetryRequestException(String message) {
         super(message);
     }
@@ -43,6 +45,10 @@ public class RetryRequestException extends HDBException {
 
     public boolean isRequireMetadataRefresh() {
         return false;
+    }
+
+    public int getMaxRetry() {
+        return MAX_RETRY_NO_OVERRIDE;
     }
 
 }

--- a/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
@@ -35,14 +35,20 @@ import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.TableSpace;
 import herddb.model.TransactionContext;
+import herddb.network.Channel;
+import herddb.proto.Pdu;
 import herddb.server.Server;
 import herddb.server.ServerConfiguration;
+import herddb.server.ServerSideConnectionPeer;
 import herddb.utils.DataAccessor;
 import herddb.utils.ZKTestEnv;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.test.TestStatsProvider;
 import org.junit.After;
@@ -57,6 +63,8 @@ import org.junit.rules.TemporaryFolder;
  * @author enrico.olivelli
  */
 public class RetryOnLeaderChangedTest {
+
+    private static final Logger LOG = Logger.getLogger(RetryOnLeaderChangedTest.class.getName());
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -378,6 +386,120 @@ public class RetryOnLeaderChangedTest {
 
             }
 
+        }
+    }
+
+    @Test
+    public void testSwitchLeaderAndAuthTimeout() throws Exception {
+
+        TestStatsProvider statsProvider = new TestStatsProvider();
+
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        ServerConfiguration serverconfig_2 = serverconfig_1
+                .copy()
+                .set(ServerConfiguration.PROPERTY_NODEID, "server2")
+                .set(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toAbsolutePath())
+                .set(ServerConfiguration.PROPERTY_PORT, 7868);
+
+        final AtomicBoolean suspendProcessing = new AtomicBoolean(false);
+        try (Server server_1 = new Server(serverconfig_1)) {
+
+            server_1.start();
+            server_1.waitForStandaloneBoot();
+
+            try (Server server_2 = new Server(serverconfig_2) {
+                @Override
+                protected ServerSideConnectionPeer buildPeer(Channel channel) {
+                    return new ServerSideConnectionPeer(channel, this) {
+
+                        @Override
+                        public void requestReceived(Pdu message, Channel channel) {
+                            if (suspendProcessing.get()) {
+                                LOG.log(Level.INFO, "dropping message type " + message.type + " id " + message.messageId);
+                                message.close();
+                                return;
+                            }
+                            super.requestReceived(message, channel);
+                        }
+
+                    };
+                }
+            }) {
+
+                server_2.start();
+
+                TestUtils.execute(server_1.getManager(),
+                        "CREATE TABLESPACE 'ttt','leader:" + server_2.getNodeId() + "','expectedreplicacount:2'",
+                        Collections.emptyList());
+
+                // wait for server_2 to wake up
+                for (int i = 0; i < 40; i++) {
+                    TableSpaceManager tableSpaceManager2 = server_2.getManager().getTableSpaceManager("ttt");
+                    if (tableSpaceManager2 != null
+                            && tableSpaceManager2.isLeader()) {
+                        break;
+                    }
+                    Thread.sleep(500);
+                }
+                assertTrue(server_2.getManager().getTableSpaceManager("ttt") != null
+                        && server_2.getManager().getTableSpaceManager("ttt").isLeader());
+
+                // wait for server_1 to announce as follower
+                waitClusterStatus(server_1.getManager(), server_1.getNodeId(), "follower");
+
+                ClientConfiguration clientConfiguration = new ClientConfiguration();
+                clientConfiguration.set(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_CLUSTER);
+                clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+                clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+                clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+                clientConfiguration.set(ClientConfiguration.PROPERTY_MAX_CONNECTIONS_PER_SERVER, 2);
+                clientConfiguration.set(ClientConfiguration.PROPERTY_TIMEOUT, 2000);
+
+                StatsLogger logger = statsProvider.getStatsLogger("ds");
+                try (HDBClient client1 = new HDBClient(clientConfiguration, logger)) {
+                    try (HDBConnection connection = client1.openConnection()) {
+
+                        // create table and insert data
+                        connection.executeUpdate(TableSpace.DEFAULT, "CREATE TABLE ttt.t1(k1 int primary key, n1 int)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                        connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(1,1)",
+                                TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+
+                        assertEquals("server2", connection.getRouteToTableSpace("ttt").getNodeId());
+
+                        // change leader
+                        switchLeader(server_1.getNodeId(), server_2.getNodeId(), server_1.getManager());
+
+
+                        try (HDBConnection connection2 = client1.openConnection()) {
+
+                            // connection routing still point to old leader (now follower)
+                            assertEquals("server2", connection2.getRouteToTableSpace("ttt").getNodeId());
+
+                            // suspend server_2 authentication
+                            suspendProcessing.set(true);
+
+                            // attempt an insert with old routing. Suspended autentication generates a timeout
+                            // and routing will be reevaluated
+                            assertEquals(1, connection2.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(2,2)",
+                                    TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList()).updateCount);
+
+                            // right routing to current master
+                            assertEquals("server1", connection2.getRouteToTableSpace("ttt").getNodeId());
+
+                            suspendProcessing.set(false);
+
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/herddb-utils/src/main/java/herddb/utils/TestUtils.java
+++ b/herddb-utils/src/main/java/herddb/utils/TestUtils.java
@@ -108,7 +108,7 @@ public class TestUtils {
     public static void waitForCondition(Callable<Boolean> condition, Callable<Void> callback, int seconds, String description) throws Exception {
         try {
             long _start = System.currentTimeMillis();
-            long millis = (long) (seconds * 1000);
+            long millis = seconds * 1000;
             while (System.currentTimeMillis() - _start <= millis) {
                 if (condition.call()) {
                     return;
@@ -129,6 +129,12 @@ public class TestUtils {
     private static final Logger LOG = Logger.getLogger(TestUtils.class.getName());
 
     public static final Callable<Void> NOOP = () -> null;
+
+    public static void assertExceptionPresentInChain(Throwable t, Class<?> clazz) {
+        if (!isExceptionPresentInChain(t, clazz)) {
+            throw new AssertionError("exception didn't contain expected " + clazz.getSimpleName(), t);
+        }
+    }
 
     public static boolean isExceptionPresentInChain(Throwable t, Class clazz) {
         if (t == null) {


### PR DESCRIPTION
On timeout failures during performAuthentication the attempt is totaly aborted but cached routes aren refreshed. In such cases remote server opened the connection but still cannot answer the client about leadership state. If the server lost leadership on a tablespace the client will still attempt forever to connect there instead checking the right tablespace leader.

Added a testcase (it fails without this pr)

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
