### PR TITLE
Basic implementation for 'FOR UPDATE' clause

### DIFF
--- a/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
+++ b/herddb-collections/src/main/java/herddb/collections/CollectionsManager.java
@@ -199,7 +199,7 @@ public final class CollectionsManager implements AutoCloseable {
                 .tablespace(TableSpace.DEFAULT)
                 .build();
         CreateTableStatement createTable = new CreateTableStatement(table);
-        tableSpaceManager.executeStatement(createTable, new StatementEvaluationContext(), TransactionContext.NO_TRANSACTION);
+        tableSpaceManager.executeStatement(createTable, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
         return table;
     }
 

--- a/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
+++ b/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
@@ -72,6 +72,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
         private final V value;
 
         public PutStatementEvaluationContext(K key, V value) {
+            super(false);
             this.key = key;
             this.value = value;
         }
@@ -137,7 +138,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
     @Override
     public void close() {
         DropTableStatement drop = new DropTableStatement(TableSpace.DEFAULT, tmpTableName, true);
-        tableSpaceManager.executeStatement(drop, new StatementEvaluationContext(),
+        tableSpaceManager.executeStatement(drop, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
                 herddb.model.TransactionContext.NO_TRANSACTION);
     }
 
@@ -196,7 +197,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
     public void forEach(BiSink<K, V> sink) throws CollectionsException, SinkException {
 
         try (DataScanner dataScanner =
-                     tableSpaceManager.scan(scan, new StatementEvaluationContext(), TransactionContext.NO_TRANSACTION,
+                     tableSpaceManager.scan(scan, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION,
                              false,
                              false)) {
             while (dataScanner.hasNext()) {
@@ -228,7 +229,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
     public void clear() throws CollectionsException {
         try {
             tableSpaceManager.executeStatement(new TruncateTableStatement(tmpTableName, tmpTableName),
-                    new StatementEvaluationContext(), TransactionContext.NO_TRANSACTION);
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
         } catch (HerdDBInternalException err) {
             throw new CollectionsException(err);
         }
@@ -237,7 +238,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
     @Override
     public void forEachKey(Sink<K> sink) throws CollectionsException, SinkException {
         try (DataScanner dataScanner =
-                     tableSpaceManager.scan(scan, new StatementEvaluationContext(), TransactionContext.NO_TRANSACTION,
+                     tableSpaceManager.scan(scan, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION,
                              false,
                              false)) {
             while (dataScanner.hasNext()) {
@@ -267,7 +268,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
             GetStatement get = new GetStatement(TableSpace.DEFAULT, tmpTableName, Bytes.from_array(serializedKey), null,
                     false);
             GetResult getResult = (GetResult) tableSpaceManager.executeStatement(get,
-                    new StatementEvaluationContext(),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
                     herddb.model.TransactionContext.NO_TRANSACTION);
             if (!getResult.found()) {
                 return null;
@@ -285,7 +286,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
             GetStatement get = new GetStatement(TableSpace.DEFAULT, tmpTableName, Bytes.from_array(serializedKey), null,
                     false);
             GetResult getResult = (GetResult) tableSpaceManager.executeStatement(get,
-                    new StatementEvaluationContext(),
+                    StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(),
                     herddb.model.TransactionContext.NO_TRANSACTION);
             return getResult.found();
         } catch (HerdDBInternalException err) {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1424,7 +1424,7 @@ public class TableSpaceManager {
             } catch (IllegalArgumentException error) {
                 throw new StatementExecutionException(error);
             }
-            validateAlterTable(newTable, null);
+            validateAlterTable(newTable, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT());
             LogEntry entry = LogEntryFactory.alterTable(newTable, null);
             try {
                 CommitLogResult pos = log.log(entry, entry.transactionId <= 0);

--- a/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
+++ b/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
@@ -42,12 +42,18 @@ public class StatementEvaluationContext {
     private String defaultTablespace = TableSpace.DEFAULT;
     private volatile long tableSpaceLock;
     private static final ZoneId timezone = ZoneId.systemDefault();
+    private final boolean forceAcquireWriteLock;
 
     // CHECKSTYLE.OFF: MethodName
     public static StatementEvaluationContext DEFAULT_EVALUATION_CONTEXT() {
-        return new StatementEvaluationContext();
+        return new StatementEvaluationContext(false);
     }
     // CHECKSTYLE.ON: MethodName
+
+    protected StatementEvaluationContext(boolean forceAcquireWriteLock) {
+        this.forceAcquireWriteLock = forceAcquireWriteLock;
+    }
+
 
     public String getDefaultTablespace() {
         return defaultTablespace;
@@ -105,6 +111,10 @@ public class StatementEvaluationContext {
 
     public ZoneId getTimezone() {
         return timezone;
+    }
+
+    public boolean isForceAcquireWriteLock() {
+        return forceAcquireWriteLock;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -856,7 +856,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
 //            LOGGER.log(Level.SEVERE, "statement " + statement);
             CompletableFuture<StatementExecutionResult> res = server
                     .getManager()
-                    .executeStatementAsync(statement, new StatementEvaluationContext(), transactionContext);
+                    .executeStatementAsync(statement, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), transactionContext);
 //                    LOGGER.log(Level.SEVERE, "query " + query + ", " + parameters + ", result:" + result);
             res.whenComplete((result, err) -> {
                 try {

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -232,16 +232,16 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
         if (allowCache) {
             ExecutionPlan cached = cache.get(cacheKey);
             if (cached != null) {
-                return new TranslatedQuery(cached, new SQLStatementEvaluationContext(query, parameters));
+                return new TranslatedQuery(cached, new SQLStatementEvaluationContext(query, parameters, false));
             }
         }
         if (query.startsWith(CalcitePlanner.TABLE_CONSISTENCY_COMMAND)) {
             ExecutionPlan executionPlan = ExecutionPlan.simple(DDLSQLPlanner.this.queryConsistencyCheckStatement(defaultTableSpace, query, parameters));
-            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters));
+            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false));
         }
         if (query.startsWith(CalcitePlanner.TABLESPACE_CONSISTENCY_COMMAND)) {
             ExecutionPlan executionPlan = ExecutionPlan.simple(DDLSQLPlanner.this.queryConsistencyCheckStatement(query));
-            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters));
+            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false));
         }
 
         net.sf.jsqlparser.statement.Statement stmt = parseStatement(query);
@@ -252,7 +252,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
         if (allowCache) {
             cache.put(cacheKey, executionPlan);
         }
-        return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters));
+        return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false));
 
     }
 

--- a/herddb-core/src/main/java/herddb/sql/SQLStatementEvaluationContext.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLStatementEvaluationContext.java
@@ -42,7 +42,8 @@ public class SQLStatementEvaluationContext extends StatementEvaluationContext {
         return jdbcParameters;
     }
 
-    public SQLStatementEvaluationContext(String query, List<Object> jdbcParameters) {
+    public SQLStatementEvaluationContext(String query, List<Object> jdbcParameters, boolean forceAcquireWriteLock) {
+        super(forceAcquireWriteLock);
         this.query = query;
         this.jdbcParameters = jdbcParameters;
         final int len = jdbcParameters.size();

--- a/herddb-core/src/test/java/herddb/sql/SQLRecordPredicateTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SQLRecordPredicateTest.java
@@ -75,7 +75,7 @@ public class SQLRecordPredicateTest {
 
                 assertTrue(pred.getWhere() != null && (pred.getWhere() instanceof CompiledSQLExpression));
 
-                StatementEvaluationContext ctx = new SQLStatementEvaluationContext("the-query", Arrays.asList("my-string"));
+                StatementEvaluationContext ctx = new SQLStatementEvaluationContext("the-query", Arrays.asList("my-string"), false);
 
                 Record record = RecordSerializer.makeRecord(table, "pk", "test", "name", "myname");
                 assertEquals(Boolean.TRUE, pred.evaluate(record, ctx));


### PR DESCRIPTION
Implementation of SELECT .... FOR UPDATE.

If you issue "SELECT .... FOR UPDATE" the transaction will hold "WRITE" locks for every record returned by the query (both SCANs and GETs).

Traditionally if you do not add "FOR UPDATE" the transaction holds only "READ" locks for every record return by the query, this behaviour is not changed.

Unfortunately the detection of "FOR UPDATE" syntax is quite hacky, because Apache Calcite does not still implement it.

This implementation will ease the compatibility with JPA providers

fixes #631 

Once #637 is in we can change the OpenJPA test case and let it use "FOR UPDATE" syntax 