### PR TITLE
Do not pool connections in JDBC Driver by default

### DIFF
--- a/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/BasicHerdDBDataSource.java
@@ -169,6 +169,9 @@ public class BasicHerdDBDataSource implements javax.sql.DataSource, AutoCloseabl
     }
 
     public synchronized void setPoolConnections(boolean poolConnections) {
+        if (client != null || pool != null) {
+            throw new IllegalStateException("Cannot set poolConections=" + poolConnections + " once bootstrap is completed");
+        }
         this.poolConnections = poolConnections;
     }
 

--- a/herddb-jdbc/src/main/java/herddb/jdbc/Driver.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/Driver.java
@@ -78,6 +78,11 @@ public class Driver implements java.sql.Driver, AutoCloseable {
              */
             ds = new HerdDBEmbeddedDataSource(info);
             ds.setUrl(url);
+            if (!url.contains("poolConnections") && !info.containsKey("poolConnections")) {
+                // default to not pooling connections if not configured explicitly
+                // usually JDBC Driver users use their own pool
+                ds.setPoolConnections(false);
+            }
             final DataSourceManager dr = this;
             ds.setOnAutoClose(d -> {
                 synchronized (dr) {

--- a/herddb-jdbc/src/test/java/herddb/jdbc/ConnectionPoolMaxActiveTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/ConnectionPoolMaxActiveTest.java
@@ -1,26 +1,27 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import herddb.client.ClientConfiguration;
 import herddb.server.Server;
@@ -44,15 +45,14 @@ public class ConnectionPoolMaxActiveTest {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
-    public void test() throws Exception {
+    public void testMaxActive() throws Exception {
 
         try (HerdDBEmbeddedDataSource dataSource = new HerdDBEmbeddedDataSource()) {
             dataSource.setMaxActive(20);
 
             dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
             dataSource.getProperties().setProperty(ClientConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
-            try (Connection con = dataSource.getConnection();
-                 Statement statement = con.createStatement()) {
+            try (Connection con = dataSource.getConnection();  Statement statement = con.createStatement()) {
                 statement.execute("CREATE TABLE mytable (key string primary key, name string)");
             }
 
@@ -74,6 +74,57 @@ public class ConnectionPoolMaxActiveTest {
                 }
             }
 
+        }
+    }
+
+    @Test
+    public void testDoNotPoolConnections() throws Exception {
+        testPoolConnections(false);
+    }
+
+    @Test
+    public void testDoPoolConnections() throws Exception {
+        testPoolConnections(true);
+    }
+
+    private void testPoolConnections(boolean poolConnections) throws Exception {
+
+        try (HerdDBEmbeddedDataSource dataSource = new HerdDBEmbeddedDataSource()) {
+            dataSource.setPoolConnections(poolConnections);
+
+            dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
+            dataSource.getProperties().setProperty(ClientConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
+            try (Connection con = dataSource.getConnection();
+                    Statement statement = con.createStatement()) {
+                statement.execute("CREATE TABLE mytable (key string primary key, name string)");
+            }
+
+            Server server = dataSource.getServer();
+
+            List<Connection> connections = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                try (Connection con = dataSource.getConnection();) {
+                    connections.add(con);
+                    try (Statement statement = con.createStatement()) {
+                        assertEquals(1, statement.executeUpdate("INSERT INTO mytable (key,name) values('k1" + i + "','name1')"));
+                    }
+                }
+            }
+            // this is the number of sockets
+            assertTrue(server.getConnectionCount() >= 1);
+
+            // check that we always got a different object if poolConnections=false
+            for (int i = 0; i < connections.size(); i++) {
+                for (int j = 0; j < connections.size(); j++) {
+                    if (poolConnections) {
+                        assertSame(connections.get(i), connections.get(j));
+                    } else {
+                        if (j != i) {
+                            assertNotSame(connections.get(i), connections.get(j));
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- introduce property poolConnections to specify use of Commons Pool for JDBC DataSource
- enable it by default for DataSources
- disable it by default for JDBC Driver

The idea is that users of the pure JDBC Driver normally use their own pool, like https://github.com/brettwooldridge/HikariCP, there is no need to add the cost of a useless pool 