### PR TITLE
Add initial support for DATETIME functions

### DIFF
--- a/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
+++ b/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
@@ -22,6 +22,7 @@ package herddb.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.core.DBManager;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
@@ -40,6 +41,7 @@ public class StatementEvaluationContext {
     private TransactionContext transactionContext;
     private String defaultTablespace = TableSpace.DEFAULT;
     private volatile long tableSpaceLock;
+    private static final ZoneId timezone = ZoneId.systemDefault();
 
     // CHECKSTYLE.OFF: MethodName
     public static StatementEvaluationContext DEFAULT_EVALUATION_CONTEXT() {
@@ -99,6 +101,10 @@ public class StatementEvaluationContext {
 
     public void setTableSpaceLock(long tableSpaceLock) {
         this.tableSpaceLock = tableSpaceLock;
+    }
+
+    public ZoneId getTimezone() {
+        return timezone;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledDivideIntExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledDivideIntExpression.java
@@ -1,0 +1,48 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql.expressions;
+
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.utils.SQLRecordPredicateFunctions;
+
+public class CompiledDivideIntExpression extends CompiledBinarySQLExpression {
+
+    public CompiledDivideIntExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
+        super(left, right);
+    }
+
+    @Override
+    public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
+        Object leftValue = left.evaluate(bean, context);
+        Object rightValue = right.evaluate(bean, context);
+        Object res =  SQLRecordPredicateFunctions.divide(leftValue, rightValue);
+        if (res == null) {
+            return null;
+        }
+        if (res instanceof Number) {
+            return ((Number) res).intValue();
+        }
+        throw new StatementExecutionException("Cannot Divide (int) " + leftValue + " and " + rightValue + ": result would be " + res);
+
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
@@ -71,10 +71,8 @@ public class SQLExpressionCompiler {
             SqlOperator op = p.op;
             String name = op.getName();
             CompiledSQLExpression[] operands = new CompiledSQLExpression[p.operands.size()];
-//            System.out.println("operator '" + op + "' with " + p.operands.size() + " ops");
             int i = 0;
             for (RexNode operand : p.operands) {
-//                System.out.println("operand: " + operand);
                 operands[i++] = compileExpression(operand);
             }
             switch (name) {
@@ -103,6 +101,8 @@ public class SQLExpressionCompiler {
                     return new CompiledMultiplyExpression(operands[0], operands[1]);
                 case "/":
                     return new CompiledDivideExpression(operands[0], operands[1]);
+                case "/INT":
+                    return new CompiledDivideIntExpression(operands[0], operands[1]);
                 case "LIKE":
                     return new CompiledLikeExpression(operands[0], operands[1]);
                 case "AND":
@@ -138,6 +138,15 @@ public class SQLExpressionCompiler {
                     return new CompiledFunction(BuiltinFunctions.ABS, Arrays.asList(operands));
                 case BuiltinFunctions.NAME_ROUND:
                     return new CompiledFunction(BuiltinFunctions.ROUND, Arrays.asList(operands));
+                case BuiltinFunctions.NAME_EXTRACT:
+                    return new CompiledFunction(BuiltinFunctions.EXTRACT, Arrays.asList(operands));
+                case BuiltinFunctions.NAME_FLOOR:
+                    return new CompiledFunction(BuiltinFunctions.FLOOR, Arrays.asList(operands));
+                case BuiltinFunctions.NAME_REINTERPRET:
+                    if (operands.length != 1) {
+                        throw new StatementExecutionException("unsupported use of Reinterpret with " + Arrays.toString(operands));
+                    }
+                    return (CompiledSQLExpression) operands[0];
                 default:
                     throw new StatementExecutionException("unsupported operator '" + name + "'");
             }

--- a/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
@@ -55,6 +55,9 @@ public class BuiltinFunctions {
     public static final String UPPER = "upper";
     public static final String ABS = "abs";
     public static final String ROUND = "round";
+    public static final String EXTRACT = "extract";
+    public static final String FLOOR = "floor";
+
     // special
     public static final String CURRENT_TIMESTAMP = "current_timestamp";
     public static final String BOOLEAN_TRUE = "true";
@@ -70,6 +73,10 @@ public class BuiltinFunctions {
     public static final String NAME_UPPER = "UPPER";
     public static final String NAME_ABS = "ABS";
     public static final String NAME_ROUND = "ROUND";
+    public static final String NAME_EXTRACT = "EXTRACT";
+    public static final String NAME_FLOOR = "FLOOR";
+
+    public static final String NAME_REINTERPRET = "Reinterpret";
     // special
     public static final String NAME_CURRENT_TIMESTAMP = "CURRENT_TIMESTAMP";
 
@@ -107,49 +114,6 @@ public class BuiltinFunctions {
                 return new SingleValueCalculator(fieldName, firstParam, context);
             default:
                 return null;
-        }
-    }
-
-    public static boolean isScalarFunction(String name) {
-        switch (name) {
-            case LOWER:
-            case UPPER:
-            case ABS:
-            case ROUND:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    public static boolean isAggregateFunction(String name) {
-        switch (name) {
-            case COUNT:
-            case SUM:
-            case MIN:
-            case MAX:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    public static int typeOfFunction(String lowerCaseName) throws StatementExecutionException {
-        switch (lowerCaseName) {
-            case BuiltinFunctions.COUNT:
-            case BuiltinFunctions.SUM:
-            case BuiltinFunctions.MIN:
-            case BuiltinFunctions.MAX:
-            case BuiltinFunctions.ABS:
-            case BuiltinFunctions.ROUND:
-                return ColumnTypes.LONG;
-
-            case BuiltinFunctions.LOWER:
-            case BuiltinFunctions.UPPER:
-                return ColumnTypes.STRING;
-            default:
-                throw new StatementExecutionException("unhandled function " + lowerCaseName);
-
         }
     }
 

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -126,6 +126,11 @@ public interface SQLRecordPredicateFunctions {
         if (a instanceof Number && b instanceof Number) {
             return ((Number) a).doubleValue() + ((Number) b).doubleValue();
         }
+        if (a instanceof java.sql.Timestamp && b instanceof Long) {
+            // TIMESTAMPADD
+            return new java.sql.Timestamp(((java.sql.Timestamp) a).getTime() + ((Long) b));
+        }
+
         throw new IllegalArgumentException("cannot add " + a + " and " + b);
     }
 
@@ -153,6 +158,10 @@ public interface SQLRecordPredicateFunctions {
         }
         if (a instanceof Number && b instanceof Number) {
             return ((Number) a).doubleValue() - ((Number) b).doubleValue();
+        }
+        if (a instanceof java.sql.Timestamp && b instanceof java.sql.Timestamp) {
+            // TIMESTAMPDIFF
+            return ((java.sql.Timestamp) a).getTime() - ((java.sql.Timestamp) b).getTime();
         }
         throw new IllegalArgumentException("cannot subtract " + a + " and " + b);
     }


### PR DESCRIPTION
- support Date functions (YEAR, MONTH...), this is mapped to the EXTRACT function
- support Reinterpret operator of Calcite
- support for FLOOR(datetime AS DAY), in order to truncate a date to midnight
- support TIMESTAMPDIFF
- support TIMESTAMPADD
- add initial explicit configuration for Calcite (timezone, locale)
- add initial support for "current timezone"

No support for other timezones is still present, it needs lots of work, even on the wire protocol.