### PR TITLE
Issue 606: ReadTimeoutException when the connection remains open for too long without load

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -58,8 +58,10 @@ public class ClientConfiguration {
 
     public static final String PROPERTY_BASEDIR = "client.base.dir";
     public static final String PROPERTY_TIMEOUT = "client.timeout";
+    public static final String PROPERTY_NETWORK_TIMEOUT = "client.network.timeout";
     public static final String PROPERTY_CLIENTID = "client.client.id";
     public static final int PROPERTY_TIMEOUT_DEFAULT = 1000 * 60 * 5;
+    public static final int PROPERTY_NETWORK_TIMEOUT_DEFAULT = 0;
     public static final String PROPERTY_CLIENTID_DEFAULT = "localhost";
 
     public static final String PROPERTY_MODE = "client.mode";

--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -159,7 +159,7 @@ public class HDBClient implements AutoCloseable {
     }
 
     Channel createChannelTo(ServerHostData server, ChannelEventListener eventReceiver) throws IOException {
-        int timeoutms = configuration.getInt(ClientConfiguration.PROPERTY_TIMEOUT, ClientConfiguration.PROPERTY_TIMEOUT_DEFAULT);
+        int timeoutms = configuration.getInt(ClientConfiguration.PROPERTY_NETWORK_TIMEOUT, ClientConfiguration.PROPERTY_NETWORK_TIMEOUT_DEFAULT);
         int timeouts = (int) TimeUnit.MILLISECONDS.toSeconds(timeoutms);
         return NettyConnector.connect(server.getHost(), server.getPort(), server.isSsl(), timeoutms, timeouts, eventReceiver, thredpool,
                 networkGroup, localEventsGroup);

--- a/herddb-core/src/test/java/herddb/client/SimpleClientServerTest.java
+++ b/herddb-core/src/test/java/herddb/client/SimpleClientServerTest.java
@@ -830,7 +830,7 @@ public class SimpleClientServerTest {
         clientConfiguration.set(ClientConfiguration.PROPERTY_MAX_CONNECTIONS_PER_SERVER, 1);
         final int timeout = 1000;
         final AtomicInteger channelCreatedCount = new AtomicInteger();
-        clientConfiguration.set(ClientConfiguration.PROPERTY_TIMEOUT, timeout);
+        clientConfiguration.set(ClientConfiguration.PROPERTY_NETWORK_TIMEOUT, timeout);
         try (HDBClient client = new HDBClient(clientConfiguration) {
             @Override
             Channel createChannelTo(ServerHostData server, ChannelEventListener eventReceiver) throws IOException {

--- a/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
@@ -85,7 +85,6 @@ public class NettyConnector {
             b.group(group)
                     .channel(channelType)
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout)
-                    .option(ChannelOption.SO_TIMEOUT, socketTimeout)
                     .handler(new ChannelInitializer<Channel>() {
                                  @Override
                                  public void initChannel(Channel ch) throws Exception {


### PR DESCRIPTION
- drop useless SO_TIMEOUT option
- add test case
- add a new client configuration option client.network.timeout and set it to 0, that means to not handle as an error sockets that do not see activity
- client.timeout is still in place and it is the single timeout for any response

Fixes #606 