### PR TITLE
Upgrade dependencies for security advisories

### DIFF
--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -32,7 +32,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <buildNumber>${maven.build.timestamp}</buildNumber>
     </properties>
-    <dependencies>        
+    <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>herddb-utils</artifactId>
@@ -58,20 +58,20 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>  
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>
-        </dependency>           
+        </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>         
+            <artifactId>curator-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>            
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.bookkeeper.stats</groupId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.apache.bookkeeper</groupId>
             <artifactId>bookkeeper-server</artifactId>
@@ -101,21 +101,21 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
-        <dependency>             
+        <dependency>
             <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>            
+            <artifactId>commons-logging</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>             
+        <dependency>
             <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>            
+            <artifactId>commons-cli</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minikdc</artifactId>
             <scope>test</scope>
-        </dependency>   
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -123,12 +123,16 @@
         </dependency>
         <dependency>
             <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>      
+            <artifactId>kryo</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>
-            <artifactId>calcite-core</artifactId>            
-            <exclusions>                
+            <artifactId>calcite-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.esri.geometry</groupId>
                     <artifactId>*</artifactId>
@@ -144,19 +148,19 @@
                 <exclusion>
                     <groupId>net.hydromatic</groupId>
                     <artifactId>*</artifactId>
-                </exclusion>                
+                </exclusion>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
-                </exclusion>                    
+                </exclusion>
                 <exclusion>
                     <groupId>commons-dbcp</groupId>
                     <artifactId>commons-dbcp</artifactId>
-                </exclusion>                    
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>*</artifactId>
-                </exclusion>                    
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/herddb-core/src/main/java/herddb/cluster/LedgersInfo.java
+++ b/herddb-core/src/main/java/herddb/cluster/LedgersInfo.java
@@ -20,6 +20,7 @@
 
 package herddb.cluster;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
 import java.io.IOException;
@@ -27,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Information on ledgers user by the broker

--- a/herddb-net/pom.xml
+++ b/herddb-net/pom.xml
@@ -38,11 +38,11 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>            
+            <artifactId>netty-transport-native-epoll</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>            
+            <artifactId>netty-transport-native-unix-common</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -59,23 +59,31 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-        </dependency> 
+        </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>            
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>herddb-utils</artifactId>
             <version>${project.version}</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.apache.bookkeeper</groupId>
             <artifactId>bookkeeper-server</artifactId>
         </dependency>
-    </dependencies>    
+    </dependencies>
 </project>

--- a/herddb-net/pom.xml
+++ b/herddb-net/pom.xml
@@ -65,8 +65,8 @@
             <artifactId>netty-tcnative-boringssl-static</artifactId>            
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/herddb-net/src/main/java/herddb/network/ServerHostData.java
+++ b/herddb-net/src/main/java/herddb/network/ServerHostData.java
@@ -20,13 +20,13 @@
 
 package herddb.network;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Information about a broker

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
         <libs.netty4ssl>2.0.28.Final</libs.netty4ssl>
         <libs.calcite>1.19.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
-        <libs.jackson.mapper>1.9.11</libs.jackson.mapper>
-        <libs.zookeeper>3.5.6</libs.zookeeper>
+        <libs.jackson.mapper>1.9.13</libs.jackson.mapper>
+        <libs.zookeeper>3.5.7</libs.zookeeper>
         <libs.jsqlparser>3.1</libs.jsqlparser>
         <libs.curator>2.12.0</libs.curator>
         <libs.guava>21.0</libs.guava>
@@ -105,7 +105,7 @@
         <libs.spotbugsannotations>3.1.8</libs.spotbugsannotations>
         <libs.spotbugsmaven>3.1.12.2</libs.spotbugsmaven>
         <fbs.version>1.9.0</fbs.version>
-        <checkstyle.version>8.23</checkstyle.version>
+        <checkstyle.version>8.30</checkstyle.version>
     </properties>
 
     <dependencies>
@@ -435,7 +435,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,16 @@
                 <version>${libs.jackson.mapper}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${libs.jackson.mapper}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${libs.jackson.mapper}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.jsqlparser</groupId>
                 <artifactId>jsqlparser</artifactId>
                 <version>${libs.jsqlparser}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <libs.netty4ssl>2.0.28.Final</libs.netty4ssl>
         <libs.calcite>1.19.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
-        <libs.jackson.mapper>1.9.13</libs.jackson.mapper>
+        <libs.jackson.mapper>2.10.3</libs.jackson.mapper>
         <libs.zookeeper>3.5.7</libs.zookeeper>
         <libs.jsqlparser>3.1</libs.jsqlparser>
         <libs.curator>2.12.0</libs.curator>
@@ -194,8 +194,8 @@
                 <version>${libs.calcite}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
                 <version>${libs.jackson.mapper}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
- update checkstyle
- update ZooKeeper client to 3.5.7 (no major differences from 3.5.5)
- move from old Jackson Mapper to Fasterxml Jackson Databind