### PR TITLE
Handle decommission leader cases

### DIFF
--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -428,7 +428,7 @@ public class HDBConnection implements AutoCloseable {
         }
         String leaderId = client.getClientSideMetadataProvider().getTableSpaceLeader(tableSpace);
         if (leaderId == null) {
-            throw new HDBException("no such tablespace " + tableSpace + " (no leader found)");
+            throw new HDBException("no leader found on metadata for tablespace "+tableSpace);
         }
         return getRouteToServer(leaderId);
     }

--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -428,7 +428,7 @@ public class HDBConnection implements AutoCloseable {
         }
         String leaderId = client.getClientSideMetadataProvider().getTableSpaceLeader(tableSpace);
         if (leaderId == null) {
-            throw new HDBException("no leader found on metadata for tablespace "+tableSpace);
+            throw new HDBException("no leader found on metadata for tablespace " + tableSpace);
         }
         return getRouteToServer(leaderId);
     }

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -642,7 +642,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
         TableSpaceManager manager = tablesSpaces.get(tableSpace);
         if (manager == null) {
-            return FutureUtils.exception(new StatementExecutionException("No such tableSpace " + tableSpace + " here. "
+            return FutureUtils.exception(new NotLeaderException("No such tableSpace " + tableSpace + " here. "
                     + "Maybe the server is starting "));
         }
         if (errorIfNotLeader && !manager.isLeader()) {
@@ -726,7 +726,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         }
         TableSpaceManager manager = tablesSpaces.get(tableSpace);
         if (manager == null) {
-            throw new StatementExecutionException("No such tableSpace " + tableSpace + " here. "
+            throw new NotLeaderException("No such tableSpace " + tableSpace + " here (at " + nodeId + "). "
                     + "Maybe the server is starting ");
         }
         if (errorIfNotLeader && !manager.isLeader()) {

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -800,7 +800,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             String tablespace = PduCodec.PrepareStatement.readTablespace(message);
             TableSpaceManager tableSpaceManager = server.getManager().getTableSpaceManager(tablespace);
             if (tableSpaceManager == null) {
-                ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "no such tablespace " + tablespace);
+                ByteBuf error = PduCodec.ErrorResponse.writeNotLeaderError(message.messageId, "no such tablespace " + tablespace+" (at "+server.getManager().getNodeId()+")");
                 channel.sendReplyMessage(message.messageId, error);
                 return;
             } else if (!tableSpaceManager.isLeader()) {

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -800,7 +800,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             String tablespace = PduCodec.PrepareStatement.readTablespace(message);
             TableSpaceManager tableSpaceManager = server.getManager().getTableSpaceManager(tablespace);
             if (tableSpaceManager == null) {
-                ByteBuf error = PduCodec.ErrorResponse.writeNotLeaderError(message.messageId, "no such tablespace " + tablespace+" (at "+server.getManager().getNodeId()+")");
+                ByteBuf error = PduCodec.ErrorResponse.writeNotLeaderError(message.messageId, "no such tablespace " + tablespace + " (at " + server.getManager().getNodeId() + ")");
                 channel.sendReplyMessage(message.messageId, error);
                 return;
             } else if (!tableSpaceManager.isLeader()) {


### PR DESCRIPTION
Handle the absence of the local TableSpaceManager as a "not leader" error