### PR TITLE
HerdDB Collections: disable XXHash64 on data/index pages #591

### DIFF
--- a/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
+++ b/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
@@ -139,7 +139,7 @@ public final class CollectionsManager implements AutoCloseable {
                 configuration.set(k.toString(), v);
             });
         }
-        
+
         boolean hashChecksEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED, ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
         boolean hashWritesEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED, ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT);
 

--- a/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
+++ b/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
@@ -139,12 +139,16 @@ public final class CollectionsManager implements AutoCloseable {
                 configuration.set(k.toString(), v);
             });
         }
+        
+        boolean hashChecksEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED, ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
+        boolean hashWritesEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED, ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT);
 
         server = new DBManager("localhost",
                 new MemoryMetadataStorageManager(),
                 new FileDataStorageManager(tmpDirectory,
                         tmpDirectory, 0, false /* fsync */,
-                        false /* o_direct */, false /* o_direct */, NullStatsLogger.INSTANCE),
+                        false /* o_direct */, false /* o_direct */,
+                        hashChecksEnabled, hashWritesEnabled, NullStatsLogger.INSTANCE),
                 new MemoryCommitLogManager(false /*serialize*/), tmpDirectory,
                 new ServerHostData("localhost", 0, "", false, Collections.emptyMap()),
                 configuration, NullStatsLogger.INSTANCE);

--- a/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
+++ b/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
@@ -140,8 +140,9 @@ public final class CollectionsManager implements AutoCloseable {
             });
         }
 
