### PR TITLE
HashJoin does not release transaction correctly in case of FilteredDataScanner

### DIFF
--- a/herddb-core/src/main/java/herddb/model/LimitedDataScanner.java
+++ b/herddb-core/src/main/java/herddb/model/LimitedDataScanner.java
@@ -69,8 +69,11 @@ public class LimitedDataScanner extends DataScanner {
 
     @Override
     public void close() throws DataScannerException {
-        wrapped.close();
-        super.close();
+        try {
+            wrapped.close();
+        } finally {
+            super.close();
+        }
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
@@ -146,6 +146,15 @@ public class FilterOp implements PlannerOp {
             return inputScanner.isRewindSupported();
         }
 
+        @Override
+        public void close() throws DataScannerException {
+            try {
+                inputScanner.close();
+            } finally {
+                super.close();
+            }
+        }
+
 
     }
 


### PR DESCRIPTION
A query like this:
```
select k1 as kk, v1 as vv
from a
where 1=1
and ( NOT EXISTS (SELECT NULL FROM b WHERE b.v2=a.k1 AND  1=1  AND b.k2 = 2 ))
```

With this plan:
```
EnumerableProject(KK=[$0], VV=[$1]): rowcount = 1.0, cumulative cost = {8.125 rows, 7.5 cpu, 0.0 io}, id = 381
  EnumerableFilter(condition=[IS NULL($3)]): rowcount = 1.0, cumulative cost = {7.125 rows, 5.5 cpu, 0.0 io}, id = 380
    EnumerableHashJoin(condition=[=($0, $2)], joinType=[left]): rowcount = 1.0, cumulative cost = {6.125 rows, 4.5 cpu, 0.0 io}, id = 379
      EnumerableTableScan(table=[[herd, a]]): rowcount = 1.0, cumulative cost = {1.0 rows, 2.0 cpu, 0.0 io}, id = 315
      EnumerableAggregate(group=[{0}], agg#0=[MIN($1)]): rowcount = 1.0, cumulative cost = {2.625 rows, 2.5 cpu, 0.0 io}, id = 378
        EnumerableProject(v2=[$0], $f1=[true]): rowcount = 1.0, cumulative cost = {1.5 rows, 2.5 cpu, 0.0 io}, id = 377
          EnumerableInterpreter: rowcount = 1.0, cumulative cost = {0.5 rows, 0.5 cpu, 0.0 io}, id = 376
            BindableTableScan(table=[[herd, b]], filters=[[AND(=($0, 1), IS NOT NULL($1))]], projects=[[1]])
```

Ends in this HerdDB plan:
```
ProjectOp{projection=ZeroCopyProjection{fieldNames=[kk, vv], zeroCopyProjections=[0, 1]},
input=FilterOp {input=[ JoinOp{leftKeys=[0], left=TableScanOp{statement=ScanStatement{table=a,predicate=null,comparator=null}}, rightKeys=[0], right=AggregateOp {GroupedFieldsIndexes = 1 ArgList = 1 }, fieldNames=[k1, v1, v2, $f1], columns=[{name=k1, type=2}, {name=v1, type=2}, {name=v2, type=2}, {name=$f1, type=7}], generateNullsOnLeft=false, generateNullsOnRight=true, mergeJoin=false} ] condition=[ herddb.sql.expressions.CompiledIsNullExpression@4da39ca9] }}
```

The FilterOp operator wraps the input of the HashJoin node with a FilteredDataScanner that does not call "close" on the wrapped DataScanners, resulting on a leak.

The fix is straighforward.
The added test reproduces exactly the error reported by an user and demonstrates that the problem is fixed