### PR TITLE
Implement all JDBC stream based methods for writes

### DIFF
--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
@@ -25,10 +25,16 @@ import herddb.client.DMLResult;
 import herddb.client.HDBException;
 import herddb.client.ScanResultSet;
 import herddb.jdbc.utils.SQLExceptionUtils;
+import herddb.utils.FileUtils;
+import herddb.utils.VisibleByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -136,7 +142,8 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        // TODO: this is an approximation
+        setDouble(parameterIndex, x.doubleValue());
     }
 
     @Override
@@ -163,7 +170,7 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setTime(int parameterIndex, Time x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new SQLException("setTime Not supported yet");
     }
 
     @Override
@@ -174,17 +181,18 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        // in ASCII length in bytes == length in chars
+        setCharacterStream(parameterIndex, new InputStreamReader(x, StandardCharsets.US_ASCII), length);
     }
 
     @Override
     public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, new InputStreamReader(x, StandardCharsets.UTF_8), length);
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setBinaryStream(parameterIndex, x, (long) length);
     }
 
     @Override
@@ -256,32 +264,32 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, reader, (long) length);
     }
 
     @Override
     public void setRef(int parameterIndex, Ref x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new SQLException("setRef is not supported yet");
     }
 
     @Override
     public void setBlob(int parameterIndex, Blob x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setBinaryStream(parameterIndex, x.getBinaryStream());
     }
 
     @Override
     public void setClob(int parameterIndex, Clob x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, x.getCharacterStream());
     }
 
     @Override
     public void setArray(int parameterIndex, Array x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new SQLException("setArray is not supported yet");
     }
 
     @Override
     public ResultSetMetaData getMetaData() throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new SQLException("Not supported yet.");
     }
 
     @Override
@@ -296,7 +304,7 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new SQLException("setTime not supported yet.");
     }
 
     @Override
@@ -312,7 +320,7 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setURL(int parameterIndex, URL x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setString(parameterIndex, x.toString());
     }
 
     @Override
@@ -326,59 +334,65 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
             @Override
             public int isNullable(int param) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                return ParameterMetaData.parameterNullableUnknown;
             }
 
             @Override
             public boolean isSigned(int param) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                // unknown at client side
+                return true;
             }
 
             @Override
             public int getPrecision(int param) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                // unknown at client side
+                return 0;
             }
 
             @Override
             public int getScale(int param) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                // unknown at client side
+                return 0;
             }
 
             @Override
             public int getParameterType(int param) throws SQLException {
+                // unknown at client side
                 return java.sql.Types.OTHER;
             }
 
             @Override
             public String getParameterTypeName(int param) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                // unknown at client side
+                return "object";
             }
 
             @Override
             public String getParameterClassName(int param) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                // unknown at client side
+                return Object.class.getName();
             }
 
             @Override
             public int getParameterMode(int param) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                return ParameterMetaData.parameterModeIn;
             }
 
             @Override
             public <T> T unwrap(Class<T> iface) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                return (T) this;
             }
 
             @Override
             public boolean isWrapperFor(Class<?> iface) throws SQLException {
-                throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                return false;
             }
         };
     }
 
     @Override
     public void setRowId(int parameterIndex, RowId x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new SQLException("setRowId not supported yet.");
     }
 
     @Override
@@ -388,32 +402,32 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, value, length);
     }
 
     @Override
     public void setNClob(int parameterIndex, NClob value) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setNCharacterStream(parameterIndex, value.getCharacterStream());
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setNCharacterStream(parameterIndex, reader, length);
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setBinaryStream(parameterIndex, inputStream, length);
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setNCharacterStream(parameterIndex, reader, length);
     }
 
     @Override
     public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setNCharacterStream(parameterIndex, xmlObject.getCharacterStream());
     }
 
     @Override