-        boolean hashChecksEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED, ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
-        boolean hashWritesEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED, ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT);
+        // In case of HerdDB Collections the usage of XXHash64 might to be overkilling.
+        boolean hashChecksEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED, false);
+        boolean hashWritesEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED, false);
 
         server = new DBManager("localhost",
                 new MemoryMetadataStorageManager(),

--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -163,12 +163,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-reflect</artifactId>
-            <version>2.0.7</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -163,6 +163,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -120,7 +120,7 @@ public class FileDataStorageManager extends DataStorageManager {
     public static final int O_DIRECT_BLOCK_BATCH =
             SystemProperties.getIntSystemProperty("herddb.file.odirectblockbatch", 16);
 
-    // With XXHash64 hashing disabled the stored is empty.
+    // With XXHash64 hashing disabled the stored value is empty.
     private static final long NO_HASH_PRESENT = 0L;
 
     public FileDataStorageManager(Path baseDirectory) {

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -98,6 +98,8 @@ public class FileDataStorageManager extends DataStorageManager {
     private final boolean requirefsync;
     private final boolean pageodirect;
     private final boolean indexodirect;
+    private final boolean hashChecksEnabled;
+    private final boolean hashWritesEnabled;
     private final StatsLogger logger;
     private final OpStatsLogger dataPageReads;
     private final OpStatsLogger dataPageWrites;
@@ -118,11 +120,7 @@ public class FileDataStorageManager extends DataStorageManager {
     public static final int O_DIRECT_BLOCK_BATCH =
             SystemProperties.getIntSystemProperty("herddb.file.odirectblockbatch", 16);
 
-    // In case of HerdDB Collections the usage of XXHash64 might to be overkilling.
-    public static final boolean HASH_WRITES_ENABLED =
-            SystemProperties.getBooleanSystemProperty("herddb.filedatastoragemanager.writehash", true);
-    public static final boolean HASH_CHECKS_ENABLED =
-            SystemProperties.getBooleanSystemProperty("herddb.filedatastoragemanager.checkhash", true);
+    // With XXHash64 hashing disabled the stored is empty.
     private static final long NO_HASH_PRESENT = 0L;
 
     public FileDataStorageManager(Path baseDirectory) {
@@ -131,12 +129,15 @@ public class FileDataStorageManager extends DataStorageManager {
                 ServerConfiguration.PROPERTY_REQUIRE_FSYNC_DEFAULT,
                 ServerConfiguration.PROPERTY_PAGE_USE_ODIRECT_DEFAULT,
                 ServerConfiguration.PROPERTY_INDEX_USE_ODIRECT_DEFAULT,
+                ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT,
+                ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT,
                 new NullStatsLogger());
     }
 
     public FileDataStorageManager(
             Path baseDirectory, Path tmpDirectory, int swapThreshold,
-            boolean requirefsync, boolean pageodirect, boolean indexodirect, StatsLogger logger
+            boolean requirefsync, boolean pageodirect, boolean indexodirect,
+            boolean hashChecksEnabled, boolean hashWritesEnabled, StatsLogger logger
     ) {
         this.baseDirectory = baseDirectory;
         this.tmpDirectory = tmpDirectory;
@@ -145,6 +146,8 @@ public class FileDataStorageManager extends DataStorageManager {
         this.requirefsync = requirefsync;
         this.pageodirect = pageodirect && OpenFileUtils.isO_DIRECT_Supported();
         this.indexodirect = indexodirect && OpenFileUtils.isO_DIRECT_Supported();
+        this.hashChecksEnabled = hashChecksEnabled;
+        this.hashWritesEnabled = hashWritesEnabled;
         StatsLogger scope = logger.scope("filedatastore");
         this.dataPageReads = scope.getOpStatsLogger("data_pagereads");
         this.dataPageWrites = scope.getOpStatsLogger("data_pagewrites");
@@ -313,7 +316,7 @@ public class FileDataStorageManager extends DataStorageManager {
         return result;
     }
 
-    private static List<Record> rawReadDataPage(Path pageFile, InputStream stream) throws IOException, DataStorageManagerException {
+    private List<Record> rawReadDataPage(Path pageFile, InputStream stream) throws IOException, DataStorageManagerException {
         int size = (int) Files.size(pageFile);
         byte[] dataPage = new byte[size];
         int read = stream.read(dataPage);
@@ -335,7 +338,7 @@ public class FileDataStorageManager extends DataStorageManager {
             }
             int pos = dataIn.getPosition();
             long hashFromFile = dataIn.readLong();
-            if (HASH_CHECKS_ENABLED && hashFromFile != NO_HASH_PRESENT) {
+            if (hashChecksEnabled && hashFromFile != NO_HASH_PRESENT) {
                 // after the hash we will have zeroes or garbage
                 // the hash is not at the end of file, but after data
                 long hashFromDigest = XXHash64Utils.hash(dataPage, 0, pos);
@@ -367,16 +370,16 @@ public class FileDataStorageManager extends DataStorageManager {
                 Bytes value = dataIn.readBytes();
                 result.add(new Record(key, value));
             }
-            hashFromDigest = HASH_CHECKS_ENABLED ? hash.hash() : 0;
+            hashFromDigest = hash.hash();
             hashFromFile = dataIn.readLong();
         }
-        if (HASH_CHECKS_ENABLED && hashFromFile != NO_HASH_PRESENT && hashFromDigest != hashFromFile) {
+        if (hashFromFile != NO_HASH_PRESENT && hashFromDigest != hashFromFile) {
             throw new DataStorageManagerException("Corrupted datafile " + pageFile + ". Bad hash " + hashFromFile + " <> " + hashFromDigest);
         }
         return result;
     }
 
-    private static <X> X readIndexPage(DataReader<X> reader, Path pageFile, InputStream stream) throws IOException, DataStorageManagerException {
+    private <X> X readIndexPage(DataReader<X> reader, Path pageFile, InputStream stream) throws IOException, DataStorageManagerException {
         int size = (int) Files.size(pageFile);
         byte[] dataPage = new byte[size];
         int read = stream.read(dataPage);
@@ -397,7 +400,7 @@ public class FileDataStorageManager extends DataStorageManager {
             X result = reader.read(dataIn);
             int pos = dataIn.getPosition();
             long hashFromFile = dataIn.readLong();
-            if (HASH_CHECKS_ENABLED && hashFromFile != NO_HASH_PRESENT) {
+            if (hashChecksEnabled && hashFromFile != NO_HASH_PRESENT) {
                 // after the hash we will have zeroes or garbage
                 // the hash is not at the end of file, but after data
                 long hashFromDigest = XXHash64Utils.hash(dataPage, 0, pos);
@@ -858,7 +861,7 @@ public class FileDataStorageManager extends DataStorageManager {
      * @return
      * @throws IOException
      */
-    private static long writePage(Collection<Record> newPage, ManagedFile file, OutputStream stream) throws IOException {
+    private long writePage(Collection<Record> newPage, ManagedFile file, OutputStream stream) throws IOException {
 
         try (RecyclableByteArrayOutputStream oo = getWriteBuffer();
              ExtendedDataOutputStream dataOutput = new ExtendedDataOutputStream(oo)) {
@@ -871,7 +874,7 @@ public class FileDataStorageManager extends DataStorageManager {
                 dataOutput.writeArray(record.value);
             }
             dataOutput.flush();
-            long hash = HASH_WRITES_ENABLED ? XXHash64Utils.hash(oo.getBuffer(), 0, oo.size()) : 0;
+            long hash = hashWritesEnabled ? XXHash64Utils.hash(oo.getBuffer(), 0, oo.size()) : NO_HASH_PRESENT;
             dataOutput.writeLong(hash);
             dataOutput.flush();
             stream.write(oo.getBuffer(), 0, oo.size());
@@ -920,14 +923,14 @@ public class FileDataStorageManager extends DataStorageManager {
         dataPageWrites.registerSuccessfulEvent(delta, TimeUnit.MILLISECONDS);
     }
 
-    private static long writeIndexPage(DataWriter writer, ManagedFile file, OutputStream stream) throws IOException {
+    private long writeIndexPage(DataWriter writer, ManagedFile file, OutputStream stream) throws IOException {
         try (RecyclableByteArrayOutputStream oo = getWriteBuffer();
              ExtendedDataOutputStream dataOutput = new ExtendedDataOutputStream(oo)) {
             dataOutput.writeVLong(1); // version
             dataOutput.writeVLong(0); // flags for future implementations
             writer.write(dataOutput);
             dataOutput.flush();
-            long hash = HASH_WRITES_ENABLED ? XXHash64Utils.hash(oo.getBuffer(), 0, oo.size()) : 0;
+            long hash = hashWritesEnabled ? XXHash64Utils.hash(oo.getBuffer(), 0, oo.size()) : NO_HASH_PRESENT;
             dataOutput.writeLong(hash);
             dataOutput.flush();
             stream.write(oo.getBuffer(), 0, oo.size());

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -311,7 +311,9 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 boolean requirefsync = configuration.getBoolean(ServerConfiguration.PROPERTY_REQUIRE_FSYNC, ServerConfiguration.PROPERTY_REQUIRE_FSYNC_DEFAULT);
                 boolean pageodirect = configuration.getBoolean(ServerConfiguration.PROPERTY_PAGE_USE_ODIRECT, ServerConfiguration.PROPERTY_PAGE_USE_ODIRECT_DEFAULT);
                 boolean indexodirect = configuration.getBoolean(ServerConfiguration.PROPERTY_INDEX_USE_ODIRECT, ServerConfiguration.PROPERTY_INDEX_USE_ODIRECT_DEFAULT);
-                return new FileDataStorageManager(dataDirectory, tmpDirectory, diskswapThreshold, requirefsync, pageodirect, indexodirect, statsLogger);
+                boolean hashChecksEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED, ServerConfiguration.PROPERTY_HASH_CHECKS_ENABLED_DEFAULT);
+                boolean hashWritesEnabled = configuration.getBoolean(ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED, ServerConfiguration.PROPERTY_HASH_WRITES_ENABLED_DEFAULT);
+                return new FileDataStorageManager(dataDirectory, tmpDirectory, diskswapThreshold, requirefsync, pageodirect, indexodirect, hashChecksEnabled, hashWritesEnabled, statsLogger);
             default:
                 throw new RuntimeException();
         }

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -93,6 +93,14 @@ public final class ServerConfiguration {
     public static final String PROPERTY_INDEX_USE_ODIRECT = "index.use_o_direct";
     public static final boolean PROPERTY_INDEX_USE_ODIRECT_DEFAULT = USE_O_DIRECT_DEFAULT;
 
+    /**
+     * In some cases the usage of XXHash64 might to be overkilling
+     */
+    public static final String PROPERTY_HASH_CHECKS_ENABLED = "server.filedatastorage.checkhash";
+    public static final boolean PROPERTY_HASH_CHECKS_ENABLED_DEFAULT = true;
+    public static final String PROPERTY_HASH_WRITES_ENABLED = "server.filedatastorage.writehash";
+    public static final boolean PROPERTY_HASH_WRITES_ENABLED_DEFAULT = true;
+
     public static final String PROPERTY_TMPDIR = "server.tmp.dir";
     public static final String PROPERTY_TMPDIR_DEFAULT = "tmp";
     public static final String PROPERTY_METADATADIR = "server.metadata.dir";

--- a/herddb-core/src/test/java/herddb/core/RestartTest.java
+++ b/herddb-core/src/test/java/herddb/core/RestartTest.java
@@ -713,4 +713,93 @@ public class RestartTest {
 
     }
 
+    @Test
+    public void recoverTableAndIndexWithoutHash() throws Exception {
+
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmoDir = folder.newFolder("tmpDir").toPath();
+
+        String nodeId = "localhost";
+        Table table;
+        Index index;
+
+        FileDataStorageManager.HASH_CHECKS_ENABLED = false;
+        FileDataStorageManager.HASH_WRITES_ENABLED = false;
+
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            assertTrue(manager.waitForTablespace("tblspace1", 10000));
+
+            table = Table
+                    .builder()
+                    .tablespace("tblspace1")
+                    .name("t1")
+                    .column("id", ColumnTypes.INTEGER)
+                    .column("name", ColumnTypes.STRING)
+                    .primaryKey("id")
+                    .build();
+
+            index = Index.builder().onTable(table).column("name", ColumnTypes.STRING).type(Index.TYPE_BRIN).build();
+
+            manager.executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            manager.executeStatement(new InsertStatement("tblspace1", table.name, RecordSerializer.makeRecord(table, "id", 1, "name", "uno")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+
+            GetResult result = manager.get(new GetStatement("tblspace1", table.name, Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            assertTrue(result.found());
+
+            /*
+             * Access through index
+             */
+            TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1", Collections.emptyList(), true, true, false, -1);
+            ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+            try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                assertEquals(1, scan1.consume().size());
+            }
+            manager.checkpoint();
+        }
+
+        // Enabling hash-chacking: previous stored hashes (value 0) has not to fail the check.
+        FileDataStorageManager.HASH_CHECKS_ENABLED = true;
+        FileDataStorageManager.HASH_WRITES_ENABLED = true;
+
+        try (DBManager manager = new DBManager("localhost",
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null)) {
+            manager.start();
+
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
+
+            /*
+             * Access through key to page
+             */
+            GetResult result = manager.get(new GetStatement("tblspace1", table.name, Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            assertTrue(result.found());
+
+            /*
+             * Access through index
+             */
+            TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1", Collections.emptyList(), true, true, false, -1);
+            ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+            try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                assertEquals(1, scan1.consume().size());
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Added two new ServerConfiguration properties for FileDataStorageManager:

- _**server.filedatastorage.writehash**_ (default **true**): to not/perform hash during data/index page writing

- _**server.filedatastorage.checkhash**_ (default **true**): to not/perform hash-checking during data/index page reading

In HerdDB Collections Framework hash checking/writing is disabled by default.

Added a test case