### PR TITLE
Speed time boot time for in-memory database

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -97,6 +97,10 @@ public class ClientConfiguration {
     public static final int PROPERTY_CLIENT_CALLBACKS_DEFAULT = 64;
     public static final String PROPERTY_CLIENT_CALLBACKS = "client.network.thread.callback";
 
+    public static final String PROPERTY_CLIENT_CONNECT_REMOTE_SERVER = "client.network.connect.remote";
+    public static final boolean PROPERTY_CLIENT_CONNECT_REMOTE_SERVER_DEFAULT = true;
+
+
     public ClientConfiguration(Properties properties) {
         this.properties = new Properties();
         this.properties.putAll(properties);
@@ -200,6 +204,9 @@ public class ClientConfiguration {
                     set(PROPERTY_SERVER_PORT, 0);
                 }
             }
+            set(PROPERTY_CLIENT_CALLBACKS, 4);
+            set(PROPERTY_MAX_CONNECTIONS_PER_SERVER, 1);
+            set(PROPERTY_CLIENT_CONNECT_REMOTE_SERVER, false);
         }
         if (questionMark < url.length()) {
             String qs = url.substring(questionMark + 1);

--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -72,6 +72,7 @@ public class HDBClient implements AutoCloseable {
         this.statsLogger = statsLogger.scope("hdbclient");
 
         int corePoolSize = configuration.getInt(ClientConfiguration.PROPERTY_CLIENT_CALLBACKS, ClientConfiguration.PROPERTY_CLIENT_CALLBACKS_DEFAULT);
+        boolean connectRemoteServers = configuration.getBoolean(ClientConfiguration.PROPERTY_CLIENT_CONNECT_REMOTE_SERVER, ClientConfiguration.PROPERTY_CLIENT_CONNECT_REMOTE_SERVER_DEFAULT);
         this.maxOperationRetryCount = configuration.getInt(ClientConfiguration.PROPERTY_MAX_OPERATION_RETRY_COUNT, ClientConfiguration.PROPERTY_MAX_OPERATION_RETRY_COUNT_DEFAULT);
         this.operationRetryDelay = configuration.getInt(ClientConfiguration.PROPERTY_OPERATION_RETRY_DELAY, ClientConfiguration.PROPERTY_OPERATION_RETRY_DELAY_DEFAULT);
         this.thredpool = new ThreadPoolExecutor(corePoolSize, Integer.MAX_VALUE,
@@ -82,7 +83,7 @@ public class HDBClient implements AutoCloseable {
                     t.setDaemon(true);
                     return t;
                 });
-        this.networkGroup = NetworkUtils.isEnableEpoolNative() ? new EpollEventLoopGroup() : new NioEventLoopGroup();
+        this.networkGroup = connectRemoteServers ? (NetworkUtils.isEnableEpoolNative() ? new EpollEventLoopGroup() : new NioEventLoopGroup()) : null;
         this.localEventsGroup = new DefaultEventLoopGroup();
         String mode = configuration.getString(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_LOCAL);
         switch (mode) {

--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -710,8 +710,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             String lastFile = getLastTableCheckpointFile(tableSpace, tableName);
             TableStatus latestStatus;
             if (lastFile == null) {
-                latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
-                        Bytes.longToByteArray(1), 1, Collections.emptyMap());
+                latestStatus = TableStatus.buildTableStatusForNewCreatedTable(tableName);
             } else {
                 latestStatus = readTableStatusFromFile(lastFile);
             }

--- a/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
@@ -75,7 +75,7 @@ public interface AbstractTableManager extends AutoCloseable {
      */
     boolean isStarted();
 
-    void start() throws DataStorageManagerException;
+    void start(boolean created) throws DataStorageManagerException;
 
     @Override
     void close();

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -480,7 +480,6 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         long now = System.currentTimeMillis();
         while (System.currentTimeMillis() - now <= millis) {
             TableSpaceManager manager = tablesSpaces.get(tableSpace);
-            LOGGER.log(Level.INFO,"waitForTablespace {0} {1}", new Object[] {tableSpace, manager});
             if (manager != null) {
                 if (checkLeader && manager.isLeader()) {
                     return true;

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -480,6 +480,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         long now = System.currentTimeMillis();
         while (System.currentTimeMillis() - now <= millis) {
             TableSpaceManager manager = tablesSpaces.get(tableSpace);
+            LOGGER.log(Level.INFO,"waitForTablespace {0} {1}", new Object[] {tableSpace, manager});
             if (manager != null) {
                 if (checkLeader && manager.isLeader()) {
                     return true;

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -375,7 +375,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
      * @throws herddb.metadata.MetadataStorageManagerException
      */
     public void start() throws DataStorageManagerException, LogNotAvailableException, MetadataStorageManagerException {
-        LOGGER.log(Level.INFO, "Starting DBManager at {0}", nodeId);
+        LOGGER.log(Level.FINE, "Starting DBManager at {0}", nodeId);
         if (serverConfiguration.getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT)) {
             JMXUtils.registerDBManagerStatsMXBean(stats);
         }
@@ -426,7 +426,9 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 .ssl(hostData.isSsl())
                 .nodeId(nodeId)
                 .build();
-        LOGGER.log(Level.INFO, "Registering on metadata storage manager my data: {0}", nodeMetadata);
+        if (!serverConfiguration.getString(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_STANDALONE).equals(ServerConfiguration.PROPERTY_MODE_LOCAL)) {
+            LOGGER.log(Level.INFO, "Registering on metadata storage manager my data: {0}", nodeMetadata);
+        }
         metadataStorageManager.registerNode(nodeMetadata);
 
         try {

--- a/herddb-core/src/main/java/herddb/core/ReplicaFullTableDataDumpReceiver.java
+++ b/herddb-core/src/main/java/herddb/core/ReplicaFullTableDataDumpReceiver.java
@@ -112,7 +112,7 @@ public class ReplicaFullTableDataDumpReceiver extends TableSpaceDumpReceiver {
         LOGGER.log(Level.INFO, "dumpReceiver " + tableSpaceName + ", beginTable " + table.name + ", stats:" + stats + ", dumped at " + dumpedTable.logSequenceNumber + " (general dump at " + logSequenceNumber + ")");
         currentTable = tableSpaceManager.bootTable(table, 0, dumpedTable.logSequenceNumber, false);
         for (Index index : dumpedTable.indexes) {
-            tableSpaceManager.bootIndex(index, currentTable, 0, false, true);
+            tableSpaceManager.bootIndex(index, currentTable, false, 0, false, true);
         }
     }
 

--- a/herddb-core/src/main/java/herddb/core/ReplicaFullTableDataDumpReceiver.java
+++ b/herddb-core/src/main/java/herddb/core/ReplicaFullTableDataDumpReceiver.java
@@ -81,7 +81,7 @@ public class ReplicaFullTableDataDumpReceiver extends TableSpaceDumpReceiver {
 
     @Override
     public void finish(LogSequenceNumber pos) throws DataStorageManagerException {
-        LOGGER.log(Level.SEVERE, "dumpReceiver " + tableSpaceName + ", finish, at " + pos);
+        LOGGER.log(Level.INFO, "dumpReceiver " + tableSpaceName + ", finish, at " + pos);
         latch.complete("");
     }
 
@@ -91,7 +91,7 @@ public class ReplicaFullTableDataDumpReceiver extends TableSpaceDumpReceiver {
             LOGGER.log(Level.SEVERE, "dumpReceiver " + tableSpaceName + ", endTable swallow data after leader side error");
             return;
         }
-        LOGGER.log(Level.SEVERE, "dumpReceiver " + tableSpaceName + ", endTable " + currentTable.getTable().name);
+        LOGGER.log(Level.INFO, "dumpReceiver " + tableSpaceName + ", endTable " + currentTable.getTable().name);
         currentTable = null;
     }
 
@@ -109,8 +109,8 @@ public class ReplicaFullTableDataDumpReceiver extends TableSpaceDumpReceiver {
     @Override
     public void beginTable(DumpedTableMetadata dumpedTable, Map<String, Object> stats) throws DataStorageManagerException {
         Table table = dumpedTable.table;
-        LOGGER.log(Level.SEVERE, "dumpReceiver " + tableSpaceName + ", beginTable " + table.name + ", stats:" + stats + ", dumped at " + dumpedTable.logSequenceNumber + " (general dump at " + logSequenceNumber + ")");
-        currentTable = tableSpaceManager.bootTable(table, 0, dumpedTable.logSequenceNumber);
+        LOGGER.log(Level.INFO, "dumpReceiver " + tableSpaceName + ", beginTable " + table.name + ", stats:" + stats + ", dumped at " + dumpedTable.logSequenceNumber + " (general dump at " + logSequenceNumber + ")");
+        currentTable = tableSpaceManager.bootTable(table, 0, dumpedTable.logSequenceNumber, false);
         for (Index index : dumpedTable.indexes) {
             tableSpaceManager.bootIndex(index, currentTable, 0, false, true);
         }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -500,8 +500,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         if (requireLoadAtStartup) {
             if (created) {
                 // this is a fresh new table, with in memory key-to-page
-                TableStatus tableStatus = new TableStatus(table.uuid, LogSequenceNumber.START_OF_TIME,
-                    Bytes.longToByteArray(1), 1, Collections.emptyMap());
+                TableStatus tableStatus = TableStatus.buildTableStatusForNewCreatedTable(table.uuid);
                 nextPrimaryKeyValue.set(Bytes.toLong(tableStatus.nextPrimaryKeyValue, 0));
                 nextPageId = tableStatus.nextPageId;
                 bootSequenceNumber = tableStatus.sequenceNumber;

--- a/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
@@ -137,7 +137,7 @@ public abstract class AbstractSystemTableManager implements AbstractTableManager
     }
 
     @Override
-    public void start() throws DataStorageManagerException {
+    public void start(boolean created) throws DataStorageManagerException {
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -517,8 +517,7 @@ public class FileDataStorageManager extends DataStorageManager {
             Path lastFile = getLastTableCheckpointFile(tableSpace, tableName);
             TableStatus latestStatus;
             if (lastFile == null) {
-                latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
-                        Bytes.longToByteArray(1), 1, Collections.emptyMap());
+                latestStatus = TableStatus.buildTableStatusForNewCreatedTable(tableName);
             } else {
                 latestStatus = readTableStatusFromFile(lastFile);
             }

--- a/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/ConcurrentMapKeyToPageIndex.java
@@ -275,7 +275,7 @@ public class ConcurrentMapKeyToPageIndex implements KeyToPageIndex {
     }
 
     @Override
-    public void start(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+    public void start(LogSequenceNumber sequenceNumber, boolean created) throws DataStorageManagerException {
         /* No work needed, this implementation require a full table scan at startup instead */
     }
 

--- a/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/KeyToPageIndex.java
@@ -53,7 +53,7 @@ public interface KeyToPageIndex extends AutoCloseable {
     default void init() throws DataStorageManagerException {
     }
 
-    void start(LogSequenceNumber sequenceNumber) throws DataStorageManagerException;
+    void start(LogSequenceNumber sequenceNumber, boolean created) throws DataStorageManagerException;
 
     @Override
     void close();

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -130,7 +130,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
     @Override
     public void rebuild() throws DataStorageManagerException {
         long _start = System.currentTimeMillis();
-        LOGGER.log(Level.INFO, "rebuilding index {0}", index.name);
+        LOGGER.log(Level.INFO, "building index {0}", index.name);
         dataStorageManager.initIndex(tableSpaceUUID, index.uuid);
         data.clear();
         Table table = tableManager.getTable();
@@ -142,7 +142,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
             recordInserted(key, indexKey);
         });
         long _stop = System.currentTimeMillis();
-        LOGGER.log(Level.INFO, "rebuilding index {0} took {1]", new Object[]{index.name, (_stop - _start) + " ms"});
+        LOGGER.log(Level.INFO, "building index {0} took {1]", new Object[]{index.name, (_stop - _start) + " ms"});
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
+++ b/herddb-core/src/main/java/herddb/index/blink/BLinkKeyToPageIndex.java
@@ -299,10 +299,11 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
     }
 
     @Override
-    public void start(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
+    public void start(LogSequenceNumber sequenceNumber, boolean created) throws DataStorageManagerException {
 
-        LOGGER.log(Level.INFO, " start index {0}", new Object[]{indexName});
-
+        if (!created) {
+            LOGGER.log(Level.INFO, " start index {0}", new Object[]{indexName});
+        }
         /* Actually the same size */
         final long pageSize = memoryManager.getMaxLogicalPageSize();
 
@@ -310,7 +311,9 @@ public class BLinkKeyToPageIndex implements KeyToPageIndex {
             /* Empty index (booting from the start) */
             tree = new BLink<>(pageSize, SizeEvaluatorImpl.INSTANCE,
                     memoryManager.getPKPageReplacementPolicy(), indexDataStorage);
-            LOGGER.log(Level.INFO, "loaded empty index {0}", new Object[]{indexName});
+            if (!created) {
+                LOGGER.log(Level.INFO, "loaded empty index {0}", new Object[]{indexName});
+            }
         } else {
             IndexStatus status = dataStorageManager.getIndexStatus(tableSpace, indexName, sequenceNumber);
             try {

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -289,7 +289,7 @@ public class BRINIndexManager extends AbstractIndexManager {
     @Override
     public void rebuild() throws DataStorageManagerException {
         long _start = System.currentTimeMillis();
-        LOGGER.log(Level.INFO, "rebuilding index {0}", index.name);
+        LOGGER.log(Level.INFO, "building index {0}", index.name);
         dataStorageManager.initIndex(tableSpaceUUID, index.uuid);
         data.reset();
         Table table = tableManager.getTable();
@@ -301,7 +301,7 @@ public class BRINIndexManager extends AbstractIndexManager {
             recordInserted(key, indexKey);
         });
         long _stop = System.currentTimeMillis();
-        LOGGER.log(Level.INFO, "rebuilding index {0} took {1}", new Object[]{index.name, (_stop - _start) + " ms"});
+        LOGGER.log(Level.INFO, "building index {0} took {1}", new Object[]{index.name, (_stop - _start) + " ms"});
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -247,7 +247,7 @@ public class BRINIndexManager extends AbstractIndexManager {
 
     @Override
     protected boolean doStart(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
-        LOGGER.log(Level.INFO, " start BRIN index {0} uuid {1}", new Object[]{index.name, index.uuid});
+        LOGGER.log(Level.FINE, " start BRIN index {0} uuid {1}", new Object[]{index.name, index.uuid});
 
         dataStorageManager.initIndex(tableSpaceUUID, index.uuid);
 
@@ -256,7 +256,7 @@ public class BRINIndexManager extends AbstractIndexManager {
         if (LogSequenceNumber.START_OF_TIME.equals(sequenceNumber)) {
             /* Empty index (booting from the start) */
             this.data.boot(BlockRangeIndexMetadata.empty());
-            LOGGER.log(Level.INFO, "loaded empty index {0}", new Object[]{index.name});
+            LOGGER.log(Level.FINE, "loaded empty index {0}", new Object[]{index.name});
 
             return true;
         } else {
@@ -289,19 +289,23 @@ public class BRINIndexManager extends AbstractIndexManager {
     @Override
     public void rebuild() throws DataStorageManagerException {
         long _start = System.currentTimeMillis();
-        LOGGER.log(Level.INFO, "building index {0}", index.name);
+        LOGGER.log(Level.FINE, "building index {0}", index.name);
         dataStorageManager.initIndex(tableSpaceUUID, index.uuid);
         data.reset();
         Table table = tableManager.getTable();
+        AtomicLong count = new AtomicLong();
         tableManager.scanForIndexRebuild(r -> {
             DataAccessor values = r.getDataAccessor(table);
             Bytes key = RecordSerializer.serializePrimaryKey(values, table, table.primaryKey);
             Bytes indexKey = RecordSerializer.serializePrimaryKey(values, index, index.columnNames);
 //            LOGGER.log(Level.SEVERE, "adding " + key + " -> " + values);
             recordInserted(key, indexKey);
+            count.incrementAndGet();
         });
         long _stop = System.currentTimeMillis();
-        LOGGER.log(Level.INFO, "building index {0} took {1}", new Object[]{index.name, (_stop - _start) + " ms"});
+        if (count.intValue() > 0) {
+            LOGGER.log(Level.INFO, "building index {0} took {1}, scanned {2} records", new Object[]{index.name, (_stop - _start) + " ms", count});
+        }
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -1095,8 +1095,9 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
     }
 
     public void boot(BlockRangeIndexMetadata<K> metadata) throws DataStorageManagerException {
-        LOG.severe("boot index, with " + metadata.getBlocksMetadata().size() + " blocks");
-
+        if (metadata.getBlocksMetadata().size() > 0) {
+            LOG.info("boot index, with " + metadata.getBlocksMetadata().size() + " blocks");
+        }
         if (metadata.getBlocksMetadata().size() == 0) {
 
             reset();

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -182,13 +182,11 @@ public class MemoryDataStorageManager extends DataStorageManager {
 
         TableStatus latestStatus;
         if (max == null) {
-            latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
-                    Bytes.longToByteArray(1), 1, Collections.emptyMap());
+            latestStatus = TableStatus.buildTableStatusForNewCreatedTable(tableName);
         } else {
             byte[] data = tableStatuses.get(checkpointName(tableSpace, tableName, max));
             if (data == null) {
-                latestStatus = new TableStatus(tableName, LogSequenceNumber.START_OF_TIME,
-                        Bytes.longToByteArray(1), 1, Collections.emptyMap());
+                latestStatus = TableStatus.buildTableStatusForNewCreatedTable(tableName);
             } else {
                 try {
                     try (InputStream input = new SimpleByteArrayInputStream(data);

--- a/herddb-core/src/main/java/herddb/mem/MemoryLocalNodeIdManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryLocalNodeIdManager.java
@@ -40,4 +40,9 @@ public class MemoryLocalNodeIdManager extends LocalNodeIdManager {
         /* NOP */
     }
 
+    @Override
+    public String readLocalNodeId() throws IOException {
+        return null;
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -338,7 +338,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
 
         switch (mode) {
             case ServerConfiguration.PROPERTY_MODE_LOCAL:
-                return new MemoryCommitLogManager();
+                return new MemoryCommitLogManager(false);
             case ServerConfiguration.PROPERTY_MODE_STANDALONE:
                 Path logDirectory = this.baseDirectory.resolve(configuration.getString(ServerConfiguration.PROPERTY_LOGDIR, ServerConfiguration.PROPERTY_LOGDIR_DEFAULT));
                 return new FileCommitLogManager(logDirectory,

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -119,10 +119,12 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
 
         this.mode = configuration.getString(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_STANDALONE);
         this.baseDirectory = Paths.get(configuration.getString(ServerConfiguration.PROPERTY_BASEDIR, ServerConfiguration.PROPERTY_BASEDIR_DEFAULT)).toAbsolutePath();
-        try {
-            Files.createDirectories(this.baseDirectory);
-        } catch (IOException ignore) {
-            LOGGER.log(Level.SEVERE, "Cannot create baseDirectory " + this.baseDirectory, ignore);
+        if (!mode.equals(ServerConfiguration.PROPERTY_MODE_LOCAL)) {
+            try {
+                Files.createDirectories(this.baseDirectory);
+            } catch (IOException ignore) {
+                LOGGER.log(Level.SEVERE, "Cannot create baseDirectory " + this.baseDirectory, ignore);
+            }
         }
         this.dataDirectory = this.baseDirectory.resolve(configuration.getString(ServerConfiguration.PROPERTY_DATADIR, ServerConfiguration.PROPERTY_DATADIR_DEFAULT));
         this.tmpDirectory = this.baseDirectory.resolve(configuration.getString(ServerConfiguration.PROPERTY_TMPDIR, ServerConfiguration.PROPERTY_TMPDIR_DEFAULT));
@@ -141,8 +143,10 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         this.metadataStorageManager = buildMetadataStorageManager();
         String host = configuration.getString(ServerConfiguration.PROPERTY_HOST, ServerConfiguration.PROPERTY_HOST_DEFAULT);
         int port = configuration.getInt(ServerConfiguration.PROPERTY_PORT, ServerConfiguration.PROPERTY_PORT_DEFAULT);
-        LOGGER.log(Level.INFO, "Configured network parameters: " + ServerConfiguration.PROPERTY_HOST + "={0}, "
+        if (!mode.equals(ServerConfiguration.PROPERTY_MODE_LOCAL)) {
+            LOGGER.log(Level.INFO, "Configured network parameters: " + ServerConfiguration.PROPERTY_HOST + "={0}, "
                 + ServerConfiguration.PROPERTY_PORT + "={1}", new Object[]{host, port});
+        }
         if (host.trim().isEmpty()) {
             String _host = "0.0.0.0";
             LOGGER.log(Level.INFO, "As configuration parameter "
@@ -180,8 +184,10 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
         HashMap<String, String> realData = new HashMap<>();
         realData.put(ServerConfiguration.PROPERTY_HOST, host);
         realData.put(ServerConfiguration.PROPERTY_PORT, port + "");
-        LOGGER.info("Public endpoint: " + ServerConfiguration.PROPERTY_ADVERTISED_HOST + "=" + advertised_host
-                + ", Public endpoint: " + ServerConfiguration.PROPERTY_ADVERTISED_PORT + "=" + advertised_port);
+        if (!mode.equals(ServerConfiguration.PROPERTY_MODE_LOCAL)) {
+            LOGGER.info("Public endpoint: " + ServerConfiguration.PROPERTY_ADVERTISED_HOST + "=" + advertised_host
+                    + ", Public endpoint: " + ServerConfiguration.PROPERTY_ADVERTISED_PORT + "=" + advertised_port);
+        }
         this.serverHostData = new ServerHostData(
                 advertised_host,
                 advertised_port,
@@ -201,7 +207,9 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                     // we need to eagerly start the metadataStorageManager, for instance to open the connection to ZK
                     metadataStorageManager.start();
                     nodeId = metadataStorageManager.generateNewNodeId(configuration);
-                    LOGGER.info("Generated new node id " + nodeId);
+                    if (!mode.equals(ServerConfiguration.PROPERTY_MODE_LOCAL)) {
+                        LOGGER.info("Generated new node id " + nodeId);
+                    }
                     localNodeIdManager.persistLocalNodeId(nodeId);
                 }
             } catch (IOException | MetadataStorageManagerException error) {
@@ -274,7 +282,7 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 !isLocal && ServerConfiguration.PROPERTY_NETWORK_ENABLED_DEFAULT);
         if (!nextworkEnabled) {
             acceptor.setEnableRealNetwork(false);
-            LOGGER.log(Level.INFO, "Local in-JVM acceptor on {0}:{1} ssl:{2}",
+            LOGGER.log(Level.FINE, "Local in-JVM acceptor on {0}:{1} ssl:{2}",
                     new Object[]{realHost, realPort, serverHostData.isSsl()});
         } else {
             LOGGER.log(Level.INFO, "Binding network acceptor to {0}:{1} ssl:{2}",

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -409,13 +409,19 @@ public final class ServerConfiguration {
             set(PROPERTY_PORT, port);
         } else if (before.startsWith("jdbc:herddb:local")) {
             set(PROPERTY_MODE, PROPERTY_MODE_LOCAL);
+            set(PROPERTY_NODEID, "local");
             if (before.startsWith("jdbc:herddb:local:")) {
                 String databaseId = before.substring("jdbc:herddb:local:".length() + 1).trim().toLowerCase();
                 if (!databaseId.isEmpty()) {
                     set(PROPERTY_HOST, databaseId);
                     set(PROPERTY_PORT, 0);
+                    set(PROPERTY_NODEID, databaseId);
                 }
             }
+            set(ServerConfiguration.PROPERTY_JMX_ENABLE, false);
+            set(PROPERTY_NETWORK_CALLBACK_THREADS, 4);
+            set(PROPERTY_NETWORK_WORKER_THREADS, 4);
+            set(PROPERTY_ASYNC_WORKER_THREADS, 4);
         }
         if (questionMark < url.length()) {
             String qs = url.substring(questionMark + 1);

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -941,7 +941,9 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
 
     @Override
     public void channelClosed(Channel channel) {
-        LOGGER.log(Level.INFO, "channelClosed {0}", this);
+        if (!channel.isLocalChannel()) {
+            LOGGER.log(Level.INFO, "channelClosed {0}", this);
+        }
         freeResources();
         this.server.connectionClosed(this);
     }

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -195,7 +195,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
         this.manager = manager;
         this.cache = new PlansCache(maxPlanCacheSize);
         //used only for DDL
-        this.fallback = new DDLSQLPlanner(manager, maxPlanCacheSize);
+        this.fallback = new DDLSQLPlanner(manager, cache);
     }
 
     private final PlansCache cache;

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -109,9 +109,9 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
         cache.clear();
     }
 
-    public DDLSQLPlanner(DBManager manager, long maxPlanCacheSize) {
+    public DDLSQLPlanner(DBManager manager, PlansCache plansCache) {
         this.manager = manager;
-        this.cache = new PlansCache(maxPlanCacheSize);
+        this.cache = plansCache;
     }
 
     public static String rewriteExecuteSyntax(String query) {

--- a/herddb-core/src/main/java/herddb/storage/TableStatus.java
+++ b/herddb-core/src/main/java/herddb/storage/TableStatus.java
@@ -23,10 +23,12 @@ package herddb.storage;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.core.PageSet.DataPageMetaData;
 import herddb.log.LogSequenceNumber;
+import herddb.utils.Bytes;
 import herddb.utils.ExtendedDataInputStream;
 import herddb.utils.ExtendedDataOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -45,6 +47,11 @@ public class TableStatus {
     public final byte[] nextPrimaryKeyValue;
     public final Map<Long, DataPageMetaData> activePages;
     public final long nextPageId;
+
+    public static TableStatus buildTableStatusForNewCreatedTable(String tableUuid) {
+        return new TableStatus(tableUuid, LogSequenceNumber.START_OF_TIME,
+                        Bytes.longToByteArray(1), 1, Collections.emptyMap());
+    }
 
     public TableStatus(
             String tableName, LogSequenceNumber sequenceNumber, byte[] nextPrimaryKeyValue, long nextPageId,

--- a/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
@@ -101,8 +101,8 @@ public class BLinkKeyToPageIndexTest extends KeyToPageIndexTest {
         }
 
         @Override
-        public void start(LogSequenceNumber sequenceNumber) throws DataStorageManagerException {
-            delegate.start(sequenceNumber);
+        public void start(LogSequenceNumber sequenceNumber, boolean created) throws DataStorageManagerException {
+            delegate.start(sequenceNumber, created);
         }
 
         @Override

--- a/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/KeyToPageIndexTest.java
@@ -52,7 +52,7 @@ public abstract class KeyToPageIndexTest {
 
             final Bytes key = Bytes.from_int(1);
 
-            index.start(LogSequenceNumber.START_OF_TIME);
+            index.start(LogSequenceNumber.START_OF_TIME, true);
 
             Assert.assertEquals(0, index.getUsedMemory());
 
@@ -88,7 +88,7 @@ public abstract class KeyToPageIndexTest {
 
             final Bytes key = Bytes.from_int(1);
 
-            index.start(LogSequenceNumber.START_OF_TIME);
+            index.start(LogSequenceNumber.START_OF_TIME, true);
 
             Assert.assertEquals(0, index.size());
 
@@ -141,7 +141,7 @@ public abstract class KeyToPageIndexTest {
 
         try (KeyToPageIndex index = createIndex()) {
 
-            index.start(LogSequenceNumber.START_OF_TIME);
+            index.start(LogSequenceNumber.START_OF_TIME, true);
 
             for (int i = 0; i < entries; ++i) {
                 index.put(Bytes.from_int(i), 1L);
@@ -161,7 +161,7 @@ public abstract class KeyToPageIndexTest {
 
         try (KeyToPageIndex index = createIndex()) {
 
-            index.start(LogSequenceNumber.START_OF_TIME);
+            index.start(LogSequenceNumber.START_OF_TIME, true);
 
             for (int i = 0; i < entries; ++i) {
                 index.put(Bytes.from_int(i), 1L);
@@ -188,7 +188,7 @@ public abstract class KeyToPageIndexTest {
 
         try (KeyToPageIndex index = createIndex()) {
 
-            index.start(LogSequenceNumber.START_OF_TIME);
+            index.start(LogSequenceNumber.START_OF_TIME, true);
 
             for (int i = 0; i < jobs; ++i) {
                 index.put(Bytes.from_int(i), 0L);

--- a/herddb-core/src/test/java/herddb/index/blink/BlinkBench.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BlinkBench.java
@@ -127,7 +127,7 @@ public class BlinkBench {
                 try (MemoryDataStorageManager ds = new MemoryDataStorageManager();
                      BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds)) {
 
-                    idx.start(LogSequenceNumber.START_OF_TIME);
+                    idx.start(LogSequenceNumber.START_OF_TIME, true);
 
                     ExecutorService ex = Executors.newFixedThreadPool(threads);
 

--- a/herddb-core/src/test/java/herddb/index/blink/BlinkRandomBench.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BlinkRandomBench.java
@@ -128,7 +128,7 @@ public class BlinkRandomBench {
                 try (MemoryDataStorageManager ds = new MemoryDataStorageManager();
                      BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds)) {
 
-                    idx.start(LogSequenceNumber.START_OF_TIME);
+                    idx.start(LogSequenceNumber.START_OF_TIME, true);
 
                     long[] data = new long[(int) (maxID - minID)];
 

--- a/herddb-core/src/test/java/herddb/sql/functions/ShowCreateTableCalculatorTest.java
+++ b/herddb-core/src/test/java/herddb/sql/functions/ShowCreateTableCalculatorTest.java
@@ -110,7 +110,7 @@ public class ShowCreateTableCalculatorTest {
         }
 
         @Override
-        public void start() throws DataStorageManagerException {
+        public void start(boolean created) throws DataStorageManagerException {
 
         }
 

--- a/herddb-jdbc/src/test/java/herddb/jdbc/JDBCBoostrapTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/JDBCBoostrapTest.java
@@ -1,0 +1,56 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.jdbc;
+
+import herddb.server.ServerConfiguration;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Properties;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JDBCBoostrapTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+        DriverManager.registerDriver(new Driver());
+        long _start = System.currentTimeMillis();
+        Properties props = new Properties();
+        props.put(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().toPath().toString());
+        try (Connection connection = DriverManager.getConnection("jdbc:herddb:local?autoClose=true", props);
+                Statement statement = connection.createStatement();) {
+            long _boot = System.currentTimeMillis();
+            System.out.println("Total time BOOT: " + (_boot - _start) + " ms");
+            for (int i = 0; i < 20; i++) {
+                String tableName = "tt" + i;
+                String indexName = tableName + "ix";
+                statement.execute("CREATE TABLE " + tableName + "(k1 string primary key, n1 int not null)");
+                statement.execute("CREATE INDEX " + indexName + " ON " + tableName + "(n1)");
+            }
+        }
+        long _end = System.currentTimeMillis();
+        System.out.println("Total time OVER: " + (_end - _start) + " ms");
+    }
+}

--- a/herddb-jdbc/src/test/java/herddb/jdbc/JDBCBoostrapTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/JDBCBoostrapTest.java
@@ -43,7 +43,7 @@ public class JDBCBoostrapTest {
                 Statement statement = connection.createStatement();) {
             long _boot = System.currentTimeMillis();
             System.out.println("Total time BOOT: " + (_boot - _start) + " ms");
-            for (int i = 0; i < 20; i++) {
+            for (int i = 0; i < 40; i++) {
                 String tableName = "tt" + i;
                 String indexName = tableName + "ix";
                 statement.execute("CREATE TABLE " + tableName + "(k1 string primary key, n1 int not null)");
@@ -52,5 +52,6 @@ public class JDBCBoostrapTest {
         }
         long _end = System.currentTimeMillis();
         System.out.println("Total time OVER: " + (_end - _start) + " ms");
+
     }
 }

--- a/herddb-net/pom.xml
+++ b/herddb-net/pom.xml
@@ -39,6 +39,9 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
+            <!-- must repeat version, otherwise NetBeans is not happy -->
+            <version>${libs.netty4}</version>
+            <classifier>linux-x86_64</classifier>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/herddb-net/src/main/java/herddb/network/Channel.java
+++ b/herddb-net/src/main/java/herddb/network/Channel.java
@@ -103,6 +103,9 @@ public abstract class Channel implements AutoCloseable {
 
     public abstract boolean isValid();
 
+    public abstract boolean isLocalChannel();
+
+
     public String getName() {
         return name;
     }

--- a/herddb-net/src/main/java/herddb/network/netty/NettyChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyChannel.java
@@ -25,6 +25,7 @@ import herddb.network.SendResultCallback;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.local.LocalChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -215,6 +216,11 @@ public class NettyChannel extends Channel {
     public boolean isValid() {
         io.netty.channel.Channel _socket = socket;
         return _socket != null && _socket.isOpen() && !ioErrors;
+    }
+
+    @Override
+    public boolean isLocalChannel() {
+        return socket instanceof LocalChannel;
     }
 
     private volatile boolean closed = false;

--- a/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
@@ -248,7 +248,9 @@ public class NettyChannelAcceptor implements AutoCloseable {
 
         });
         InetSocketAddress address = new InetSocketAddress(host, port);
-        LOGGER.log(Level.INFO, "Starting HerdDB network server at {0}:{1}", new Object[]{host, port + ""});
+        if (enableRealNetwork) {
+            LOGGER.log(Level.INFO, "Starting HerdDB network server at {0}:{1}", new Object[]{host, port + ""});
+        }
         if (enableRealNetwork && address.isUnresolved()) {
             throw new IOException("Bind address " + host + ":" + port + " cannot be resolved");
         }
@@ -295,8 +297,7 @@ public class NettyChannelAcceptor implements AutoCloseable {
         }
 
         if (enableJVMNetwork) {
-            localBossGroup = new DefaultEventLoopGroup(workerThreads);
-            localWorkerGroup = new DefaultEventLoopGroup(workerThreads);
+            localBossGroup = localWorkerGroup = new DefaultEventLoopGroup();
             ServerBootstrap b_local = new ServerBootstrap();
             b_local.group(localBossGroup, localWorkerGroup)
                     .channel(LocalServerChannel.class)

--- a/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
@@ -74,6 +74,8 @@ public class NettyConnector {
                 channelType = LocalChannel.class;
                 address = new LocalAddress(hostAddress + ":" + port + ":" + ssl);
                 group = localEventsGroup;
+            } else if (networkGroup == null) {
+                throw new IOException("Connection using network is disabled");
             } else {
                 channelType = networkGroup instanceof EpollEventLoopGroup ? EpollSocketChannel.class : NioSocketChannel.class;
                 address = inet;

--- a/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
@@ -26,6 +26,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Network utility
@@ -34,10 +36,17 @@ import java.net.UnknownHostException;
  */
 public class NetworkUtils {
 
+    private static final Logger LOG = Logger.getLogger(NetworkUtils.class.getName());
     private static final boolean ENABLE_EPOOL_NATIVE =
             System.getProperty("os.name").equalsIgnoreCase("linux")
                     && !Boolean.getBoolean("herddb.network.disablenativeepoll")
                     && Epoll.isAvailable();
+    static {
+        if (!ENABLE_EPOOL_NATIVE && !Epoll.isAvailable()) {
+            LOG.log(Level.INFO, "Netty Epoll is not enabled, os.name {0}, Epoll.isAvailable(): {1} cause: {2}",
+                    new Object[]{System.getProperty("os.name"), Epoll.isAvailable(), Epoll.unavailabilityCause()});
+        }
+    }
 
     public static boolean isEnableEpoolNative() {
         return ENABLE_EPOOL_NATIVE;

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,8 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
                 <version>${libs.netty4}</version>
-            </dependency>
+                <classifier>linux-x86_64</classifier>
+            </dependency>            
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>


### PR DESCRIPTION
The goal of this patch is to enhance the overall bootstrap process in case of in-memory only database:
- skip useless steps
- clean up logs (do not log obvious things, like empty tables, empty indexes...)
- change default configuration (less number of threads....)
- do not start network server in "local" mode
- fix Netty epoll dependencies