@@ -424,52 +438,98 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        // in ASCII length in bytes == length in chars
+        setCharacterStream(parameterIndex, new InputStreamReader(x, StandardCharsets.US_ASCII), length);
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        if (length >= Integer.MAX_VALUE) {
+            throw new SQLException("Cannot send a byte[] larger than " + Integer.MAX_VALUE);
+        }
+        try {
+            VisibleByteArrayOutputStream out = new VisibleByteArrayOutputStream((int) length);
+            // one day we will be able to use InputStream#transferTo
+            long writtenCount = FileUtils.copyStreams(x, out, length);
+            if (writtenCount != length) {
+                throw new SQLException("The supplied inputstream returned only " + writtenCount + " bytes, exptected " + length);
+            }
+            // toByteArrayNoCopy won't create an additional copy if not needed
+            setBytes(parameterIndex, out.toByteArrayNoCopy());
+        } catch (IOException ex) {
+            throw new SQLException(ex);
+        }
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        if (length >= Integer.MAX_VALUE) {
+            throw new SQLException("Cannot handle a value larger that " + Integer.MAX_VALUE + " chars");
+        }
+        try {
+            CharBuffer buffer = CharBuffer.allocate((int) length);
+            int readCount = reader.read(buffer);
+            if (readCount != length) {
+                throw new IOException("short read from " + reader + ", read " + readCount + " characters, expected " + length);
+            }
+            buffer.flip();
+            setString(parameterIndex, buffer.toString());
+        } catch (IOException iOException) {
+            throw new SQLException(iOException);
+        }
     }
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, new InputStreamReader(x, StandardCharsets.US_ASCII));
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        try {
+            VisibleByteArrayOutputStream out = new VisibleByteArrayOutputStream();
+            // one day we will be able to use InputStream#transferTo
+            FileUtils.copyStreams(x, out);
+            setBytes(parameterIndex, out.toByteArray());
+        } catch (IOException ex) {
+            throw new SQLException(ex);
+        }
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        try {
+            // one day we will be able to use Reader#transferTo
+            char[] arr = new char[8 * 1024];
+            StringBuilder buffer = new StringBuilder();
+            int numCharsRead;
+            while ((numCharsRead = reader.read(arr, 0, arr.length)) != -1) {
+                buffer.append(arr, 0, numCharsRead);
+            }
+            setString(parameterIndex, buffer.toString());
+        } catch (IOException iOException) {
+            throw new SQLException(iOException);
+        }
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, value);
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, reader);
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setBinaryStream(parameterIndex, inputStream);
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
-        throw new SQLException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        setCharacterStream(parameterIndex, reader);
     }
 
     @Override

