### PR TITLE
Diskless cluster mode - first implementation

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -350,7 +350,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
         return getTableSpaceZNode(tablespace) + "/" + (indexname + ".index");
     }
 
-    private static String getTableCheckPointsFile(String tableDirectory, LogSequenceNumber sequenceNumber) {
+    private static String getCheckPointsFile(String tableDirectory, LogSequenceNumber sequenceNumber) {
         return tableDirectory + "/" + sequenceNumber.ledgerId + "." + sequenceNumber.offset + EXTENSION_TABLEORINDExCHECKPOINTINFOFILE;
     }
 
@@ -561,7 +561,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             throws DataStorageManagerException {
 
         String dir = getIndexDirectory(tableSpace, indexName);
-        String checkpointFile = getTableCheckPointsFile(dir, sequenceNumber);
+        String checkpointFile = getCheckPointsFile(dir, sequenceNumber);
 
         checkExistsZNode(checkpointFile, "no such index checkpoint: " + checkpointFile);
 
@@ -668,7 +668,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
         try {
 
             String dir = getTableDirectory(tableSpace, tableUuid);
-            String checkpointFile = getTableCheckPointsFile(dir, sequenceNumber);
+            String checkpointFile = getCheckPointsFile(dir, sequenceNumber);
 
             checkExistsZNode(checkpointFile, "no such table checkpoint: " + checkpointFile);
 
@@ -782,7 +782,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     public List<PostCheckpointAction> tableCheckpoint(String tableSpace, String tableName, TableStatus tableStatus, boolean pin) throws DataStorageManagerException {
         LogSequenceNumber logPosition = tableStatus.sequenceNumber;
         String dir = getTableDirectory(tableSpace, tableName);
-        String checkpointFile = getTableCheckPointsFile(dir, logPosition);
+        String checkpointFile = getCheckPointsFile(dir, logPosition);
         Stat stat = new Stat();
         try {
             byte[] exists = readZNode(checkpointFile, stat);
@@ -859,7 +859,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     public List<PostCheckpointAction> indexCheckpoint(String tableSpace, String indexName, IndexStatus indexStatus, boolean pin) throws DataStorageManagerException {
         String dir = getIndexDirectory(tableSpace, indexName);
         LogSequenceNumber logPosition = indexStatus.sequenceNumber;
-        String checkpointFile = getTableCheckPointsFile(dir, logPosition);
+        String checkpointFile = getCheckPointsFile(dir, logPosition);
 
         Stat stat = new Stat();
         byte[] exists = readZNode(checkpointFile, stat);
@@ -1067,7 +1067,6 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             long pageId, DataWriter writer
     ) throws DataStorageManagerException {
         long _start = System.currentTimeMillis();
-        String tableDir = getIndexDirectory(tableSpace, indexName);
 
         long size;
         long ledgerId;
@@ -1182,17 +1181,17 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             long version = din.readVLong(); // version
             long flags = din.readVLong(); // flags for future implementations
             if (version != 1 || flags != 0) {
-                throw new DataStorageManagerException("corrupted table list file " + file);
+                throw new DataStorageManagerException("corrupted table list file");
             }
             String readname = din.readUTF();
             if (!readname.equals(tableSpace)) {
-                throw new DataStorageManagerException("file " + file + " is not for spablespace " + tableSpace);
+                throw new DataStorageManagerException("file is not for spablespace " + tableSpace+" but for "+readname);
             }
             long ledgerId = din.readZLong();
             long offset = din.readZLong();
             if (sequenceNumber != null) {
                 if (ledgerId != sequenceNumber.ledgerId || offset != sequenceNumber.offset) {
-                    throw new DataStorageManagerException("file " + file + " is not for sequence number " + sequenceNumber);
+                    throw new DataStorageManagerException("file is not for sequence number " + sequenceNumber);
                 }
             }
             int numTables = din.readInt();
@@ -1437,7 +1436,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             }
             String readname = din.readUTF();
             if (!readname.equals(tableSpace)) {
-                throw new DataStorageManagerException("zonde " + checkPointFile + " is not for spablespace " + tableSpace);
+                throw new DataStorageManagerException("zonde "+checkPointFile+" is not for spablespace " + tableSpace+" but for "+readname);
             }
             long ledgerId = din.readZLong();
             long offset = din.readZLong();

--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -146,6 +146,11 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             this.pageIdToLedgerId = pageIdToLedgerId;
         }
 
+        @Override
+        public String toString() {
+            return "PagesMapping{" + "pageIdToLedgerId=" + pageIdToLedgerId + '}';
+        }
+
 
     }
 
@@ -178,6 +183,11 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             this.indexMappings = indexMappings;
         }
 
+        @Override
+        public String toString() {
+            return "TableSpacePagesMapping{" + "tableMappings=" + tableMappings + ", indexMappings=" + indexMappings + '}';
+        }
+        
 
     }
 
@@ -188,9 +198,9 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     private void persistTableSpaceMapping(String tableSpace) {
         try {
             TableSpacePagesMapping mapping = getTableSpacePagesMapping(tableSpace);
-            LOGGER.log(Level.INFO, "persisteTableSpaceMapping {0}", tableSpace);
             byte[] serialized = MAPPER.writeValueAsBytes(mapping);
             String znode = getTableSpaceMappingZNode(tableSpace);
+            LOGGER.log(Level.INFO, "persistTableSpaceMapping "+tableSpace+", "+mapping+" to "+znode+" "+new String(serialized, StandardCharsets.UTF_8));
             writeZNode(znode, serialized, null);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
@@ -199,6 +209,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
 
     private void loadTableSpacesAtBoot() throws DataStorageManagerException {
         List<String> list = zkGetChildren(baseZkNode, false);
+        LOGGER.log(Level.INFO, "tableSpaces to load: {0}", list);
         for (String tablespace : list) {
             loadTableSpaceMapping(tablespace);
         }
@@ -213,6 +224,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
         } else {
             try {
                 TableSpacePagesMapping read = MAPPER.readValue(serialized, TableSpacePagesMapping.class);
+                LOGGER.log(Level.INFO, "loadTableSpaceMapping "+tableSpace+", "+read+" from "+znode+" "+new String(serialized, StandardCharsets.UTF_8));
                 tableSpaceMappings.put(tableSpace, read);
             } catch (IOException ex) {
                 throw new DataStorageManagerException(ex);

--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -1,0 +1,1623 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.cluster;
+
+import static herddb.file.FileDataStorageManager.O_DIRECT_BLOCK_BATCH;
+import herddb.file.*;
+import herddb.core.HerdDBInternalException;
+import herddb.core.MemoryManager;
+import herddb.core.PostCheckpointAction;
+import herddb.core.RecordSetFactory;
+import herddb.index.KeyToPageIndex;
+import herddb.index.blink.BLinkKeyToPageIndex;
+import herddb.log.LogSequenceNumber;
+import herddb.model.Index;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.model.Transaction;
+import herddb.server.ServerConfiguration;
+import herddb.storage.DataPageDoesNotExistException;
+import herddb.storage.DataStorageManager;
+import herddb.storage.DataStorageManagerException;
+import herddb.storage.FullTableScanConsumer;
+import herddb.storage.IndexStatus;
+import herddb.storage.TableStatus;
+import herddb.utils.ByteArrayCursor;
+import herddb.utils.Bytes;
+import herddb.utils.CleanDirectoryFileVisitor;
+import herddb.utils.DeleteFileVisitor;
+import herddb.utils.ExtendedDataInputStream;
+import herddb.utils.ExtendedDataOutputStream;
+import herddb.utils.FileUtils;
+import herddb.utils.ManagedFile;
+import herddb.utils.ODirectFileOutputStream;
+import herddb.utils.SimpleBufferedOutputStream;
+import herddb.utils.SimpleByteArrayInputStream;
+import herddb.utils.SystemInstrumentation;
+import herddb.utils.SystemProperties;
+import herddb.utils.VisibleByteArrayOutputStream;
+import herddb.utils.XXHash64Utils;
+import io.netty.util.Recycler;
+import java.io.BufferedInputStream;
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZKUtil;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.Stat;
+
+/**
+ * Data Storage on BookKeeper.
+ *
+ * Beware that this kind of storage is useful when you have most of the DB in memory.
+ * Random access to BK is generally slower than when using local disk, and we also have to deal
+ * with lots of metadata to be stored on Zookeeper.
+ *
+ * @author enrico.olivelli
+ */
+public class BookKeeperDataStorageManager extends DataStorageManager {
+
+    private static final Logger LOGGER = Logger.getLogger(BookKeeperDataStorageManager.class.getName());    
+    private final Path tmpDirectory;
+    private final int swapThreshold;
+    private final StatsLogger logger;
+    private final OpStatsLogger dataPageReads;
+    private final OpStatsLogger dataPageWrites;
+    private final OpStatsLogger indexPageReads;
+    private final OpStatsLogger indexPageWrites;
+    private final ZookeeperMetadataStorageManager zk;
+    private final BookkeeperCommitLogManager bk;
+    
+    private final ConcurrentHashMap<String, TableSpacePagesMapping> tableSpaceMappings = new ConcurrentHashMap<>();
+    
+    private final String baseZkNode;
+
+    public static final String FILEEXTENSION_PAGE = ".page";
+    
+    private static final class TableSpacePagesMapping {
+        ConcurrentHashMap<Long, Long> pageIdToLedgerId = new ConcurrentHashMap<>();
+        ConcurrentHashMap<Long, Long> indexpageIdToLedgerId = new ConcurrentHashMap<>();
+
+        private Long getLedgerIdForDatapage(Long pageId) {
+            return pageIdToLedgerId.get(pageId);
+        }
+        private Long getLedgerIdForindexpage(Long pageId) {
+            return indexpageIdToLedgerId.get(pageId);
+        }
+    }
+    
+    private TableSpacePagesMapping getTableSpacePagesMapping(String tableSpace) {
+        return tableSpaceMappings.computeIfAbsent(tableSpace, s -> new TableSpacePagesMapping());
+    }
+    
+    private String getTableSpaceZNode(String tableSpaceUUID) {
+        return baseZkNode + "/" + tableSpaceUUID;
+    }
+
+    /**
+     * Standard buffer size for data copies
+     */
+    public static final int COPY_BUFFERS_SIZE =
+            SystemProperties.getIntSystemProperty("herddb.file.copybuffersize", 64 * 1024);
+
+   
+    public BookKeeperDataStorageManager(Path baseDirectory, ZookeeperMetadataStorageManager zk, BookkeeperCommitLogManager bk) {
+        this(baseDirectory.resolve("tmp"),
+                ServerConfiguration.PROPERTY_DISK_SWAP_MAX_RECORDS_DEFAULT,
+                zk,
+                bk,
+                new NullStatsLogger());
+    }
+
+    public BookKeeperDataStorageManager(
+            Path tmpDirectory, int swapThreshold, ZookeeperMetadataStorageManager zk, BookkeeperCommitLogManager bk, StatsLogger logger
+    ) {
+        this.tmpDirectory = tmpDirectory;
+        this.swapThreshold = swapThreshold;
+        this.logger = logger;
+        StatsLogger scope = logger.scope("bkdatastore");
+        this.dataPageReads = scope.getOpStatsLogger("data_pagereads");
+        this.dataPageWrites = scope.getOpStatsLogger("data_pagewrites");
+        this.indexPageReads = scope.getOpStatsLogger("index_pagereads");
+        this.indexPageWrites = scope.getOpStatsLogger("index_pagewrites");
+        this.zk = zk;
+        this.bk = bk;
+        this.baseZkNode = zk.getBasePath()+"/data";
+    }
+
+    @Override
+    public void start() throws DataStorageManagerException {
+        try {
+            LOGGER.log(Level.INFO, "ensuring directory {0}", tmpDirectory.toAbsolutePath().toString());
+            Files.createDirectories(tmpDirectory);
+            LOGGER.log(Level.INFO, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+            FileUtils.cleanDirectory(tmpDirectory);
+            Files.createDirectories(tmpDirectory);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void close() throws DataStorageManagerException {
+        LOGGER.log(Level.INFO, "cleaning tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+        try {
+            FileUtils.cleanDirectory(tmpDirectory);
+        } catch (IOException err) {
+            LOGGER.log(Level.SEVERE, "Cannot clean tmp directory", err);
+        }
+    }
+
+    @Override
+    public void eraseTablespaceData(String tableSpace) throws DataStorageManagerException {
+        SystemInstrumentation.instrumentationPoint("eraseTablespaceData", tableSpace);
+        String tableSpaceZNode = getTableSpaceZNode(tableSpace);
+        
+        LOGGER.log(Level.INFO, "erasing tablespace " + tableSpace + " znode {0}", tableSpaceZNode);
+        try {
+            ZKUtil.deleteRecursive(zk.ensureZooKeeper(), tableSpaceZNode);        
+        } catch (KeeperException | IOException err) {
+            LOGGER.log(Level.SEVERE, "Cannot clean znode for tablespace " + tableSpace, err);
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(Level.SEVERE, "Cannot clean znode for tablespace " + tableSpace, err);
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    public static final String EXTENSION_TABLEORINDExCHECKPOINTINFOFILE = ".checkpoint";
+
+    private static boolean isTablespaceCheckPointInfoFile(String name) {
+        return (name.startsWith("checkpoint.") && name.endsWith(EXTENSION_TABLEORINDExCHECKPOINTINFOFILE))
+                || name.equals(EXTENSION_TABLEORINDExCHECKPOINTINFOFILE); // legacy 1.0 file
+    }
+
+    private String getTablespaceTablesMetadataFile(String tablespace, LogSequenceNumber sequenceNumber) {
+        return getTableSpaceZNode(tablespace) + "/" + ("tables." + sequenceNumber.ledgerId + "." + sequenceNumber.offset + ".tablesmetadata");
+    }
+
+    private static boolean isTablespaceTablesMetadataFile(String filename) {
+        filename = getFilename(filename);
+        return filename != null && filename.startsWith("tables.")
+                && filename.endsWith(".tablesmetadata");
+    }
+
+    private static boolean isTablespaceIndexesMetadataFile(String filename) {        
+        filename = getFilename(filename);
+        return filename != null && filename.startsWith("indexes.")
+                && filename.endsWith(".tablesmetadata");
+    }
+
+    private String getTablespaceIndexesMetadataFile(String tablespace, LogSequenceNumber sequenceNumber) {
+        return getTableSpaceZNode(tablespace) + "/" + ("indexes." + sequenceNumber.ledgerId + "." + sequenceNumber.offset + ".tablesmetadata");
+    }
+
+    private String getTablespaceTransactionsFile(String tablespace, LogSequenceNumber sequenceNumber) {
+        return getTableSpaceZNode(tablespace) + "/" + ("transactions." + sequenceNumber.ledgerId + "." + sequenceNumber.offset + ".tx");
+    }
+
+    private static boolean isTransactionsFile(String filename) {
+        filename = getFilename(filename);
+        return filename != null && filename.startsWith("transactions.")
+                && filename.endsWith(".tx");
+    }
+
+    private String getTableDirectory(String tablespace, String tablename) {
+        return getTableSpaceZNode(tablespace) + "/" + (tablename + ".table");
+    }
+
+    private String getIndexDirectory(String tablespace, String indexname) {
+        return getTableSpaceZNode(tablespace) + "/" + (indexname + ".index");
+    }
+
+    private static String getPageFile(String tableDirectory, Long pageId) {
+        return tableDirectory + "/" + (pageId + FILEEXTENSION_PAGE);
+    }
+
+    private static String getTableCheckPointsFile(String tableDirectory, LogSequenceNumber sequenceNumber) {
+        return tableDirectory + "/" + sequenceNumber.ledgerId + "." + sequenceNumber.offset + EXTENSION_TABLEORINDExCHECKPOINTINFOFILE;
+    }
+
+    private static boolean isTableOrIndexCheckpointsFile(String filename) {
+        filename = getFilename(filename);
+        return filename != null && filename.endsWith(EXTENSION_TABLEORINDExCHECKPOINTINFOFILE);
+    }
+
+    @Override
+    public void initIndex(String tableSpace, String uuid) throws DataStorageManagerException {
+        String indexDir = getIndexDirectory(tableSpace, uuid);
+        LOGGER.log(Level.FINE, "initIndex {0} {1} at {2}", new Object[]{tableSpace, uuid, indexDir});        
+        
+        try {
+            zk.ensureZooKeeper().create(indexDir, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        } catch (IOException | KeeperException err) {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void initTable(String tableSpace, String uuid) throws DataStorageManagerException {
+        String tableDir = getTableDirectory(tableSpace, uuid);
+        LOGGER.log(Level.FINE, "initTable {0} {1} at {2}", new Object[]{tableSpace, uuid, tableDir});
+        try {
+            zk.ensureZooKeeper().create(tableDir, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        } catch (IOException | KeeperException err) {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+
+    @Override
+    public List<Record> readPage(String tableSpace, String tableName, Long pageId) throws DataStorageManagerException {
+        long _start = System.currentTimeMillis();        
+        TableSpacePagesMapping tableSpacePagesMapping = getTableSpacePagesMapping(tableSpace);
+        Long ledgerId = tableSpacePagesMapping.getLedgerIdForDatapage(pageId);
+        if (ledgerId == null) {
+            throw new DataPageDoesNotExistException("No such page: " + tableSpace + "_" + tableName + "." + pageId);
+        }
+        byte[] data;
+        try (ReadHandle read =
+                FutureUtils.result(bk.getBookKeeper()
+                        .newOpenLedgerOp()
+                        .withLedgerId(ledgerId)
+                        .withPassword(new byte[0])
+                        .execute(), BKException.HANDLER);) {
+            try (LedgerEntries entries = read.readUnconfirmed(0, 0);) {
+                data = entries.getEntry(0).getEntryBytes();
+            }
+            List<Record> result = rawReadDataPage(data);
+            long _stop = System.currentTimeMillis();
+            long delta = _stop - _start;
+            LOGGER.log(Level.FINE, "readPage {0}.{1} {2} ms", new Object[]{tableSpace, tableName, delta + ""});
+            dataPageReads.registerSuccessfulEvent(delta, TimeUnit.MILLISECONDS);
+            return result;
+        } catch (BKException.BKNoSuchLedgerExistsException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (org.apache.bookkeeper.client.api.BKException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (IOException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err)  {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+        
+    }
+
+    private static List<Record> rawReadDataPage(byte[] dataPage) throws IOException, DataStorageManagerException {
+        try (ByteArrayCursor dataIn = ByteArrayCursor.wrap(dataPage)) {
+            long version = dataIn.readVLong(); // version
+            long flags = dataIn.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted data");
+            }
+            int numRecords = dataIn.readInt();
+            List<Record> result = new ArrayList<>(numRecords);
+            for (int i = 0; i < numRecords; i++) {
+                Bytes key = dataIn.readBytesNoCopy();
+                Bytes value = dataIn.readBytesNoCopy();
+                result.add(new Record(key, value));
+            }
+            int pos = dataIn.getPosition();
+            long hashFromFile = dataIn.readLong();
+            // after the hash we will have zeroes or garbage
+            // the hash is not at the end of file, but after data
+            long hashFromDigest = XXHash64Utils.hash(dataPage, 0, pos);
+            if (hashFromDigest != hashFromFile) {
+                throw new DataStorageManagerException("Corrupted datafile. Bad hash " + hashFromFile + " <> " + hashFromDigest);
+            }
+            return result;
+        }
+    }
+
+    private static <X> X readIndexPage(byte[] dataPage, DataReader<X> reader) throws IOException, DataStorageManagerException {
+        try (ByteArrayCursor dataIn = ByteArrayCursor.wrap(dataPage)) {
+            long version = dataIn.readVLong(); // version
+            long flags = dataIn.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted data file");
+            }
+            X result = reader.read(dataIn);
+            int pos = dataIn.getPosition();
+            long hashFromFile = dataIn.readLong();
+            // after the hash we will have zeroes or garbage
+            // the hash is not at the end of file, but after data
+            long hashFromDigest = XXHash64Utils.hash(dataPage, 0, pos);
+            if (hashFromDigest != hashFromFile) {
+                throw new DataStorageManagerException("Corrupted datafile . Bad hash " + hashFromFile + " <> " + hashFromDigest);
+            }
+            return result;
+        }
+    }
+
+    @Override
+    public <X> X readIndexPage(String tableSpace, String indexName, Long pageId, DataReader<X> reader) throws DataStorageManagerException {
+        String tableDir = getIndexDirectory(tableSpace, indexName);
+        String pageFile = getPageFile(tableDir, pageId);
+        long _start = System.currentTimeMillis();
+        
+        TableSpacePagesMapping tableSpacePagesMapping = getTableSpacePagesMapping(tableSpace);
+        Long ledgerId = tableSpacePagesMapping.getLedgerIdForindexpage(pageId);
+        if (ledgerId == null) {
+            throw new DataPageDoesNotExistException("No such page: " + tableSpace + "_" + tableName + "." + pageId);
+        }
+        byte[] data;
+        try (ReadHandle read =
+                FutureUtils.result(bk.getBookKeeper()
+                        .newOpenLedgerOp()
+                        .withLedgerId(ledgerId)
+                        .withPassword(new byte[0])
+                        .execute(), BKException.HANDLER);) {
+            try (LedgerEntries entries = read.readUnconfirmed(0, 0);) {
+                data = entries.getEntry(0).getEntryBytes();
+            }
+            X result = readIndexPage(data, reader);
+            long _stop = System.currentTimeMillis();
+            long delta = _stop - _start;
+           
+            LOGGER.log(Level.FINE, "readIndexPage {0}.{1} {2} ms", new Object[]{tableSpace, indexName, delta + ""});
+            indexPageReads.registerSuccessfulEvent(delta, TimeUnit.MILLISECONDS);
+            return result;
+        } catch (BKException.BKNoSuchLedgerExistsException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (BKException.BKNoSuchLedgerExistsOnMetadataServerException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (org.apache.bookkeeper.client.api.BKException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (IOException err)  {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err)  {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void fullTableScan(String tableSpace, String tableName, FullTableScanConsumer consumer) throws DataStorageManagerException {
+        try {
+            TableStatus status = getLatestTableStatus(tableSpace, tableName);
+            fullTableScan(tableSpace, tableName, status, consumer);
+        } catch (HerdDBInternalException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void fullTableScan(String tableSpace, String tableUuid, LogSequenceNumber sequenceNumber, FullTableScanConsumer consumer) throws DataStorageManagerException {
+        try {
+            TableStatus status = getTableStatus(tableSpace, tableUuid, sequenceNumber);
+            fullTableScan(tableSpace, tableUuid, status, consumer);
+        } catch (HerdDBInternalException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    private void fullTableScan(String tableSpace, String tableUuid, TableStatus status, FullTableScanConsumer consumer) {
+        LOGGER.log(Level.INFO, "fullTableScan table {0}.{1}, status: {2}", new Object[]{tableSpace, tableUuid, status});
+        consumer.acceptTableStatus(status);
+        List<Long> activePages = new ArrayList<>(status.activePages.keySet());
+        activePages.sort(null);
+        for (long idpage : activePages) {
+            List<Record> records = readPage(tableSpace, tableUuid, idpage);
+            LOGGER.log(Level.FINE, "fullTableScan table {0}.{1}, page {2}, contains {3} records", new Object[]{tableSpace, tableUuid, idpage, records.size()});
+            consumer.acceptPage(idpage, records);
+        }
+        consumer.endTable();
+    }
+
+    @Override
+    public int getActualNumberOfPages(String tableSpace, String tableName) throws DataStorageManagerException {
+        TableStatus latestStatus = getLatestTableStatus(tableSpace, tableName);
+        return latestStatus.activePages.size();
+    }
+
+    @Override
+    public IndexStatus getIndexStatus(String tableSpace, String indexName, LogSequenceNumber sequenceNumber)
+            throws DataStorageManagerException {
+
+        String dir = getIndexDirectory(tableSpace, indexName);
+        String checkpointFile = getTableCheckPointsFile(dir, sequenceNumber);
+
+        checkExistsZNode(checkpointFile, "no such index checkpoint: " + checkpointFile);
+
+        return readIndexStatusFromFile(checkpointFile);
+    }
+
+    private void checkExistsZNode(String checkpointFile, String message) throws DataStorageManagerException {
+        try {
+            if (zk.ensureZooKeeper().exists(checkpointFile, false) == null) {
+                throw new DataStorageManagerException(message);
+            }
+        } catch (IOException | KeeperException err) {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+    }
+    
+    private List<String> ensureZNodeDirectoryAndReturnChildren(String znode) throws DataStorageManagerException {
+        try {
+            if (zk.ensureZooKeeper().exists(znode, false) == null) {
+                return zk.ensureZooKeeper().getChildren(znode, false);
+            } else {
+                zk.ensureZooKeeper().create(znode, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                return Collections.emptyList();
+            }
+        } catch (IOException | KeeperException err) {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+    }
+    
+    private byte[] readZNode(String checkpointFile) throws DataStorageManagerException {
+        try {
+            return zk.ensureZooKeeper().getData(checkpointFile, false, new Stat());
+        } catch (IOException | KeeperException err) {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public TableStatus getTableStatus(String tableSpace, String tableUuid, LogSequenceNumber sequenceNumber)
+            throws DataStorageManagerException {
+        try {
+
+            String dir = getTableDirectory(tableSpace, tableUuid);
+            String checkpointFile = getTableCheckPointsFile(dir, sequenceNumber);
+
+            checkExistsZNode(checkpointFile, "no such table checkpoint: " + checkpointFile);
+            
+            return readTableStatusFromFile(checkpointFile);
+
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public TableStatus getLatestTableStatus(String tableSpace, String tableName) throws DataStorageManagerException {
+        try {
+            String lastFile = getLastTableCheckpointFile(tableSpace, tableName);
+            TableStatus latestStatus;
+            if (lastFile == null) {
+                latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
+                        Bytes.longToByteArray(1), 1, Collections.emptyMap());
+            } else {
+                latestStatus = readTableStatusFromFile(lastFile);
+            }
+            return latestStatus;
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    public TableStatus readTableStatusFromFile(String checkpointsFile) throws IOException {
+        byte[] fileContent = readZNode(checkpointsFile);
+        XXHash64Utils.verifyBlockWithFooter(fileContent, 0, fileContent.length);
+        try (InputStream input = new SimpleByteArrayInputStream(fileContent);
+             ExtendedDataInputStream dataIn = new ExtendedDataInputStream(input)) {
+            long version = dataIn.readVLong(); // version
+            long flags = dataIn.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted table status file " + checkpointsFile);
+            }
+            return TableStatus.deserialize(dataIn);
+        }
+    }
+
+    private String getLastTableCheckpointFile(String tableSpace, String tableName) throws IOException {
+        String dir = getTableDirectory(tableSpace, tableName);
+        String result = getMostRecentCheckPointFile(dir);
+        return result;
+    }
+
+    private String getMostRecentCheckPointFile(String dir) throws IOException {
+        String result = null;
+        long lastMod = -1;
+        List<String> children = ensureZNodeDirectoryAndReturnChildren(dir);
+        
+         for (String path : children) {
+             String fullpath = dir + "/"+path;
+            if (isTableOrIndexCheckpointsFile(path)) {
+                LOGGER.log(Level.INFO, "getMostRecentCheckPointFile on " + dir + " -> ACCEPT " + fullpath);
+                Stat stat = new Stat();
+                zk.ensureZooKeeper().exists(fullpath , false, null, stat);
+                long ts = stat.getMtime();
+                if (lastMod < 0 || lastMod < ts) {
+                    result = fullpath;
+                    lastMod = ts;
+                }
+            } else {
+                LOGGER.log(Level.INFO, "getMostRecentCheckPointFile on " + dir  + " -> SKIP " + fullpath);
+            }
+        }
+        
+        LOGGER.log(Level.INFO, "getMostRecentCheckPointFile on " + dir + " -> " + result);
+        return result;
+    }
+
+    public IndexStatus readIndexStatusFromFile(String checkpointsFile) throws DataStorageManagerException {
+        try {
+            byte[] fileContent = readZNode(checkpointsFile);
+            XXHash64Utils.verifyBlockWithFooter(fileContent, 0, fileContent.length);
+            try (InputStream input = new SimpleByteArrayInputStream(fileContent);
+                 ExtendedDataInputStream dataIn = new ExtendedDataInputStream(input)) {
+                long version = dataIn.readVLong(); // version
+                long flags = dataIn.readVLong(); // flags for future implementations
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted index status file " + checkpointsFile);
+                }
+                return IndexStatus.deserialize(dataIn);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public List<PostCheckpointAction> tableCheckpoint(String tableSpace, String tableName, TableStatus tableStatus, boolean pin) throws DataStorageManagerException {
+        LogSequenceNumber logPosition = tableStatus.sequenceNumber;
+        String dir = getTableDirectory(tableSpace, tableName);
+        String checkpointFile = getTableCheckPointsFile(dir, logPosition);
+        try {
+            if (Files.isRegularFile(checkpointFile)) {
+                TableStatus actualStatus = readTableStatusFromFile(checkpointFile);
+                if (actualStatus != null && actualStatus.equals(tableStatus)) {
+                    LOGGER.log(Level.FINE,
+                            "tableCheckpoint " + tableSpace + ", " + tableName + ": " + tableStatus + " (pin:" + pin + ") already saved on file " + checkpointFile);
+                    return Collections.emptyList();
+                }
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        Path parent = getParent(checkpointFile);
+        Path checkpointFileTemp = parent.resolve(checkpointFile.getFileName() + ".tmp");
+        LOGGER.log(Level.FINE, "tableCheckpoint " + tableSpace + ", " + tableName + ": " + tableStatus + " (pin:" + pin + ") to file " + checkpointFile);
+
+        try (ManagedFile file = ManagedFile.open(checkpointFileTemp, requirefsync);
+             SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE);
+             XXHash64Utils.HashingOutputStream oo = new XXHash64Utils.HashingOutputStream(buffer);
+             ExtendedDataOutputStream dataOutputKeys = new ExtendedDataOutputStream(oo)) {
+
+            dataOutputKeys.writeVLong(1); // version
+            dataOutputKeys.writeVLong(0); // flags for future implementations
+            tableStatus.serialize(dataOutputKeys);
+
+            dataOutputKeys.writeLong(oo.hash());
+            dataOutputKeys.flush();
+            file.sync();
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        try {
+            Files.move(checkpointFileTemp, checkpointFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+
+        /* Checkpoint pinning */
+        final Map<Long, Integer> pins = pinTableAndGetPages(tableSpace, tableName, tableStatus, pin);
+        final Set<LogSequenceNumber> checkpoints = pinTableAndGetCheckpoints(tableSpace, tableName, tableStatus, pin);
+
+        long maxPageId = tableStatus.activePages.keySet().stream().max(Comparator.naturalOrder()).orElse(Long.MAX_VALUE);
+        List<PostCheckpointAction> result = new ArrayList<>();
+        // we can drop old page files now
+        List<Path> pageFiles = getTablePageFiles(tableSpace, tableName);
+        for (Path p : pageFiles) {
+            long pageId = getPageId(p);
+            LOGGER.log(Level.FINEST, "checkpoint file {0} pageId {1}", new Object[]{p.toAbsolutePath(), pageId});
+            if (pageId > 0
+                    && !pins.containsKey(pageId)
+                    && !tableStatus.activePages.containsKey(pageId)
+                    && pageId < maxPageId) {
+                LOGGER.log(Level.FINEST, "checkpoint file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted after checkpoint end");
+                result.add(new DeleteFileAction(tableName, "delete page " + pageId + " file " + p.toAbsolutePath(), p));
+            }
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+            for (Path p : stream) {
+                if (isTableOrIndexCheckpointsFile(p) && !p.equals(checkpointFile)) {
+                    TableStatus status = readTableStatusFromFile(p);
+                    if (logPosition.after(status.sequenceNumber) && !checkpoints.contains(status.sequenceNumber)) {
+                        LOGGER.log(Level.FINEST, "checkpoint metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
+                        result.add(new DeleteFileAction(tableName, "delete checkpoint metadata file " + p.toAbsolutePath(), p));
+                    }
+                }
+            }
+        } catch (IOException err) {
+            LOGGER.log(Level.SEVERE, "Could not list table dir " + dir, err);
+        }
+        return result;
+    }
+
+    @Override
+    public List<PostCheckpointAction> indexCheckpoint(String tableSpace, String indexName, IndexStatus indexStatus, boolean pin) throws DataStorageManagerException {
+        String dir = getIndexDirectory(tableSpace, indexName);
+        LogSequenceNumber logPosition = indexStatus.sequenceNumber;
+        String checkpointFile = getTableCheckPointsFile(dir, logPosition);
+        String parent = getParent(checkpointFile);
+        String checkpointFileTemp = parent + "/" + checkpointFile.getFileName() + ".tmp";
+
+        if (Files.isRegularFile(checkpointFile)) {
+            IndexStatus actualStatus = readIndexStatusFromFile(checkpointFile);
+            if (actualStatus != null && actualStatus.equals(indexStatus)) {
+                LOGGER.log(Level.INFO,
+                        "indexCheckpoint " + tableSpace + ", " + indexName + ": " + indexStatus + " already saved on" + checkpointFile);
+                return Collections.emptyList();
+            }
+        }
+
+        LOGGER.log(Level.FINE, "indexCheckpoint " + tableSpace + ", " + indexName + ": " + indexStatus + " to file " + checkpointFile);
+
+        try (ManagedFile file = ManagedFile.open(checkpointFileTemp, requirefsync);
+             SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE);
+             XXHash64Utils.HashingOutputStream oo = new XXHash64Utils.HashingOutputStream(buffer);
+             ExtendedDataOutputStream dataOutputKeys = new ExtendedDataOutputStream(oo)) {
+
+            dataOutputKeys.writeVLong(1); // version
+            dataOutputKeys.writeVLong(0); // flags for future implementations
+            indexStatus.serialize(dataOutputKeys);
+
+            dataOutputKeys.writeLong(oo.hash());
+            dataOutputKeys.flush();
+            file.sync();
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        try {
+            Files.move(checkpointFileTemp, checkpointFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+
+        /* Checkpoint pinning */
+        final Map<Long, Integer> pins = pinIndexAndGetPages(tableSpace, indexName, indexStatus, pin);
+        final Set<LogSequenceNumber> checkpoints = pinIndexAndGetCheckpoints(tableSpace, indexName, indexStatus, pin);
+
+        long maxPageId = indexStatus.activePages.stream().max(Comparator.naturalOrder()).orElse(Long.MAX_VALUE);
+        List<PostCheckpointAction> result = new ArrayList<>();
+        // we can drop old page files now
+        List<Path> pageFiles = getIndexPageFiles(tableSpace, indexName);
+        for (Path p : pageFiles) {
+            long pageId = getPageId(p);
+            LOGGER.log(Level.FINEST, "checkpoint file {0} pageId {1}", new Object[]{p.toAbsolutePath(), pageId});
+            if (pageId > 0
+                    && !pins.containsKey(pageId)
+                    && !indexStatus.activePages.contains(pageId)
+                    && pageId < maxPageId) {
+                LOGGER.log(Level.FINEST, "checkpoint file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted after checkpoint end");
+                result.add(new DeleteFileAction(indexName, "delete page " + pageId + " file " + p.toAbsolutePath(), p));
+            }
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+            for (Path p : stream) {
+                if (isTableOrIndexCheckpointsFile(p) && !p.equals(checkpointFile)) {
+                    IndexStatus status = readIndexStatusFromFile(p);
+                    if (logPosition.after(status.sequenceNumber) && !checkpoints.contains(status.sequenceNumber)) {
+                        LOGGER.log(Level.FINEST, "checkpoint metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
+                        result.add(new DeleteFileAction(indexName, "delete checkpoint metadata file " + p.toAbsolutePath(), p));
+                    }
+                }
+            }
+        } catch (IOException err) {
+            LOGGER.log(Level.SEVERE, "Could not list indexName dir " + dir, err);
+        }
+
+        return result;
+    }
+
+    private static String getParent(String file) throws DataStorageManagerException {
+
+        final Path path = file.getParent();
+
+        if (path != null) {
+            return path;
+        }
+
+        if (file.isAbsolute()) {
+            throw new DataStorageManagerException("Invalid path " + file);
+        }
+
+        try {
+
+            return getParent(file.toAbsolutePath());
+
+        } catch (IOError | SecurityException e) {
+
+            throw new DataStorageManagerException("Invalid path " + file);
+        }
+
+    }
+
+    private static String getFilename(String s) {
+        int last = s.lastIndexOf("/");
+        return s.substring(last + 1);
+    }
+    
+    private static long getPageId(String p) {
+        String filename = getFilename(p);
+        if (filename.endsWith(FILEEXTENSION_PAGE)) {
+            try {
+                return Long.parseLong(filename.substring(0, filename.length() - FILEEXTENSION_PAGE.length()));
+            } catch (NumberFormatException no) {
+                return -1;
+            }
+        } else {
+            return -1;
+        }
+    }
+
+    private static boolean isPageFile(String path) {
+        return getPageId(path) >= 0;
+    }
+
+    public List<String> getTablePageFiles(String tableSpace, String tableName) throws DataStorageManagerException {
+        String tableDir = getTableDirectory(tableSpace, tableName);
+
+        try (DirectoryStream<Path> files = Files.newDirectoryStream(tableDir, new DirectoryStream.Filter<Path>() {
+            @Override
+            public boolean accept(Path entry) throws IOException {
+                return isPageFile(entry);
+            }
+
+        })) {
+            List<Path> result = new ArrayList<>();
+            files.forEach(result::add);
+            return result;
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    public List<String> getIndexPageFiles(String tableSpace, String indexName) throws DataStorageManagerException {
+        String indexDir = getIndexDirectory(tableSpace, indexName);
+
+        try (DirectoryStream<Path> files = Files.newDirectoryStream(indexDir, new DirectoryStream.Filter<Path>() {
+            @Override
+            public boolean accept(Path entry) throws IOException {
+                return isPageFile(entry);
+            }
+
+        })) {
+            List<Path> result = new ArrayList<>();
+            files.forEach(result::add);
+            return result;
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void cleanupAfterBoot(String tableSpace, String tableName, Set<Long> activePagesAtBoot) throws DataStorageManagerException {
+        // we have to drop old page files or page files partially written by checkpoint interrupted at JVM crash/reboot
+        List<Path> pageFiles = getTablePageFiles(tableSpace, tableName);
+        for (Path p : pageFiles) {
+            long pageId = getPageId(p);
+            LOGGER.log(Level.FINER, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId);
+            if (pageId > 0 && !activePagesAtBoot.contains(pageId)) {
+                LOGGER.log(Level.INFO, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted");
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException err) {
+                    throw new DataStorageManagerException(err);
+                }
+            }
+        }
+    }
+
+    /**
+     * Write a record page
+     *
+     * @param newPage data to write
+     * @param file    managed file used for sync operations
+     * @param stream  output stream related to given managed file for write
+     *                operations
+     * @return
+     * @throws IOException
+     */
+    private static long writePage(Collection<Record> newPage, ManagedFile file, OutputStream stream) throws IOException {
+
+        try (RecyclableByteArrayOutputStream oo = getWriteBuffer();
+             ExtendedDataOutputStream dataOutput = new ExtendedDataOutputStream(oo)) {
+
+            dataOutput.writeVLong(1); // version
+            dataOutput.writeVLong(0); // flags for future implementations
+            dataOutput.writeInt(newPage.size());
+            for (Record record : newPage) {
+                dataOutput.writeArray(record.key);
+                dataOutput.writeArray(record.value);
+            }
+            dataOutput.flush();
+            long hash = XXHash64Utils.hash(oo.getBuffer(), 0, oo.size());
+            dataOutput.writeLong(hash);
+            dataOutput.flush();
+            stream.write(oo.getBuffer(), 0, oo.size());
+            if (file != null) { // O_DIRECT does not need fsync
+                file.sync();
+            }
+            return oo.size();
+        }
+
+    }
+
+    @Override
+    public void writePage(String tableSpace, String tableName, long pageId, Collection<Record> newPage) throws DataStorageManagerException {
+        // synch on table is done by the TableManager
+        long _start = System.currentTimeMillis();
+        Path tableDir = getTableDirectory(tableSpace, tableName);
+        Path pageFile = getPageFile(tableDir, pageId);
+        long size;
+
+        try {
+            if (pageodirect) {
+                try (ODirectFileOutputStream odirect = new ODirectFileOutputStream(pageFile, O_DIRECT_BLOCK_BATCH,
+                        StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                    size = writePage(newPage, null, odirect);
+                }
+
+            } else {
+                try (ManagedFile file = ManagedFile.open(pageFile, requirefsync,
+                        StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                     SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE)) {
+
+                    size = writePage(newPage, file, buffer);
+                }
+
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        long now = System.currentTimeMillis();
+        long delta = (now - _start);
+
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.log(Level.FINER, "writePage {0} KBytes,{1} records, time {2} ms", new Object[]{(size / 1024) + "", newPage.size(), delta + ""});
+        }
+        dataPageWrites.registerSuccessfulEvent(delta, TimeUnit.MILLISECONDS);
+    }
+
+    private static long writeIndexPage(DataWriter writer, ManagedFile file, OutputStream stream) throws IOException {
+        try (RecyclableByteArrayOutputStream oo = getWriteBuffer();
+             ExtendedDataOutputStream dataOutput = new ExtendedDataOutputStream(oo)) {
+            dataOutput.writeVLong(1); // version
+            dataOutput.writeVLong(0); // flags for future implementations
+            writer.write(dataOutput);
+            dataOutput.flush();
+            long hash = XXHash64Utils.hash(oo.getBuffer(), 0, oo.size());
+            dataOutput.writeLong(hash);
+            dataOutput.flush();
+            stream.write(oo.getBuffer(), 0, oo.size());
+            if (file != null) { // O_DIRECT does not need fsync
+                file.sync();
+            }
+            return oo.size();
+        }
+    }
+
+    @Override
+    public void writeIndexPage(
+            String tableSpace, String indexName,
+            long pageId, DataWriter writer
+    ) throws DataStorageManagerException {
+        long _start = System.currentTimeMillis();
+        String tableDir = getIndexDirectory(tableSpace, indexName);
+
+        String pageFile = getPageFile(tableDir, pageId);
+        long size;
+        try {
+            if (indexodirect) {
+                try (ODirectFileOutputStream odirect = new ODirectFileOutputStream(pageFile, O_DIRECT_BLOCK_BATCH,
+                        StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                    size = writeIndexPage(writer, null, odirect);
+                }
+
+            } else {
+                try (ManagedFile file = ManagedFile.open(pageFile, requirefsync,
+                        StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                     SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE)) {
+
+                    size = writeIndexPage(writer, file, buffer);
+                }
+            }
+
+        } catch (IOException err) {
+            LOGGER.log(Level.SEVERE, "Failed to write on path: {0}", pageFile);
+            Path path = pageFile;
+            boolean exists;
+            do {
+                exists = Files.exists(path);
+
+                if (exists) {
+                    LOGGER.log(Level.INFO,
+                            "Path {0}: directory {1}, file {2}, link {3}, writable {4}, readable {5}, executable {6}",
+                            new Object[] { path, Files.isDirectory(path), Files.isRegularFile(path),
+                                    Files.isSymbolicLink(path), Files.isWritable(path), Files.isReadable(path),
+                                    Files.isExecutable(path) });
+                } else {
+                    LOGGER.log(Level.INFO, "Path {0} doesn't exists", path);
+                }
+
+                path = path.getParent();
+            } while (path != null && !exists);
+
+            throw new DataStorageManagerException(err);
+        }
+
+        long now = System.currentTimeMillis();
+        long delta = (now - _start);
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.log(Level.FINER, "writePage {0} KBytes, time {2} ms", new Object[]{(size / 1024) + "", delta + ""});
+        }
+        indexPageWrites.registerSuccessfulEvent(delta, TimeUnit.MILLISECONDS);
+    }
+
+    private static LogSequenceNumber readLogSequenceNumberFromTablesMetadataFile(String tableSpace, Path file) throws DataStorageManagerException {
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(file, StandardOpenOption.READ), 4 * 1024 * 1024);
+             ExtendedDataInputStream din = new ExtendedDataInputStream(input)) {
+            long version = din.readVLong(); // version
+            long flags = din.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted table list file " + file.toAbsolutePath());
+            }
+            String readname = din.readUTF();
+            if (!readname.equals(tableSpace)) {
+                throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for spablespace " + tableSpace);
+            }
+            long ledgerId = din.readZLong();
+            long offset = din.readZLong();
+            return new LogSequenceNumber(ledgerId, offset);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    private static LogSequenceNumber readLogSequenceNumberFromIndexMetadataFile(String tableSpace, Path file) throws DataStorageManagerException {
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(file, StandardOpenOption.READ), 4 * 1024 * 1024);
+             ExtendedDataInputStream din = new ExtendedDataInputStream(input)) {
+            long version = din.readVLong(); // version
+            long flags = din.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted index list file " + file.toAbsolutePath());
+            }
+            String readname = din.readUTF();
+            if (!readname.equals(tableSpace)) {
+                throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for spablespace " + tableSpace);
+            }
+            long ledgerId = din.readZLong();
+            long offset = din.readZLong();
+            return new LogSequenceNumber(ledgerId, offset);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public List<Table> loadTables(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
+        try {
+            Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
+            Files.createDirectories(tableSpaceDirectory);
+            Path file = getTablespaceTablesMetadataFile(tableSpace, sequenceNumber);
+            LOGGER.log(Level.INFO, "loadTables for tableSpace " + tableSpace + " from " + file.toAbsolutePath().toString() + ", sequenceNumber:" + sequenceNumber);
+            if (!Files.isRegularFile(file)) {
+                if (sequenceNumber.isStartOfTime()) {
+                    LOGGER.log(Level.INFO, "file " + file.toAbsolutePath().toString() + " not found");
+                    return Collections.emptyList();
+                } else {
+                    throw new DataStorageManagerException("local table data not available for tableSpace " + tableSpace + ", recovering from sequenceNumber " + sequenceNumber);
+                }
+            }
+            return readTablespaceStructure(file, tableSpace, sequenceNumber);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    public static List<Table> readTablespaceStructure(Path file, String tableSpace, LogSequenceNumber sequenceNumber) throws IOException, DataStorageManagerException {
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(file, StandardOpenOption.READ), 4 * 1024 * 1024);
+             ExtendedDataInputStream din = new ExtendedDataInputStream(input)) {
+            long version = din.readVLong(); // version
+            long flags = din.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted table list file " + file.toAbsolutePath());
+            }
+            String readname = din.readUTF();
+            if (!readname.equals(tableSpace)) {
+                throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for spablespace " + tableSpace);
+            }
+            long ledgerId = din.readZLong();
+            long offset = din.readZLong();
+            if (sequenceNumber != null) {
+                if (ledgerId != sequenceNumber.ledgerId || offset != sequenceNumber.offset) {
+                    throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for sequence number " + sequenceNumber);
+                }
+            }
+            int numTables = din.readInt();
+            List<Table> res = new ArrayList<>();
+            for (int i = 0; i < numTables; i++) {
+                byte[] tableData = din.readArray();
+                Table table = Table.deserialize(tableData);
+                res.add(table);
+            }
+            return Collections.unmodifiableList(res);
+        }
+    }
+
+    @Override
+    public List<Index> loadIndexes(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
+        try {
+            Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
+            Files.createDirectories(tableSpaceDirectory);
+            Path file = getTablespaceIndexesMetadataFile(tableSpace, sequenceNumber);
+            LOGGER.log(Level.INFO, "loadIndexes for tableSpace " + tableSpace + " from " + file.toAbsolutePath().toString() + ", sequenceNumber:" + sequenceNumber);
+            if (!Files.isRegularFile(file)) {
+                if (sequenceNumber.isStartOfTime()) {
+                    LOGGER.log(Level.INFO, "file " + file.toAbsolutePath().toString() + " not found");
+                    return Collections.emptyList();
+                } else {
+                    throw new DataStorageManagerException("local index data not available for tableSpace " + tableSpace + ", recovering from sequenceNumber " + sequenceNumber);
+                }
+            }
+            try (InputStream input = new BufferedInputStream(Files.newInputStream(file, StandardOpenOption.READ), 4 * 1024 * 1024);
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(input)) {
+                long version = din.readVLong(); // version
+                long flags = din.readVLong(); // flags for future implementations
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted index list file " + file.toAbsolutePath());
+                }
+                String readname = din.readUTF();
+                if (!readname.equals(tableSpace)) {
+                    throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for spablespace " + tableSpace);
+                }
+                long ledgerId = din.readZLong();
+                long offset = din.readZLong();
+                if (ledgerId != sequenceNumber.ledgerId || offset != sequenceNumber.offset) {
+                    throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for sequence number " + sequenceNumber);
+                }
+                int numTables = din.readInt();
+                List<Index> res = new ArrayList<>();
+                for (int i = 0; i < numTables; i++) {
+                    byte[] indexData = din.readArray();
+                    Index table = Index.deserialize(indexData);
+                    res.add(table);
+                }
+                return Collections.unmodifiableList(res);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeTables(
+            String tableSpace, LogSequenceNumber sequenceNumber,
+            List<Table> tables, List<Index> indexlist, boolean prepareActions
+    ) throws DataStorageManagerException {
+        if (sequenceNumber.isStartOfTime() && !tables.isEmpty()) {
+            throw new DataStorageManagerException("impossible to write a non empty table list at start-of-time");
+        }
+        Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
+        try {
+            Files.createDirectories(tableSpaceDirectory);
+            Path fileTables = getTablespaceTablesMetadataFile(tableSpace, sequenceNumber);
+            Path fileIndexes = getTablespaceIndexesMetadataFile(tableSpace, sequenceNumber);
+            Path parent = getParent(fileTables);
+            Files.createDirectories(parent);
+
+            LOGGER.log(Level.FINE, "writeTables for tableSpace " + tableSpace + " sequenceNumber " + sequenceNumber + " to " + fileTables.toAbsolutePath().toString());
+            try (ManagedFile file = ManagedFile.open(fileTables, requirefsync);
+                 SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE);
+                 ExtendedDataOutputStream dout = new ExtendedDataOutputStream(buffer)) {
+
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags for future implementations
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(sequenceNumber.ledgerId);
+                dout.writeZLong(sequenceNumber.offset);
+                dout.writeInt(tables.size());
+                for (Table t : tables) {
+                    byte[] tableSerialized = t.serialize();
+                    dout.writeArray(tableSerialized);
+                }
+
+                dout.flush();
+                file.sync();
+            } catch (IOException err) {
+                throw new DataStorageManagerException(err);
+            }
+
+            try (ManagedFile file = ManagedFile.open(fileIndexes, requirefsync);
+                 SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE);
+                 ExtendedDataOutputStream dout = new ExtendedDataOutputStream(buffer)) {
+
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags for future implementations
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(sequenceNumber.ledgerId);
+                dout.writeZLong(sequenceNumber.offset);
+                if (indexlist != null) {
+                    dout.writeInt(indexlist.size());
+                    for (Index t : indexlist) {
+                        byte[] indexSerialized = t.serialize();
+                        dout.writeArray(indexSerialized);
+                    }
+                } else {
+                    dout.writeInt(0);
+                }
+
+                dout.flush();
+                file.sync();
+            } catch (IOException err) {
+                throw new DataStorageManagerException(err);
+            }
+
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        Collection<PostCheckpointAction> result = new ArrayList<>();
+        if (prepareActions) {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(tableSpaceDirectory)) {
+                for (Path p : stream) {
+                    if (isTablespaceIndexesMetadataFile(p)) {
+                        try {
+                            LogSequenceNumber logPositionInFile = readLogSequenceNumberFromIndexMetadataFile(tableSpace, p);
+                            if (sequenceNumber.after(logPositionInFile)) {
+                                LOGGER.log(Level.FINEST, "indexes metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
+                                result.add(new DeleteFileAction("indexes", "delete indexesmetadata file " + p.toAbsolutePath(), p));
+                            }
+                        } catch (DataStorageManagerException ignore) {
+                            LOGGER.log(Level.SEVERE, "Unparsable indexesmetadata file " + p.toAbsolutePath(), ignore);
+                            result.add(new DeleteFileAction("indexes", "delete unparsable indexesmetadata file " + p.toAbsolutePath(), p));
+                        }
+                    } else if (isTablespaceTablesMetadataFile(p)) {
+                        try {
+                            LogSequenceNumber logPositionInFile = readLogSequenceNumberFromTablesMetadataFile(tableSpace, p);
+                            if (sequenceNumber.after(logPositionInFile)) {
+                                LOGGER.log(Level.FINEST, "tables metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
+                                result.add(new DeleteFileAction("tables", "delete tablesmetadata file " + p.toAbsolutePath(), p));
+                            }
+                        } catch (DataStorageManagerException ignore) {
+                            LOGGER.log(Level.SEVERE, "Unparsable tablesmetadata file " + p.toAbsolutePath(), ignore);
+                            result.add(new DeleteFileAction("transactions", "delete unparsable tablesmetadata file " + p.toAbsolutePath(), p));
+                        }
+                    }
+                }
+            } catch (IOException err) {
+                LOGGER.log(Level.SEVERE, "Could not list dir " + tableSpaceDirectory, err);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeCheckpointSequenceNumber(String tableSpace, LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+        Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
+        try {
+            Files.createDirectories(tableSpaceDirectory);
+            Path checkPointFile = getTablespaceCheckPointInfoFile(tableSpace, sequenceNumber);
+            Path parent = getParent(checkPointFile);
+            Files.createDirectories(parent);
+
+            Path checkpointFileTemp = parent.resolve(checkPointFile.getFileName() + ".tmp");
+            LOGGER.log(Level.INFO, "checkpoint for " + tableSpace + " at " + sequenceNumber + " to " + checkPointFile.toAbsolutePath().toString());
+
+            try (ManagedFile file = ManagedFile.open(checkpointFileTemp, requirefsync);
+                 SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE);
+                 ExtendedDataOutputStream dout = new ExtendedDataOutputStream(buffer)) {
+
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags for future implementations
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(sequenceNumber.ledgerId);
+                dout.writeZLong(sequenceNumber.offset);
+
+                dout.flush();
+                file.sync();
+            } catch (IOException err) {
+                throw new DataStorageManagerException(err);
+            }
+
+            // write file atomically
+            Files.move(checkpointFileTemp, checkPointFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        Collection<PostCheckpointAction> result = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(tableSpaceDirectory)) {
+            for (Path p : stream) {
+                if (isTablespaceCheckPointInfoFile(p)) {
+                    try {
+                        LogSequenceNumber logPositionInFile = readLogSequenceNumberFromCheckpointInfoFile(tableSpace, p);
+                        if (sequenceNumber.after(logPositionInFile)) {
+                            LOGGER.log(Level.FINEST, "checkpoint info file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
+                            result.add(new DeleteFileAction("checkpoint", "delete checkpoint info file " + p.toAbsolutePath(), p));
+                        }
+                    } catch (DataStorageManagerException ignore) {
+                        LOGGER.log(Level.SEVERE, "unparsable checkpoint info file " + p.toAbsolutePath(), ignore);
+                        // do not auto-delete checkpoint files
+                    }
+                }
+            }
+        } catch (IOException err) {
+            LOGGER.log(Level.SEVERE, "Could not list dir " + tableSpaceDirectory, err);
+        }
+        return result;
+
+    }
+
+    @Override
+    public void dropTable(String tablespace, String tableName) throws DataStorageManagerException {
+        Path tableDir = getTableDirectory(tablespace, tableName);
+        LOGGER.log(Level.INFO, "dropTable {0}.{1} in {2}", new Object[]{tablespace, tableName, tableDir});
+        try {
+            deleteDirectory(tableDir);
+        } catch (IOException ex) {
+            throw new DataStorageManagerException(ex);
+        }
+    }
+
+    @Override
+    public void truncateIndex(String tablespace, String name) throws DataStorageManagerException {
+        Path tableDir = getIndexDirectory(tablespace, name);
+        LOGGER.log(Level.INFO, "truncateIndex {0}.{1} in {2}", new Object[]{tablespace, name, tableDir});
+        try {
+            cleanDirectory(tableDir);
+        } catch (IOException ex) {
+            throw new DataStorageManagerException(ex);
+        }
+    }
+
+    @Override
+    public void dropIndex(String tablespace, String name) throws DataStorageManagerException {
+        Path tableDir = getIndexDirectory(tablespace, name);
+        LOGGER.log(Level.INFO, "dropIndex {0}.{1} in {2}", new Object[]{tablespace, name, tableDir});
+        try {
+            deleteDirectory(tableDir);
+        } catch (IOException ex) {
+            throw new DataStorageManagerException(ex);
+        }
+    }
+
+    private static LogSequenceNumber readLogSequenceNumberFromCheckpointInfoFile(String tableSpace, Path checkPointFile) throws DataStorageManagerException, IOException {
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(checkPointFile, StandardOpenOption.READ), 4 * 1024 * 1024);
+             ExtendedDataInputStream din = new ExtendedDataInputStream(input)) {
+            long version = din.readVLong(); // version
+            long flags = din.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new IOException("corrupted checkpoint file");
+            }
+            String readname = din.readUTF();
+            if (!readname.equals(tableSpace)) {
+                throw new DataStorageManagerException("file " + checkPointFile.toAbsolutePath() + " is not for spablespace " + tableSpace);
+            }
+            long ledgerId = din.readZLong();
+            long offset = din.readZLong();
+
+            return new LogSequenceNumber(ledgerId, offset);
+        }
+    }
+
+    @Override
+    public LogSequenceNumber getLastcheckpointSequenceNumber(String tableSpace) throws DataStorageManagerException {
+        try {
+            Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
+            Files.createDirectories(tableSpaceDirectory);
+            LogSequenceNumber max = LogSequenceNumber.START_OF_TIME;
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(tableSpaceDirectory)) {
+                for (Path p : stream) {
+                    if (isTablespaceCheckPointInfoFile(p)) {
+                        try {
+                            LogSequenceNumber logPositionInFile = readLogSequenceNumberFromCheckpointInfoFile(tableSpace, p);
+                            if (logPositionInFile.after(max)) {
+                                max = logPositionInFile;
+                            }
+                        } catch (DataStorageManagerException ignore) {
+                            LOGGER.log(Level.SEVERE, "unparsable checkpoint info file " + p.toAbsolutePath(), ignore);
+                        }
+                    }
+                }
+            } catch (IOException err) {
+                LOGGER.log(Level.SEVERE, "Could not list dir " + tableSpaceDirectory, err);
+            }
+            return max;
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+
+        }
+    }
+
+    public static void deleteDirectory(Path f) throws IOException {
+        deleteDirectoryContent(f, false);
+    }
+
+    public static void cleanDirectory(Path f) throws IOException {
+        deleteDirectoryContent(f, true);
+    }
+
+    private static void deleteDirectoryContent(Path f, boolean keepDirectory) throws IOException {
+        if (Files.isDirectory(f)) {
+            final SimpleFileVisitor<Path> visitor =
+                    keepDirectory ? new CleanDirectoryFileVisitor() : DeleteFileVisitor.INSTANCE;
+            Files.walkFileTree(f, visitor);
+        } else if (Files.isRegularFile(f)) {
+            throw new IOException("name " + f.toAbsolutePath() + " is not a directory");
+        }
+    }
+
+    @Override
+    public KeyToPageIndex createKeyToPageMap(String tablespace, String name, MemoryManager memoryManager) throws DataStorageManagerException {
+        return new BLinkKeyToPageIndex(tablespace, name, memoryManager, this);
+    }
+
+    @Override
+    public void releaseKeyToPageMap(String tablespace, String name, KeyToPageIndex keyToPage) {
+        if (keyToPage != null) {
+            keyToPage.close();
+        }
+    }
+
+    @Override
+    public RecordSetFactory createRecordSetFactory() {
+        return new FileRecordSetFactory(tmpDirectory, swapThreshold);
+    }
+
+    private static LogSequenceNumber readLogSequenceNumberFromTransactionsFile(String tableSpace, Path file) throws DataStorageManagerException {
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(file, StandardOpenOption.READ), 4 * 1024 * 1024);
+             ExtendedDataInputStream din = new ExtendedDataInputStream(input)) {
+            long version = din.readVLong(); // version
+            long flags = din.readVLong(); // flags for future implementations
+            if (version != 1 || flags != 0) {
+                throw new DataStorageManagerException("corrupted transaction list file " + file.toAbsolutePath());
+            }
+            String readname = din.readUTF();
+            if (!readname.equals(tableSpace)) {
+                throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for spablespace " + tableSpace);
+            }
+            long ledgerId = din.readZLong();
+            long offset = din.readZLong();
+            return new LogSequenceNumber(ledgerId, offset);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public void loadTransactions(LogSequenceNumber sequenceNumber, String tableSpace, Consumer<Transaction> consumer) throws DataStorageManagerException {
+        try {
+            Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
+            Files.createDirectories(tableSpaceDirectory);
+            Path file = getTablespaceTransactionsFile(tableSpace, sequenceNumber);
+            boolean exists = Files.isRegularFile(file);
+            LOGGER.log(Level.INFO, "loadTransactions " + sequenceNumber + " for tableSpace " + tableSpace + " from file " + file + " (exists: " + exists + ")");
+            if (!exists) {
+                return;
+            }
+            try (InputStream input = new BufferedInputStream(Files.newInputStream(file, StandardOpenOption.READ), 4 * 1024 * 1024);
+                 ExtendedDataInputStream din = new ExtendedDataInputStream(input)) {
+                long version = din.readVLong(); // version
+                long flags = din.readVLong(); // flags for future implementations
+                if (version != 1 || flags != 0) {
+                    throw new DataStorageManagerException("corrupted transaction list file " + file.toAbsolutePath());
+                }
+                String readname = din.readUTF();
+                if (!readname.equals(tableSpace)) {
+                    throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for spablespace " + tableSpace);
+                }
+                long ledgerId = din.readZLong();
+                long offset = din.readZLong();
+                if (ledgerId != sequenceNumber.ledgerId || offset != sequenceNumber.offset) {
+                    throw new DataStorageManagerException("file " + file.toAbsolutePath() + " is not for sequence number " + sequenceNumber);
+                }
+                int numTransactions = din.readInt();
+                for (int i = 0; i < numTransactions; i++) {
+                    Transaction tx = Transaction.deserialize(tableSpace, din);
+                    consumer.accept(tx);
+                }
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    @Override
+    public Collection<PostCheckpointAction> writeTransactionsAtCheckpoint(String tableSpace, LogSequenceNumber sequenceNumber, Collection<Transaction> transactions) throws DataStorageManagerException {
+        if (sequenceNumber.isStartOfTime() && !transactions.isEmpty()) {
+            throw new DataStorageManagerException("impossible to write a non empty transactions list at start-of-time");
+        }
+        Path tableSpaceDirectory = getTablespaceDirectory(tableSpace);
+        try {
+            Files.createDirectories(tableSpaceDirectory);
+            Path checkPointFile = getTablespaceTransactionsFile(tableSpace, sequenceNumber);
+            Path parent = getParent(checkPointFile);
+            Files.createDirectories(parent);
+
+            Path checkpointFileTemp = parent.resolve(checkPointFile.getFileName() + ".tmp");
+            LOGGER.log(Level.FINE, "writeTransactionsAtCheckpoint for tableSpace {0} sequenceNumber {1} to {2}, active transactions {3}", new Object[]{tableSpace, sequenceNumber, checkPointFile.toAbsolutePath().toString(), transactions.size()});
+            try (ManagedFile file = ManagedFile.open(checkpointFileTemp, requirefsync);
+                 SimpleBufferedOutputStream buffer = new SimpleBufferedOutputStream(file.getOutputStream(), COPY_BUFFERS_SIZE);
+                 ExtendedDataOutputStream dout = new ExtendedDataOutputStream(buffer)) {
+
+                dout.writeVLong(1); // version
+                dout.writeVLong(0); // flags for future implementations
+                dout.writeUTF(tableSpace);
+                dout.writeZLong(sequenceNumber.ledgerId);
+                dout.writeZLong(sequenceNumber.offset);
+                dout.writeInt(transactions.size());
+                for (Transaction t : transactions) {
+                    t.serialize(dout);
+                }
+
+                dout.flush();
+                file.sync();
+            } catch (IOException err) {
+                throw new DataStorageManagerException(err);
+            }
+
+            try {
+                Files.move(checkpointFileTemp, checkPointFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException err) {
+                throw new DataStorageManagerException(err);
+            }
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+
+        Collection<PostCheckpointAction> result = new ArrayList<>();
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(tableSpaceDirectory)) {
+            for (Path p : stream) {
+                if (isTransactionsFile(p)) {
+                    try {
+                        LogSequenceNumber logPositionInFile = readLogSequenceNumberFromTransactionsFile(tableSpace, p);
+                        if (sequenceNumber.after(logPositionInFile)) {
+                            LOGGER.log(Level.FINEST, "transactions metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
+                            result.add(new DeleteFileAction("transactions", "delete transactions file " + p.toAbsolutePath(), p));
+                        }
+                    } catch (DataStorageManagerException ignore) {
+                        LOGGER.log(Level.SEVERE, "Unparsable transactions file " + p.toAbsolutePath(), ignore);
+                        result.add(new DeleteFileAction("transactions", "delete unparsable transactions file " + p.toAbsolutePath(), p));
+                    }
+                }
+            }
+        } catch (IOException err) {
+            LOGGER.log(Level.SEVERE, "Could not list dir " + tableSpaceDirectory, err);
+        }
+        return result;
+    }
+
+    private static class DeleteFileAction extends PostCheckpointAction {
+
+        private final Path p;
+
+        public DeleteFileAction(String tableName, String description, Path p) {
+            super(tableName, description);
+            this.p = p;
+        }
+
+        @Override
+        public void run() {
+            try {
+                LOGGER.log(Level.FINE, description);
+                Files.deleteIfExists(p);
+            } catch (IOException err) {
+                LOGGER.log(Level.SEVERE, "Could not delete file " + p.toAbsolutePath() + ":" + err, err);
+            }
+        }
+    }
+
+    private static final Recycler<RecyclableByteArrayOutputStream> WRITE_BUFFERS_RECYCLER = new Recycler<RecyclableByteArrayOutputStream>() {
+
+        @Override
+        protected RecyclableByteArrayOutputStream newObject(
+                Recycler.Handle<RecyclableByteArrayOutputStream> handle
+        ) {
+            return new RecyclableByteArrayOutputStream(handle);
+        }
+
+    };
+
+    private static RecyclableByteArrayOutputStream getWriteBuffer() {
+        RecyclableByteArrayOutputStream res = WRITE_BUFFERS_RECYCLER.get();
+        res.closed = false;
+        res.reset();
+        return res;
+    }
+
+    /**
+     * These buffers are useful only inside FileDataStorageManager, because they
+     * will eventually be mostly of about maximum page size bytes large.
+     */
+    private static class RecyclableByteArrayOutputStream extends VisibleByteArrayOutputStream {
+
+        private static final int DEFAULT_INITIAL_SIZE = 1024 * 1024;
+        private final io.netty.util.Recycler.Handle<RecyclableByteArrayOutputStream> handle;
+        private boolean closed;
+
+        RecyclableByteArrayOutputStream(Recycler.Handle<RecyclableByteArrayOutputStream> handle) {
+            super(DEFAULT_INITIAL_SIZE);
+            this.handle = handle;
+        }
+
+        @Override
+        public void close() {
+            if (!closed) { // prevent double 'recycle'
+                super.close();
+                handle.recycle(this);
+                closed = true;
+            }
+        }
+
+    }
+}

--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -45,7 +45,6 @@ import herddb.utils.ExtendedDataOutputStream;
 import herddb.utils.FileUtils;
 import herddb.utils.SimpleByteArrayInputStream;
 import herddb.utils.SystemInstrumentation;
-import herddb.utils.SystemProperties;
 import herddb.utils.VisibleByteArrayOutputStream;
 import herddb.utils.XXHash64Utils;
 import io.netty.util.Recycler;
@@ -319,8 +318,8 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             throw new DataPageDoesNotExistException("No such page: " + tableSpace + "_" + tableName + "." + pageId);
         }
         byte[] data;
-        try (ReadHandle read
-                = FutureUtils.result(bk.getBookKeeper()
+        try (ReadHandle read =
+                FutureUtils.result(bk.getBookKeeper()
                         .newOpenLedgerOp()
                         .withLedgerId(ledgerId)
                         .withPassword(new byte[0])
@@ -405,8 +404,8 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             throw new DataPageDoesNotExistException("No such page for index : " + tableSpace + "_" + indexName + "." + pageId);
         }
         byte[] data;
-        try (ReadHandle read
-                = FutureUtils.result(bk.getBookKeeper()
+        try (ReadHandle read =
+                FutureUtils.result(bk.getBookKeeper()
                         .newOpenLedgerOp()
                         .withLedgerId(ledgerId)
                         .withPassword(new byte[0])
@@ -916,8 +915,8 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             try (VisibleByteArrayOutputStream buffer = new VisibleByteArrayOutputStream()) {
                 size = writePage(newPage, buffer);
 
-                try (WriteHandle result
-                        = FutureUtils.result(bk.getBookKeeper()
+                try (WriteHandle result =
+                         FutureUtils.result(bk.getBookKeeper()
                                 .newCreateLedgerOp()
                                 .withEnsembleSize(bk.getEnsemble())
                                 .withWriteQuorumSize(bk.getWriteQuorumSize())
@@ -977,8 +976,8 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
 
                 size = writeIndexPage(writer, buffer);
 
-                try (WriteHandle result
-                        = FutureUtils.result(bk.getBookKeeper()
+                try (WriteHandle result =
+                        FutureUtils.result(bk.getBookKeeper()
                                 .newCreateLedgerOp()
                                 .withEnsembleSize(bk.getEnsemble())
                                 .withWriteQuorumSize(bk.getWriteQuorumSize())

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
@@ -107,6 +107,10 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
         });
     }
 
+    public BookKeeper getBookKeeper() {
+        return bookKeeper;
+    }
+
     private void forceLastAddConfirmed() {
         activeLogs.values().forEach(l -> {
             l.forceLastAddConfirmed();

--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -78,6 +78,10 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         }
     };
 
+    public String getBasePath() {
+        return basePath;
+    }
+
     public String getZkAddress() {
         return zkAddress;
     }
@@ -187,7 +191,7 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
         return zooKeeper;
     }
 
-    private synchronized ZooKeeper ensureZooKeeper() throws KeeperException, InterruptedException, IOException {
+    public synchronized ZooKeeper ensureZooKeeper() throws KeeperException, InterruptedException, IOException {
         if (!started) {
             throw new IOException("MetadataStorageManager not yet started");
         }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -521,7 +521,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         }
         keyToPage.start(bootSequenceNumber);
 
-        dataStorageManager.cleanupAfterBoot(tableSpaceUUID, table.uuid, activePagesAtBoot.keySet());
+        dataStorageManager.cleanupAfterTableBoot(tableSpaceUUID, table.uuid, activePagesAtBoot.keySet());
 
         pageSet.setActivePagesAtBoot(activePagesAtBoot);
 
@@ -1230,7 +1230,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 }
             }, transaction, true, true);
         } catch (HerdDBInternalException err) {
-            LOGGER.log(Level.SEVERE,"bad error during an update", err);
+            LOGGER.log(Level.SEVERE, "bad error during an update", err);
             return FutureUtils.exception(err);
         }
 
@@ -1321,7 +1321,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 }
             }, transaction, true, true);
         } catch (HerdDBInternalException err) {
-            LOGGER.log(Level.SEVERE,"bad error during a delete", err);
+            LOGGER.log(Level.SEVERE, "bad error during a delete", err);
             return FutureUtils.exception(err);
         }
         if (writes.isEmpty()) {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1800,7 +1800,6 @@ public class TableSpaceManager {
                 }
             }
             return new TableSpaceCheckpoint(logSequenceNumber, checkpointsTableNameSequenceNumber);
-
         } finally {
             long _stop = System.currentTimeMillis();
             LOGGER.log(Level.INFO, "{0} checkpoint finish {1} started ad {2}, finished at {3}, total time {4} ms",

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -834,7 +834,7 @@ public class FileDataStorageManager extends DataStorageManager {
     }
 
     @Override
-    public void cleanupAfterBoot(String tableSpace, String tableName, Set<Long> activePagesAtBoot) throws DataStorageManagerException {
+    public void cleanupAfterTableBoot(String tableSpace, String tableName, Set<Long> activePagesAtBoot) throws DataStorageManagerException {
         // we have to drop old page files or page files partially written by checkpoint interrupted at JVM crash/reboot
         List<Path> pageFiles = getTablePageFiles(tableSpace, tableName);
         for (Path p : pageFiles) {

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -22,6 +22,7 @@ package herddb.index.blink;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.core.AbstractIndexManager;
+import herddb.core.HerdDBInternalException;
 import herddb.core.MemoryManager;
 import herddb.core.PostCheckpointAction;
 import herddb.index.IndexOperation;
@@ -122,27 +123,47 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
 
     @Override
     public void put(Bytes key, Long currentPage) {
-        getTree().insert(key, currentPage);
+        try {
+            getTree().insert(key, currentPage);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
     }
 
     @Override
     public boolean put(Bytes key, Long newPage, Long expectedPage) {
-        return getTree().insert(key, newPage, expectedPage);
+        try {
+            return getTree().insert(key, newPage, expectedPage);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
     }
 
     @Override
     public boolean containsKey(Bytes key) {
-        return getTree().search(key) != null;
+        try {
+            return getTree().search(key) != null;
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
     }
 
     @Override
     public Long get(Bytes key) {
-        return getTree().search(key);
+        try {
+            return getTree().search(key);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
     }
 
     @Override
     public Long remove(Bytes key) {
-        return getTree().delete(key);
+        try {
+            return getTree().delete(key);
+        } catch (UncheckedIOException err) {
+            throw new HerdDBInternalException(err);
+        }
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -578,7 +578,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
     }
 
     @Override
-    public void cleanupAfterBoot(
+    public void cleanupAfterTableBoot(
             String tablespace, String name, Set<Long> activePagesAtBoot
     ) {
     }

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -190,6 +190,10 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 realData);
 
         if (nodeId.isEmpty()) {
+            if (ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER.equals(mode)) {
+                throw new RuntimeException("With " + ServerConfiguration.PROPERTY_MODE + "="
+                        + mode + " you must assign " + ServerConfiguration.PROPERTY_NODEID + " explicitly in your server configuration file");
+            }
             LocalNodeIdManager localNodeIdManager = buildLocalNodeIdManager();
             try {
                 nodeId = localNodeIdManager.readLocalNodeId();

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -54,6 +54,7 @@ public final class ServerConfiguration {
     public static final String PROPERTY_MODE_LOCAL = "local";
     public static final String PROPERTY_MODE_STANDALONE = "standalone";
     public static final String PROPERTY_MODE_CLUSTER = "cluster";
+    public static final String PROPERTY_MODE_DISKLESSCLUSTER = "diskless-cluster";
 
     public static final String PROPERTY_BASEDIR = "server.base.dir";
     public static final String PROPERTY_BASEDIR_DEFAULT = "dbdata";

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -246,7 +246,7 @@ public abstract class DataStorageManager implements AutoCloseable {
 
     public abstract RecordSetFactory createRecordSetFactory();
 
-    public abstract void cleanupAfterBoot(String tablespace, String name, Set<Long> activePagesAtBoot)
+    public abstract void cleanupAfterTableBoot(String tablespace, String name, Set<Long> activePagesAtBoot)
             throws DataStorageManagerException;
 
     public abstract void truncateIndex(String tableSpaceUUID, String name) throws DataStorageManagerException;

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperDataStorageManagerRestartTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperDataStorageManagerRestartTest.java
@@ -1,0 +1,61 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.cluster.bookkeeper;
+
+import herddb.cluster.BookKeeperDataStorageManager;
+import herddb.cluster.BookkeeperCommitLogManager;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.core.DBManager;
+import herddb.core.RestartTestBase;
+import herddb.server.ServerConfiguration;
+import herddb.utils.ZKTestEnv;
+import java.nio.file.Path;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.After;
+import org.junit.Before;
+
+public class BookKeeperDataStorageManagerRestartTest extends RestartTestBase {
+
+    ZKTestEnv testEnv;
+
+    @Before
+    public void setup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder("zk").toPath());
+        testEnv.startBookieAndInitCluster();
+    }
+
+    @After
+    public void stop() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+        testEnv = null;
+    }
+
+    protected DBManager buildDBManager(String nodeId, Path metadataPath, Path dataPath, Path logsPath, Path tmoDir) {
+        ZookeeperMetadataStorageManager man = new ZookeeperMetadataStorageManager(testEnv.getAddress(),
+                testEnv.getTimeout(), testEnv.getPath());
+        ServerConfiguration serverConfiguration = new ServerConfiguration();
+        BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE);
+        BookKeeperDataStorageManager dataManager = new BookKeeperDataStorageManager(tmoDir, man, logManager);
+        return new DBManager(nodeId, man, dataManager, logManager, tmoDir, null);
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperDataStorageManagerRestartTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperDataStorageManagerRestartTest.java
@@ -54,7 +54,7 @@ public class BookKeeperDataStorageManagerRestartTest extends RestartTestBase {
                 testEnv.getTimeout(), testEnv.getPath());
         ServerConfiguration serverConfiguration = new ServerConfiguration();
         BookkeeperCommitLogManager logManager = new BookkeeperCommitLogManager(man, serverConfiguration, NullStatsLogger.INSTANCE);
-        BookKeeperDataStorageManager dataManager = new BookKeeperDataStorageManager(tmoDir, man, logManager);
+        BookKeeperDataStorageManager dataManager = new BookKeeperDataStorageManager(nodeId, tmoDir, man, logManager);
         return new DBManager(nodeId, man, dataManager, logManager, tmoDir, null);
     }
 

--- a/herddb-core/src/test/java/herddb/core/BaseTestcase.java
+++ b/herddb-core/src/test/java/herddb/core/BaseTestcase.java
@@ -62,7 +62,7 @@ public class BaseTestcase {
         return new MemoryCommitLogManager();
     }
 
-    protected DataStorageManager makeDataStorageManager() throws Exception {
+    protected DataStorageManager makeDataStorageManager(CommitLogManager commitLog, MetadataStorageManager metadata) throws Exception {
         return new MemoryDataStorageManager();
     }
 
@@ -87,7 +87,7 @@ public class BaseTestcase {
         beforeSetup();
         metadataStorageManager = makeMetadataStorageManager();
         commitLogManager = makeCommitLogManager();
-        dataStorageManager = makeDataStorageManager();
+        dataStorageManager = makeDataStorageManager(commitLogManager, metadataStorageManager);
         System.setErr(System.out);
         manager = new DBManager("localhost", metadataStorageManager, dataStorageManager, commitLogManager, null, null);
         manager.start();

--- a/herddb-core/src/test/java/herddb/core/DropOldPagesTest.java
+++ b/herddb-core/src/test/java/herddb/core/DropOldPagesTest.java
@@ -22,6 +22,8 @@ package herddb.core;
 
 import static org.junit.Assert.assertEquals;
 import herddb.file.FileDataStorageManager;
+import herddb.log.CommitLogManager;
+import herddb.metadata.MetadataStorageManager;
 import herddb.model.Record;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.TransactionContext;
@@ -43,7 +45,7 @@ public class DropOldPagesTest extends BaseTestcase {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Override
-    protected DataStorageManager makeDataStorageManager() {
+    protected DataStorageManager makeDataStorageManager(CommitLogManager commitLog, MetadataStorageManager metadata) {
         try {
             return new FileDataStorageManager(folder.newFolder("data").toPath());
         } catch (IOException err) {

--- a/herddb-core/src/test/java/herddb/core/FileDataStorageManagerRestartTest.java
+++ b/herddb-core/src/test/java/herddb/core/FileDataStorageManagerRestartTest.java
@@ -1,0 +1,151 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.codec.RecordSerializer;
+import herddb.file.FileCommitLogManager;
+import herddb.file.FileDataStorageManager;
+import herddb.file.FileMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.DataScanner;
+import herddb.model.GetResult;
+import herddb.model.Index;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.Table;
+import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateIndexStatement;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.model.commands.CreateTableStatement;
+import herddb.model.commands.GetStatement;
+import herddb.model.commands.InsertStatement;
+import herddb.model.commands.ScanStatement;
+import herddb.server.ServerConfiguration;
+import herddb.sql.TranslatedQuery;
+import herddb.utils.Bytes;
+import java.nio.file.Path;
+import java.util.Collections;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.junit.Test;
+
+public class FileDataStorageManagerRestartTest extends RestartTestBase {
+
+
+    protected DBManager buildDBManager(String nodeId, Path metadataPath, Path dataPath, Path logsPath, Path tmoDir) {
+        return new DBManager(nodeId,
+                new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(dataPath),
+                new FileCommitLogManager(logsPath),
+                tmoDir, null);
+    }
+
+
+    @Test
+    public void recoverTableAndIndexWithoutHash() throws Exception {
+
+        Path dataPath = folder.newFolder("data").toPath();
+        Path logsPath = folder.newFolder("logs").toPath();
+        Path metadataPath = folder.newFolder("metadata").toPath();
+        Path tmpDir = folder.newFolder("tmpDir").toPath();
+
+        String nodeId = "localhost";
+        Table table;
+        Index index;
+
+        try (DBManager manager = new DBManager("localhost", new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(
+                        dataPath, dataPath.resolve("tmp"),
+                        ServerConfiguration.PROPERTY_DISK_SWAP_MAX_RECORDS_DEFAULT,
+                        ServerConfiguration.PROPERTY_REQUIRE_FSYNC_DEFAULT,
+                        ServerConfiguration.PROPERTY_PAGE_USE_ODIRECT_DEFAULT,
+                        ServerConfiguration.PROPERTY_INDEX_USE_ODIRECT_DEFAULT,
+                        false, false, new NullStatsLogger()
+                ),
+                new FileCommitLogManager(logsPath), tmpDir, null)) {
+
+            manager.start();
+
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            assertTrue(manager.waitForTablespace("tblspace1", 10000));
+
+            table = Table
+                    .builder()
+                    .tablespace("tblspace1")
+                    .name("t1")
+                    .column("id", ColumnTypes.INTEGER)
+                    .column("name", ColumnTypes.STRING)
+                    .primaryKey("id")
+                    .build();
+
+            index = Index.builder().onTable(table).column("name", ColumnTypes.STRING).type(Index.TYPE_BRIN).build();
+
+            manager.executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            manager.executeStatement(new InsertStatement("tblspace1", table.name, RecordSerializer.makeRecord(table, "id", 1, "name", "uno")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+
+            GetResult result = manager.get(new GetStatement("tblspace1", table.name, Bytes.from_int(1), null, false), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
+                    TransactionContext.NO_TRANSACTION);
+            assertTrue(result.found());
+
+            /*
+             * Access through index
+             */
+            TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1", Collections.emptyList(), true, true, false, -1);
+            ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+            try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                assertEquals(1, scan1.consume().size());
+            }
+            manager.checkpoint();
+        }
+
+        // Enabling hash-chacking: previous stored hashes (value 0) has not to fail the check.
+        try (DBManager manager = new DBManager("localhost", new FileMetadataStorageManager(metadataPath),
+                new FileDataStorageManager(
+                        dataPath, dataPath.resolve("tmp"),
+                        ServerConfiguration.PROPERTY_DISK_SWAP_MAX_RECORDS_DEFAULT,
+                        ServerConfiguration.PROPERTY_REQUIRE_FSYNC_DEFAULT,
+                        ServerConfiguration.PROPERTY_PAGE_USE_ODIRECT_DEFAULT,
+                        ServerConfiguration.PROPERTY_INDEX_USE_ODIRECT_DEFAULT,
+                        true, true, new NullStatsLogger()
+                ),
+                new FileCommitLogManager(logsPath), tmpDir, null)) {
+
+            manager.start();
+
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
+
+            /*
+             * Access through index
+             */
+            TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1", Collections.emptyList(), true, true, false, -1);
+            ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+            try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                assertEquals(1, scan1.consume().size());
+            }
+        }
+    }
+
+
+}

--- a/herddb-core/src/test/java/herddb/core/FlushFileTest.java
+++ b/herddb-core/src/test/java/herddb/core/FlushFileTest.java
@@ -28,6 +28,7 @@ import herddb.file.FileCommitLog;
 import herddb.file.FileDataStorageManager;
 import herddb.log.CommitLog;
 import herddb.log.CommitLogManager;
+import herddb.metadata.MetadataStorageManager;
 import herddb.model.GetResult;
 import herddb.model.Record;
 import herddb.model.StatementEvaluationContext;
@@ -94,7 +95,7 @@ public class FlushFileTest extends BaseTestcase {
     }
 
     @Override
-    protected DataStorageManager makeDataStorageManager() {
+    protected DataStorageManager makeDataStorageManager(CommitLogManager commitLog, MetadataStorageManager metadata) {
         try {
             return new FileDataStorageManager(folder.newFolder("data").toPath());
         } catch (IOException err) {

--- a/herddb-core/src/test/java/herddb/core/SimpleClusterDisklessTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleClusterDisklessTest.java
@@ -24,9 +24,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import herddb.cluster.BookKeeperDataStorageManager;
 import herddb.cluster.BookkeeperCommitLogManager;
 import herddb.cluster.ZookeeperMetadataStorageManager;
-import herddb.file.FileDataStorageManager;
 import herddb.log.CommitLogManager;
 import herddb.metadata.MetadataStorageManager;
 import herddb.model.GetResult;
@@ -53,7 +53,7 @@ import org.junit.rules.TemporaryFolder;
 /**
  * @author enrico.olivelli
  */
-public class SimpleClusterTest extends BaseTestcase {
+public class SimpleClusterDisklessTest extends BaseTestcase {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -84,7 +84,7 @@ public class SimpleClusterTest extends BaseTestcase {
 
     @Override
     protected DataStorageManager makeDataStorageManager(CommitLogManager commitLog, MetadataStorageManager metadata) throws Exception {
-        return new FileDataStorageManager(folder.newFolder().toPath());
+        return new BookKeeperDataStorageManager(folder.newFolder().toPath(), (ZookeeperMetadataStorageManager) metadata, (BookkeeperCommitLogManager) commitLog);
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/core/SimpleClusterDisklessTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleClusterDisklessTest.java
@@ -84,7 +84,7 @@ public class SimpleClusterDisklessTest extends BaseTestcase {
 
     @Override
     protected DataStorageManager makeDataStorageManager(CommitLogManager commitLog, MetadataStorageManager metadata) throws Exception {
-        return new BookKeeperDataStorageManager(folder.newFolder().toPath(), (ZookeeperMetadataStorageManager) metadata, (BookkeeperCommitLogManager) commitLog);
+        return new BookKeeperDataStorageManager("localhost", folder.newFolder().toPath(), (ZookeeperMetadataStorageManager) metadata, (BookkeeperCommitLogManager) commitLog);
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/server/DisklessClusterTest.java
+++ b/herddb-core/src/test/java/herddb/server/DisklessClusterTest.java
@@ -1,0 +1,176 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.server;
+
+import static org.junit.Assert.assertEquals;
+import herddb.codec.RecordSerializer;
+import herddb.core.TestUtils;
+import herddb.model.ColumnTypes;
+import herddb.model.DataScanner;
+import herddb.model.Index;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.Table;
+import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateIndexStatement;
+import herddb.model.commands.CreateTableStatement;
+import herddb.model.commands.InsertStatement;
+import herddb.utils.ZKTestEnv;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DisklessClusterTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        testEnv.startBookieAndInitCluster();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Test
+    public void testCannotBootWithoutNodeId() throws Exception {
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        try (Server server_1 = new Server(serverconfig_1)) {
+            server_1.start();
+        } catch (RuntimeException err) {
+            assertEquals("With server.mode=diskless-cluster you must assign server.node.id explicitly in your server configuration file", err.getMessage());
+        }
+    }
+
+
+    @Test
+    public void testRestartWithCheckpoint() throws Exception {
+        testRestart(true);
+    }
+
+    @Test
+    public void testRestartWithoutCheckpoint() throws Exception {
+        testRestart(false);
+    }
+
+    private void testRestart(boolean withCheckpoint) throws Exception {
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        try (Server server_1 = new Server(serverconfig_1)) {
+            server_1.start();
+            server_1.waitForTableSpaceBoot(TableSpace.DEFAULT, true);
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .column("d", ColumnTypes.NOTNULL_STRING)
+                    .primaryKey("c")
+                    .build();
+            Index index1 = Index
+                    .builder()
+                    .onTable(table)
+                    .column("d", ColumnTypes.NOTNULL_STRING)
+                    .type(Index.TYPE_BRIN)
+                    .build();
+            Index index2 = Index
+                    .builder()
+                    .onTable(table)
+                    .column("d", ColumnTypes.NOTNULL_STRING)
+                    .column("c", ColumnTypes.NOTNULL_INTEGER)
+                    .type(Index.TYPE_HASH)
+                    .build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 1, "d", "sd")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            server_1.getManager().executeStatement(new CreateIndexStatement(index1), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            server_1.getManager().executeStatement(new CreateIndexStatement(index2), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            server_1.getManager().executeUpdate(new InsertStatement(TableSpace.DEFAULT, "t1", RecordSerializer.makeRecord(table, "c", 2, "d", "sd")), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            try (DataScanner scan = TestUtils.scan(server_1.getManager(), "SELECT * FROM t1", Collections.emptyList());) {
+                assertEquals(2, scan.consume().size());
+            }
+            if (withCheckpoint) {
+                server_1.getManager().checkpoint();
+            }
+        }
+
+        // restart, we are in diskless-mode
+        // the base dir can be changed without problems
+        // usually the server will start on a new machine with ephemeral disk
+        serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+        try (Server server_1 = new Server(serverconfig_1)) {
+            server_1.start();
+            server_1.waitForTableSpaceBoot(TableSpace.DEFAULT, true);
+
+            try (DataScanner scan = TestUtils.scan(server_1.getManager(), "SELECT * FROM t1", Collections.emptyList());) {
+                assertEquals(2, scan.consume().size());
+            }
+        }
+
+        // restart, we are in diskless-mode
+        // the base dir can be changed without problems
+        // usually the server will start on a new machine with ephemeral disk
+        serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+        try (Server server_1 = new Server(serverconfig_1)) {
+            server_1.start();
+            server_1.waitForTableSpaceBoot(TableSpace.DEFAULT, true);
+
+            try (DataScanner scan = TestUtils.scan(server_1.getManager(), "SELECT * FROM t1", Collections.emptyList());) {
+                assertEquals(2, scan.consume().size());
+            }
+        }
+    }
+
+}

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBEmbeddedDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBEmbeddedDataSource.java
@@ -86,7 +86,8 @@ public class HerdDBEmbeddedDataSource extends BasicHerdDBDataSource {
             String mode = serverConfiguration.getString(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_LOCAL);
             if (ServerConfiguration.PROPERTY_MODE_LOCAL.equals(mode)
                     || (ServerConfiguration.PROPERTY_MODE_STANDALONE.equals(mode) && startServer)
-                    || (ServerConfiguration.PROPERTY_MODE_CLUSTER.equals(mode) && startServer)) {
+                    || (ServerConfiguration.PROPERTY_MODE_CLUSTER.equals(mode) && startServer)
+                    || (ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER.equals(mode) && startServer)) {
                 LOGGER.log(Level.INFO, "Booting Local Embedded HerdDB mode, url:" + url + ", properties:" + serverConfiguration);
                 server = new Server(serverConfiguration, statsLogger);
                 try {

--- a/herddb-jdbc/src/test/java/herddb/jdbc/EmbeddedDisklessClusterTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/EmbeddedDisklessClusterTest.java
@@ -1,0 +1,92 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.client.ClientConfiguration;
+import herddb.server.ServerConfiguration;
+import herddb.utils.ZKTestEnv;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Start embedded diskless server. Data is stored on BooKeeper + ZooKeeper
+ *
+ * @author enrico.olivelli
+ */
+public class EmbeddedDisklessClusterTest {
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        testEnv.startBookie();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+
+        try (HerdDBEmbeddedDataSource dataSource = new HerdDBEmbeddedDataSource()) {
+            dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
+            dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+            dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+            dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_NODEID, "my-server");
+            dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
+            dataSource.getProperties().setProperty(ClientConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
+            dataSource.setStartServer(true);
+            try (Connection con = dataSource.getConnection();
+                    Statement statement = con.createStatement()) {
+                statement.execute("CREATE TABLE mytable (key string primary key, name string)");
+                assertEquals(1, statement.executeUpdate("INSERT INTO mytable (key,name) values('k1','name1')"));
+                try (ResultSet rs = statement.executeQuery("SELECT * FROM mytable")) {
+                    boolean found = false;
+                    while (rs.next()) {
+                        String key = rs.getString("key");
+                        String name = rs.getString("name");
+                        assertEquals("k1", key);
+                        assertEquals("name1", name);
+                        found = true;
+                    }
+                    assertTrue(found);
+                }
+            }
+        }
+    }
+
+}

--- a/herddb-jdbc/src/test/java/herddb/jdbc/JdbcDriverDiskLessClusterTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/JdbcDriverDiskLessClusterTest.java
@@ -41,7 +41,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
-public class JdbcDriverZookeeperTest {
+public class JdbcDriverDiskLessClusterTest {
 
     private ZKTestEnv testEnv;
 
@@ -62,12 +62,11 @@ public class JdbcDriverZookeeperTest {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
-    public void test() throws Exception {
-
+    public void testDisklessCluster() throws Exception {
         ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
         serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
-        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
-        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7869);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
         serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
         serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
         serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());

--- a/herddb-jdbc/src/test/java/herddb/jdbc/JdbcDriverZookeeperTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/JdbcDriverZookeeperTest.java
@@ -30,6 +30,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Enumeration;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,8 +88,34 @@ public class JdbcDriverZookeeperTest {
         }
     }
 
-    @After
-    public void destroy() throws Exception {
+    @Test
+    public void testDisklessCluster() throws Exception {
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7869);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        try (Server server = new Server(serverconfig_1)) {
+            server.start();
+            server.waitForStandaloneBoot();
+            try (Connection connection = DriverManager.getConnection("jdbc:herddb:zookeeper:" + testEnv.getAddress() + "" + testEnv.getPath());
+                 Statement statement = connection.createStatement();
+                 ResultSet rs = statement.executeQuery("SELECT * FROM SYSTABLES")) {
+                int count = 0;
+                while (rs.next()) {
+                    System.out.println("table: " + rs.getString(1));
+                    count++;
+                }
+                assertTrue(count > 0);
+            }
+        }
+    }
+
+    @AfterClass
+    public static void destroy() throws Exception {
         for (Enumeration<java.sql.Driver> drivers = DriverManager.getDrivers(); drivers.hasMoreElements(); ) {
             DriverManager.deregisterDriver(drivers.nextElement());
         }

--- a/herddb-jdbc/src/test/java/herddb/jdbc/JdbcJdbcDriverStartDiskLessTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/JdbcJdbcDriverStartDiskLessTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.jdbc;
+
+import static org.junit.Assert.assertTrue;
+import herddb.utils.ZKTestEnv;
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Enumeration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for connections using jdbc driver
+ *
+ * @author enrico.olivelli
+ */
+public class JdbcJdbcDriverStartDiskLessTest {
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        testEnv.startBookie();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testStartServer() throws Exception {
+
+        File dataDirFirstTime = folder.newFolder();
+        String jdbcUrl = "jdbc:herddb:zookeeper:" + testEnv.getAddress() + "" + testEnv.getPath() + "?"
+                + "server.start=true"
+                + "&server.base.dir=" + dataDirFirstTime.getAbsolutePath()
+                + "&server.node.id=nodeid"
+                + "&server.mode=diskless-cluster";
+        try (Connection connection = DriverManager.getConnection(jdbcUrl);
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT * FROM SYSTABLES")) {
+            int count = 0;
+            while (rs.next()) {
+                System.out.println("table: " + rs.getString(1));
+                count++;
+            }
+            assertTrue(count > 0);
+        }
+
+        try (Connection connection = DriverManager.getConnection(jdbcUrl);
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT * FROM SYSTABLES")) {
+            int count = 0;
+            while (rs.next()) {
+                System.out.println("table: " + rs.getString(1));
+                count++;
+            }
+            assertTrue(count > 0);
+        }
+
+    }
+
+    @AfterClass
+    public static void destroy() throws Exception {
+        for (Enumeration<java.sql.Driver> drivers = DriverManager.getDrivers(); drivers.hasMoreElements();) {
+            DriverManager.deregisterDriver(drivers.nextElement());
+        }
+    }
+}

--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# standalone|cluster
+# standalone|cluster|diskless-cluster
 server.mode=standalone
 
 # listening endpoint for client and server-to-server communications
@@ -115,6 +115,8 @@ server.bookkeeper.ledgers.max.size=1073741824
 server.bookkeeper.max.idle.time=10000
 
 # start a bookie inside the same JVM (if the server is started in cluster mode)
+# if you are using diskless-clustermode it is better to not start the embedded
+# bookie, otherwise it is better to start the standard cluster mode
 server.bookkeeper.start=true
 # if you leave port to zero a random port will be used an then persisted to bookie_port file
 # bookkeeper uses local hostname and this port to identify bookies


### PR DESCRIPTION
This is the implementation of a new DataStorageManager totally based on BookKeeper + ZooKeeper.: BookKeeperDataStorageManager

It is supposed to be used in pure cloud environment when you already have a ZooKeeper + BookKeeper cluster and you want to store all of the data on those pods.

A valid use case is for Apache Pulsar Manager, when you already have a BK cluster for Pulsar.

It is expected not to start the Bookie in  "embedded bookie" when working on diskless cluster mode, because it won't make sense at all, using local disk is better if you have a stateful pod for HerdDB it is better to use the default FileDataStorageManager

In order to activate diskless cluster mode you only have to configure:
- server.mode=diskless-cluster
- server.node.id=MYID
- configure ZK settings

server.node.id is required because disk is expected to be ephemeral and we must have a persistent node id.
Data pages and Index pages are stored on BookKeeper, one ledger per page.
Metadata about mapping between HerdDB pages and BK ledgers are stored on ZK.
Every other kind of data and metadata is persisted on ZooKeeper:
- table and index status
- checkpoint information
- temporary transaction during checkpoints

ZK znodes have an hard limit in size, so in the future we have to improve the storage for potentially big data stored on znodes, like the transactions persisted during checkpoint.

Garbage collection works are for all of the other storage engines.

It is expected to use this mode when:
- you do not have persisted disks for HerdDB but you have a BookKeeper and ZooKeeper cluster
- database mostly fits into memory, or you are mostly performing writes over reads
- you have only one HerdDB server (you can still have a replication factor bigger than 1)

Replication:
- replication works as usual, but when you are writing data pages/index pages, data is replicated on bookies
- the replication factor for data is the same as for the WAL
- each server has its own data space on BK + ZK, if you start more servers each server will have its own copy of data, replicated on BK according to the replication factor

It is not expected to run two instances of the same server (identified by the node id), exactly as you do with other modes. Each instance of the server may overwrite data pages leading to data corruption.
This is something we should improve in the future, but it is not a trivial task.
 
 