### PR TITLE
HerdDB Collections Improvements: clear and better ValueSerializer

### DIFF
--- a/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
+++ b/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
@@ -73,7 +73,7 @@ public final class CollectionsManager implements AutoCloseable {
                 try (VisibleByteArrayOutputStream oo = new VisibleByteArrayOutputStream(expectedSize);
                         ObjectOutputStream ooo = new ObjectOutputStream(oo)) {
                     ooo.writeUnshared(object);
-                    return oo.toByteArray();
+                    return oo.toByteArrayNoCopy();
                 }
             }
 

--- a/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
+++ b/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
@@ -40,7 +40,6 @@ import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.VisibleByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Properties;
@@ -96,7 +95,7 @@ public final class CollectionsManager implements AutoCloseable {
     private static <K> Function<K, byte[]> defaultKeySerializer(ValueSerializer<K> serializer) {
         return (K key) -> {
             try {
-                return serializer.serialize(key);                
+                return serializer.serialize(key);
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }

--- a/herddb-collections/src/main/java/herddb/collections/TmpMap.java
+++ b/herddb-collections/src/main/java/herddb/collections/TmpMap.java
@@ -118,6 +118,12 @@ public interface TmpMap<K, V> extends AutoCloseable {
      */
     void forEachKey(Sink<K> sink) throws CollectionsException, SinkException;
 
+    /**
+     * Clear the contents. It is internally mapped to a TRUNCATE table.
+     * @throws CollectionsException
+     */
+    void clear() throws CollectionsException;
+
     @Override
     void close();
 }

--- a/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
+++ b/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
@@ -47,7 +47,6 @@ import herddb.model.commands.TruncateTableStatement;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import herddb.utils.RawString;
-import herddb.utils.VisibleByteArrayOutputStream;
 import java.util.function.Function;
 
 /**

--- a/herddb-collections/src/main/java/herddb/collections/ValueSerializer.java
+++ b/herddb-collections/src/main/java/herddb/collections/ValueSerializer.java
@@ -21,7 +21,6 @@
 package herddb.collections;
 
 import herddb.utils.Bytes;
-import java.io.OutputStream;
 
 /**
  * Generic serializer abstraction.
@@ -30,7 +29,7 @@ import java.io.OutputStream;
  */
 public interface ValueSerializer<K> {
 
-    void serialize(K object, OutputStream outputStream) throws Exception;
+    byte[] serialize(K object) throws Exception;
 
     K deserialize(Bytes bytes) throws Exception;
 

--- a/herddb-collections/src/test/java/herddb/collections/TmpMapTest.java
+++ b/herddb-collections/src/test/java/herddb/collections/TmpMapTest.java
@@ -202,8 +202,8 @@ public class TmpMapTest {
                     .<MyPojo>newMap()
                     .withValueSerializer(new ValueSerializer<MyPojo>() {
                         @Override
-                        public void serialize(MyPojo object, OutputStream outputStream) throws Exception {
-                            outputStream.write(Bytes.intToByteArray(object.wrapped));
+                        public byte[] serialize(MyPojo object) throws Exception {
+                            return Bytes.intToByteArray(object.wrapped);
                         }
 
                         @Override
@@ -414,6 +414,33 @@ public class TmpMapTest {
                     fail();
             } catch (Exception err) {
                 assertTrue(TestUtils.isExceptionPresentInChain(err, ClassCastException.class));
+            }
+        }
+    }
+
+    @Test
+    public void testClearMap() throws Exception {
+        try (CollectionsManager manager = CollectionsManager
+                .builder()
+                .maxMemory(10 * 1024 * 1024)
+                .tmpDirectory(tmpDir.newFolder().toPath())
+                .build()) {
+            manager.start();
+            try (TmpMap<Integer, String> tmpMap = manager
+                    .newMap()
+                    .withIntKeys()
+                    .build()) {
+                for (int i = 0; i < 1000; i++) {
+                    tmpMap.put(i, "foo" + i);
+                }
+                for (int i = 0; i < 1000; i++) {
+                    assertTrue(tmpMap.containsKey(i));
+                }
+                tmpMap.clear();
+                for (int i = 0; i < 1000; i++) {
+                    assertFalse(tmpMap.containsKey(i));
+                }
+                assertEquals(0, tmpMap.size());
             }
         }
     }

--- a/herddb-collections/src/test/java/herddb/collections/TmpMapTest.java
+++ b/herddb-collections/src/test/java/herddb/collections/TmpMapTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.fail;
 import herddb.utils.Bytes;
 import herddb.utils.TestUtils;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;

--- a/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
@@ -122,6 +122,17 @@ public class VisibleByteArrayOutputStream extends OutputStream {
         return Arrays.copyOf(buf, count);
     }
 
+    /**
+     * Return the internal buffer or perform a copy
+     * @return the internal buffer or a copy
+     */
+    public byte[] toByteArrayNoCopy() {
+        if (count == buf.length) {
+            return buf;
+        }
+        return Arrays.copyOf(buf, count);
+    }
+
     public int size() {
         return count;
     }

--- a/herddb-utils/src/test/java/herddb/utils/VisibleByteArrayOutputStreamTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/VisibleByteArrayOutputStreamTest.java
@@ -21,6 +21,8 @@
 package herddb.utils;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.junit.Test;
@@ -45,6 +47,25 @@ public class VisibleByteArrayOutputStreamTest {
         byte[] expected = XXHash64Utils.digest(content, 0, content.length);
         System.out.println("expected:" + Arrays.toString(expected));
         assertArrayEquals(expected, md5);
+    }
+
+    @Test
+    public void testToByteArrayNoCopy() throws Exception {
+        byte[] content = "foo".getBytes(StandardCharsets.UTF_8);
+        byte[] content2 = "fooa".getBytes(StandardCharsets.UTF_8);
+        try (VisibleByteArrayOutputStream oo = new VisibleByteArrayOutputStream(3)) {
+            oo.write(content);
+            assertArrayEquals(content, oo.toByteArray());
+            assertNotSame(content, oo.toByteArray());
+            // accessing directly the buffer
+            assertSame(oo.getBuffer(), oo.toByteArrayNoCopy());
+
+            oo.write('a');
+            assertArrayEquals(content2, oo.toByteArray());
+            assertNotSame(content, oo.toByteArray());
+            assertNotSame(oo.getBuffer(), oo.toByteArrayNoCopy());
+
+        }
     }
 
 }


### PR DESCRIPTION
- supports clear() (TRUNCATE TABLE)
- let the ValueSerializer return directly a byte[] in order to save memory and CPU cycles
