### PR TITLE
Issue 625: Allow indexing of NULL values for single column indexes

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1095,7 +1095,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             try {
                 DataAccessor values = new Record(key, Bytes.from_array(value)).getDataAccessor(table);
                 for (AbstractIndexManager index : indexes.values()) {
-                    RecordSerializer.validatePrimaryKey(values, index.getIndex(), index.getColumnNames());
+                    RecordSerializer.validateIndexableValue(values, index.getIndex(), index.getColumnNames());
                 }
             } catch (IllegalArgumentException err) {
                 return FutureUtils.exception(new StatementExecutionException(err.getMessage(), err));
@@ -1230,7 +1230,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         if (indexes != null) {
                             DataAccessor values = new Record(actual.key, Bytes.from_array(newValue)).getDataAccessor(table);
                             for (AbstractIndexManager index : indexes.values()) {
-                                RecordSerializer.validatePrimaryKey(values, index.getIndex(), index.getColumnNames());
+                                RecordSerializer.validateIndexableValue(values, index.getIndex(), index.getColumnNames());
                             }
                         }
                     } catch (IllegalArgumentException | StatementExecutionException err) {

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -273,6 +273,9 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
 
     @Override
     public void recordDeleted(Bytes key, Bytes indexKey) {
+        if (indexKey == null) {
+            return;
+        }
         removeValueFromIndex(indexKey, key);
     }
 
@@ -289,6 +292,9 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
 
     @Override
     public void recordInserted(Bytes key, Bytes indexKey) {
+        if (indexKey == null) {
+            return;
+        }
         addValueToIndex(indexKey, key);
     }
 

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -247,7 +247,7 @@ public class BRINIndexManager extends AbstractIndexManager {
 
     @Override
     protected boolean doStart(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
-        LOGGER.log(Level.SEVERE, " start BRIN index {0} uuid {1}", new Object[]{index.name, index.uuid});
+        LOGGER.log(Level.INFO, " start BRIN index {0} uuid {1}", new Object[]{index.name, index.uuid});
 
         dataStorageManager.initIndex(tableSpaceUUID, index.uuid);
 
@@ -256,7 +256,7 @@ public class BRINIndexManager extends AbstractIndexManager {
         if (LogSequenceNumber.START_OF_TIME.equals(sequenceNumber)) {
             /* Empty index (booting from the start) */
             this.data.boot(BlockRangeIndexMetadata.empty());
-            LOGGER.log(Level.SEVERE, "loaded empty index {0}", new Object[]{index.name});
+            LOGGER.log(Level.INFO, "loaded empty index {0}", new Object[]{index.name});
 
             return true;
         } else {
@@ -301,7 +301,7 @@ public class BRINIndexManager extends AbstractIndexManager {
             recordInserted(key, indexKey);
         });
         long _stop = System.currentTimeMillis();
-        LOGGER.log(Level.SEVERE, "rebuilding index {0} took {1}", new Object[]{index.name, (_stop - _start) + " ms"});
+        LOGGER.log(Level.INFO, "rebuilding index {0} took {1}", new Object[]{index.name, (_stop - _start) + " ms"});
     }
 
     @Override
@@ -418,11 +418,17 @@ public class BRINIndexManager extends AbstractIndexManager {
 
     @Override
     public void recordDeleted(Bytes key, Bytes indexKey) {
+        if (indexKey == null) {
+            return;
+        }
         data.delete(indexKey, key);
     }
 
     @Override
     public void recordInserted(Bytes key, Bytes indexKey) {
+        if (indexKey == null) {
+            return;
+        }
         data.put(indexKey, key);
     }
 

--- a/herddb-core/src/main/java/herddb/model/ColumnsList.java
+++ b/herddb-core/src/main/java/herddb/model/ColumnsList.java
@@ -32,4 +32,6 @@ public interface ColumnsList {
     Column getColumn(String name);
 
     String[] getPrimaryKey();
+
+    boolean allowNullsForIndexedValues();
 }

--- a/herddb-core/src/main/java/herddb/model/Index.java
+++ b/herddb-core/src/main/java/herddb/model/Index.java
@@ -59,6 +59,13 @@ public class Index implements ColumnsList {
         return columnNames;
     }
 
+    @Override
+    public boolean allowNullsForIndexedValues() {
+        // for single column indexes we can support null values
+        // they usually won't be indexed, but this fact depends on the index implemention.
+        return columnNames.length == 1;
+    }
+
     private Index(
             String uuid,
             String name, String table, String tablespace, String type, Column[] columns

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -239,6 +239,13 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
         return primaryKey;
     }
 
+    @Override
+    public boolean allowNullsForIndexedValues() {
+        // this refers to the PK, the PK cannot be NULL
+        return false;
+    }
+
+
     public Table applyAlterTable(AlterTableStatement alterTableStatement) {
         int new_maxSerialPosition = this.maxSerialPosition;
         String newTableName = alterTableStatement.getNewTableName() != null ? alterTableStatement.getNewTableName().toLowerCase()

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -451,7 +451,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                 throw new TableDoesNotExistException("no such table " + tableName + " in tablespace " + tableSpace);
             }
             for (String columnName : s.getIndex().getColumnsNames()) {
-                columnName = columnName.toLowerCase();
+                columnName = fixMySqlBackTicks(columnName.toLowerCase());
                 Column column = tableDefinition.getTable().getColumn(columnName);
                 if (column == null) {
                     throw new StatementExecutionException(

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -433,9 +433,10 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
             if (tableSpace == null) {
                 tableSpace = defaultTableSpace;
             }
-            String tableName = s.getTable().getName().toLowerCase();
+            tableSpace = fixMySqlBackTicks(tableSpace);
+            String tableName = fixMySqlBackTicks(s.getTable().getName().toLowerCase());
 
-            String indexName = s.getIndex().getName().toLowerCase();
+            String indexName = fixMySqlBackTicks(s.getIndex().getName().toLowerCase());
             String indexType = convertIndexType(s.getIndex().getType());
 
             herddb.model.Index.Builder builder = herddb.model.Index

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -2360,16 +2360,17 @@ public class RawSQLTest {
 
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
 
-            execute(manager, "CREATE INDEX `ix1` ON tblspace1.`tsql`(`n1`,`s1`)", Collections.emptyList());
+            execute(manager, "CREATE INDEX `ix1` ON `tblspace1`.`tsql`(`n1`,`s1`)", Collections.emptyList());
 
 
             try {
-            executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", null));
+                executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", null));
                 fail("nulls are not allowed on indexed columns");
             } catch (StatementExecutionException ok) {
             }
 
-            executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", 213));
+            executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,s1) values(?,?,?)", Arrays.asList("mykey", 213, "a"));
+
             try {
                 executeUpdate(manager, "UPDATE tblspace1.tsql set n1=null where k1 = ?", Arrays.asList("mykey"));
                 fail("nulls are not allowed on indexed columns");
@@ -2377,7 +2378,7 @@ public class RawSQLTest {
             }
 
             try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=213", Arrays.asList())) {
-                assertEquals(2, scan.consume().size());
+                assertEquals(1, scan.consume().size());
             }
         }
     }

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -20,7 +20,6 @@
 
 package herddb.core;
 
-import static herddb.core.TestUtils.beginTransaction;
 import static herddb.core.TestUtils.commitTransaction;
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.executeUpdate;
@@ -2319,7 +2318,7 @@ public class RawSQLTest {
     }
 
     @Test
-    public void createNullNotIndexable() throws Exception {
+    public void allowNullsInSingleColumnSecondaryIndexes() throws Exception {
         String nodeId = "localhost";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
@@ -2329,10 +2328,43 @@ public class RawSQLTest {
 
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
 
-            execute(manager, "CREATE INDEX ix1 ON tblspace1.tsql(n1)", Collections.emptyList());
+            execute(manager, "CREATE INDEX `ix1` ON tblspace1.tsql(`n1`)", Collections.emptyList());
+
+            executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", null));
+
+            executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey2", 213));
+
+            try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=213", Arrays.asList())) {
+                assertEquals(1, scan.consume().size());
+            }
+            executeUpdate(manager, "UPDATE tblspace1.tsql set n1=null where k1 = ?", Arrays.asList("mykey2"));
+
+            try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=213", Arrays.asList())) {
+                assertEquals(0, scan.consume().size());
+            }
+
+            try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1 is null", Arrays.asList())) {
+                assertEquals(2, scan.consume().size());
+            }
+        }
+    }
+
+     @Test
+    public void createNullNotIndexableInMultiColumnIndex() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+
+            execute(manager, "CREATE INDEX `ix1` ON tblspace1.`tsql`(`n1`,`s1`)", Collections.emptyList());
+
 
             try {
-                executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", null));
+            executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey", null));
                 fail("nulls are not allowed on indexed columns");
             } catch (StatementExecutionException ok) {
             }
@@ -2343,22 +2375,6 @@ public class RawSQLTest {
                 fail("nulls are not allowed on indexed columns");
             } catch (StatementExecutionException ok) {
             }
-
-            long tx = beginTransaction(manager, "tblspace1");
-            // now during a transaction
-            try {
-                executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey2", null), new TransactionContext(tx));
-                fail("nulls are not allowed on indexed columns");
-            } catch (StatementExecutionException ok) {
-            }
-
-            executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1) values(?,?)", Arrays.asList("mykey2", 213), new TransactionContext(tx));
-            try {
-                executeUpdate(manager, "UPDATE tblspace1.tsql set n1=null where k1 = ?", Arrays.asList("mykey2"), new TransactionContext(tx));
-                fail("nulls are not allowed on indexed columns");
-            } catch (StatementExecutionException ok) {
-            }
-            commitTransaction(manager, "tblspace1", tx);
 
             try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql WHERE n1=213", Arrays.asList())) {
                 assertEquals(2, scan.consume().size());


### PR DESCRIPTION
- allow NULLs on columns indexed by single column indexes
- multi column indexes still do not support null values
- "IS NULL" and "IS NOT NULL" clauses does not take indexes into account, the index contains only non-null values

Relates to #625
