### PR TITLE
Issue 610 Follower nodes should not try to rollback abandoned transactions

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -814,6 +814,9 @@ public class TableSpaceManager {
     }
 
     void processAbandonedTransactions() {
+        if (!leader) {
+            return;
+        }
         long now = System.currentTimeMillis();
         long timeout = dbmanager.getAbandonedTransactionsTimeout();
         if (timeout <= 0) {


### PR DESCRIPTION
- do not run the abandoned transaction manager while not in leader mode
- prevent followers to try to open new ledgers
- add test case that reproduces the error