### PR TITLE
Fix Benchmarks project after ZK 3.6.x upgrade

### DIFF
--- a/herddb-bench/pom.xml
+++ b/herddb-bench/pom.xml
@@ -37,6 +37,18 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>
-        </dependency>       
+        </dependency>
+        <dependency>
+            <!-- needed for ZK server -->
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- needed for ZK server -->
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Add snappy and metrics dependencies, that are needed by ZK server runtime but are not listed as dependencies in ZK client jar