--- a/herddb-jdbc/src/test/java/herddb/jdbc/StreamBasedWritesTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/StreamBasedWritesTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.server.StaticClientSideMetadataProvider;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.sql.Blob;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class StreamBasedWritesTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+        try (Server server = new Server(new ServerConfiguration(folder.newFolder().toPath()))) {
+            server.start();
+            server.waitForStandaloneBoot();
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()))) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+                try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client);  Connection con = dataSource.getConnection();  Statement statement = con.createStatement()) {
+                    statement.execute("CREATE TABLE mytable ("
+                            + "key int primary key,"
+                            + "valstring string,"
+                            + "valbinary blob"
+                            + ")");
+
+                    String myString = "mystring";
+                    byte[] myBinary = "mybinary".getBytes(StandardCharsets.UTF_8);
+
+                    String myShortString = "my";
+                    byte[] myShortBinary = "my".getBytes(StandardCharsets.UTF_8);
+
+                    Set<Integer> shorterValues = new HashSet<>();
+                    try (PreparedStatement insert = con.prepareStatement("INSERT INTO mytable (key,valstring,valbinary ) values(?,?,?)")) {
+
+                        int i = 0;
+
+                        insert.setInt(1, i);
+                        insert.setString(2, myString);
+                        insert.setBytes(3, myBinary);
+                        insert.executeUpdate();
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setCharacterStream(2, new StringReader(myString));
+                        insert.setBinaryStream(3, new ByteArrayInputStream(myBinary));
+                        insert.executeUpdate();
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setNCharacterStream(2, new StringReader(myString));
+                        insert.setBinaryStream(3, new ByteArrayInputStream(myBinary));
+                        insert.executeUpdate();
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setCharacterStream(2, new StringReader(myString), 2);
+                        insert.setBinaryStream(3, new ByteArrayInputStream(myBinary), 2);
+                        insert.executeUpdate();
+                        shorterValues.add(i);
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setNCharacterStream(2, new StringReader(myString), 2);
+                        insert.setBinaryStream(3, new ByteArrayInputStream(myBinary), 2L);
+                        insert.executeUpdate();
+                        shorterValues.add(i);
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setClob(2, new StringReader(myString));
+                        insert.setBlob(3, new ByteArrayInputStream(myBinary));
+                        insert.executeUpdate();
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setClob(2, new StringReader(myString), 2);
+                        insert.setBlob(3, new ByteArrayInputStream(myBinary), 2);
+                        insert.executeUpdate();
+                        shorterValues.add(i);
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setAsciiStream(2, new ByteArrayInputStream(myString.getBytes(StandardCharsets.US_ASCII)), 2);
+                        insert.setBlob(3, new ByteArrayInputStream(myBinary), 2);
+                        insert.executeUpdate();
+                        shorterValues.add(i);
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setAsciiStream(2, new ByteArrayInputStream(myString.getBytes(StandardCharsets.US_ASCII)));
+                        insert.setBlob(3, new ByteArrayInputStream(myBinary));
+                        insert.executeUpdate();
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setAsciiStream(2, new ByteArrayInputStream(myString.getBytes(StandardCharsets.US_ASCII)), 2L);
+                        insert.setBlob(3, new ByteArrayInputStream(myBinary), 2);
+                        insert.executeUpdate();
+                        shorterValues.add(i);
+
+                        i++;
+
+                        insert.setInt(1, i);
+                        insert.setUnicodeStream(2, new ByteArrayInputStream(myString.getBytes(StandardCharsets.US_ASCII)), 2);
+                        insert.setBlob(3, new ByteArrayInputStream(myBinary), 2);
+                        insert.executeUpdate();
+                        shorterValues.add(i);
+
+                    }
+
+                    try (PreparedStatement ps = con.prepareStatement("SELECT key,valstring,valbinary"
+                            + " FROM mytable ORDER BY key");  ResultSet rs = ps.executeQuery()) {
+                        while (rs.next()) {
+                            int key = rs.getInt(1);
+                            if (shorterValues.contains(key)) {
+                                checkString(rs, 2, myShortString, key);
+                                checkBlob(rs, 3, myShortBinary, key);
+                            } else {
+                                checkString(rs, 2, myString, key);
+                                checkBlob(rs, 3, myBinary, key);
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+
+    private static void checkString(ResultSet rs, int index, Object expected, int key) {
+        try {
+            String actual = rs.getString(index);
+            Assert.assertEquals("error at key " + key, expected, actual);
+
+            Object object = rs.getObject(index);
+            Assert.assertEquals("error at key " + key, expected, object);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void checkBlob(ResultSet rs, int index, byte[] expected, int key) {
+        try {
+            byte[] actual = rs.getBytes(index);
+            Assert.assertArrayEquals(expected, actual);
+
+            if (expected != null) {
+                DataInputStream dataInputStream = new DataInputStream(rs.getBinaryStream(index));
+                byte[] actualFromStream = new byte[actual.length];
+                dataInputStream.readFully(actualFromStream);
+                Assert.assertArrayEquals("error at key " + key, expected, actualFromStream);
+
+                Blob blob = rs.getBlob(index);
+                assertEquals("error at key " + key, blob.length(), actual.length);
+
+                DataInputStream dataInputStream2 = new DataInputStream(blob.getBinaryStream());
+                byte[] actualFromStream2 = new byte[actual.length];
+                dataInputStream2.readFully(actualFromStream2);
+                Assert.assertArrayEquals("error at key " + key, expected, actualFromStream2);
+            }
+
+            byte[] object = (byte[]) rs.getObject(index);
+            Assert.assertArrayEquals((byte[]) expected, object);
+        } catch (SQLException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
Implement all JDBC PreparedStatement methods regarding Character streams, Binary streams, Blobs and Clobs.
The implementation is trivial and it simply fallback to `setString` and to `setBytes`.

Implement all of the other methods that can be implemented (all except setTime and setRef, for which we do not have support in HerdDB)


fixes #633