### PR TITLE
Unregister local server and make network tests pass on JDK15

### DIFF
--- a/herddb-net/pom.xml
+++ b/herddb-net/pom.xml
@@ -88,5 +88,10 @@
             <groupId>org.apache.bookkeeper</groupId>
             <artifactId>bookkeeper-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
@@ -73,6 +73,7 @@ public class NettyChannelAcceptor implements AutoCloseable {
     private EventLoopGroup localWorkerGroup;
     private int port = 7000;
     private String host = "localhost";
+    private String jvmhostAddress;
     private boolean ssl;
     private ServerSideConnectionAcceptor acceptor;
     private SslContext sslCtx;
@@ -303,10 +304,10 @@ public class NettyChannelAcceptor implements AutoCloseable {
                     .channel(LocalServerChannel.class)
                     .childHandler(channelInitialized);
 
-            String hostAddress = NetworkUtils.getAddress(address);
-            LocalServerRegistry.registerLocalServer(hostAddress, port, ssl);
+            jvmhostAddress = NetworkUtils.getAddress(address);
+            LocalServerRegistry.registerLocalServer(jvmhostAddress, port, ssl);
 
-            ChannelFuture local_f = b_local.bind(new LocalAddress(hostAddress + ":" + port + ":" + ssl)).sync();
+            ChannelFuture local_f = b_local.bind(new LocalAddress(jvmhostAddress + ":" + port + ":" + ssl)).sync();
             this.localChannel = local_f.channel();
         }
 
@@ -317,7 +318,10 @@ public class NettyChannelAcceptor implements AutoCloseable {
         if (channel != null) {
             channel.close();
         }
-        if (localChannel != null) {
+        if (enableJVMNetwork && jvmhostAddress != null) {
+            LocalServerRegistry.unregisterLocalServer(jvmhostAddress, port, ssl);
+        }
+        if (localChannel != null) {            
             localChannel.close();
         }
         if (workerGroup != null) {

--- a/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyChannelAcceptor.java
@@ -321,7 +321,7 @@ public class NettyChannelAcceptor implements AutoCloseable {
         if (enableJVMNetwork && jvmhostAddress != null) {
             LocalServerRegistry.unregisterLocalServer(jvmhostAddress, port, ssl);
         }
-        if (localChannel != null) {            
+        if (localChannel != null) {
             localChannel.close();
         }
         if (workerGroup != null) {

--- a/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
@@ -39,20 +39,20 @@ public class NetworkUtils {
     private static final Logger LOG = Logger.getLogger(NetworkUtils.class.getName());
 
     // computed lazily, in order not to force loading of Netty EPoll if not needed
-    private static volatile Boolean ENABLE_EPOOL_NATIVE;
+    private static volatile Boolean nettyEpoolNativeAvailable;
 
     public static boolean isEnableEpoolNative() {
-        if (ENABLE_EPOOL_NATIVE == null) {
-            ENABLE_EPOOL_NATIVE =
+        if (nettyEpoolNativeAvailable == null) {
+            nettyEpoolNativeAvailable =
                     System.getProperty("os.name").equalsIgnoreCase("linux")
                     && !Boolean.getBoolean("herddb.network.disablenativeepoll")
                     && Epoll.isAvailable();
-            if (!ENABLE_EPOOL_NATIVE && !Epoll.isAvailable()) {
+            if (!nettyEpoolNativeAvailable && !Epoll.isAvailable()) {
                 LOG.log(Level.INFO, "Netty Epoll is not enabled, os.name {0}, Epoll.isAvailable(): {1} cause: {2}",
                         new Object[]{System.getProperty("os.name"), Epoll.isAvailable(), Epoll.unavailabilityCause()});
             }
         }
-        return ENABLE_EPOOL_NATIVE;
+        return nettyEpoolNativeAvailable;
     }
 
     public static String getAddress(InetSocketAddress address) {

--- a/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
@@ -37,18 +37,21 @@ import java.util.logging.Logger;
 public class NetworkUtils {
 
     private static final Logger LOG = Logger.getLogger(NetworkUtils.class.getName());
-    private static final boolean ENABLE_EPOOL_NATIVE =
-            System.getProperty("os.name").equalsIgnoreCase("linux")
-                    && !Boolean.getBoolean("herddb.network.disablenativeepoll")
-                    && Epoll.isAvailable();
-    static {
-        if (!ENABLE_EPOOL_NATIVE && !Epoll.isAvailable()) {
-            LOG.log(Level.INFO, "Netty Epoll is not enabled, os.name {0}, Epoll.isAvailable(): {1} cause: {2}",
-                    new Object[]{System.getProperty("os.name"), Epoll.isAvailable(), Epoll.unavailabilityCause()});
-        }
-    }
+
+    // computed lazily, in order not to force loading of Netty EPoll if not needed
+    private static volatile Boolean ENABLE_EPOOL_NATIVE;
 
     public static boolean isEnableEpoolNative() {
+        if (ENABLE_EPOOL_NATIVE == null) {
+            ENABLE_EPOOL_NATIVE =
+                    System.getProperty("os.name").equalsIgnoreCase("linux")
+                    && !Boolean.getBoolean("herddb.network.disablenativeepoll")
+                    && Epoll.isAvailable();
+            if (!ENABLE_EPOOL_NATIVE && !Epoll.isAvailable()) {
+                LOG.log(Level.INFO, "Netty Epoll is not enabled, os.name {0}, Epoll.isAvailable(): {1} cause: {2}",
+                        new Object[]{System.getProperty("os.name"), Epoll.isAvailable(), Epoll.unavailabilityCause()});
+            }
+        }
         return ENABLE_EPOOL_NATIVE;
     }
 

--- a/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NetworkUtils.java
@@ -39,9 +39,9 @@ public class NetworkUtils {
     private static final Logger LOG = Logger.getLogger(NetworkUtils.class.getName());
 
     // computed lazily, in order not to force loading of Netty EPoll if not needed
-    private static volatile Boolean nettyEpoolNativeAvailable;
+    private static Boolean nettyEpoolNativeAvailable;
 
-    public static boolean isEnableEpoolNative() {
+    public static synchronized boolean isEnableEpoolNative() {
         if (nettyEpoolNativeAvailable == null) {
             nettyEpoolNativeAvailable =
                     System.getProperty("os.name").equalsIgnoreCase("linux")

--- a/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
@@ -18,31 +18,30 @@
 
 */
 
-package herddb.network;
+package herddb.network.netty;
 
-import static herddb.network.Utils.buildAckRequest;
-import static herddb.network.Utils.buildAckResponse;
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.ServerSideConnection;
+import static herddb.network.netty.Utils.buildAckRequest;
+import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
 import herddb.network.netty.NettyChannelAcceptor;
 import herddb.network.netty.NettyConnector;
-import herddb.network.netty.NetworkUtils;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.DefaultEventLoopGroup;
-import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.Test;
 
-public class NetworkChannelTest {
+public class ChannelBenchTest {
 
     @Test
     public void test() throws Exception {
         try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor("localhost", 1111, true)) {
-            acceptor.setEnableJVMNetwork(false);
             acceptor.setAcceptor((Channel channel) -> {
                 channel.setMessagesReceiver(new ChannelEventListener() {
                     @Override
@@ -71,7 +70,7 @@ public class NetworkChannelTest {
             }, executor, new NioEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
                 for (int i = 0; i < 100; i++) {
                     ByteBuf buffer = buildAckRequest(i);
-                    try (Pdu result = client.sendMessageWithPduReply(i, Unpooled.wrappedBuffer(buffer), 10000)) {
+                    try (Pdu result = client.sendMessageWithPduReply(i, buffer, 10000)) {
                         assertEquals(Pdu.TYPE_ACK, result.type);
                     }
                 }
@@ -79,47 +78,7 @@ public class NetworkChannelTest {
                 executor.shutdown();
             }
         }
-        if (NetworkUtils.isEnableEpoolNative()) {
-            try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor("localhost", 1111, true)) {
-                acceptor.setEnableJVMNetwork(false);
-                acceptor.setAcceptor((Channel channel) -> {
-                    channel.setMessagesReceiver(new ChannelEventListener() {
-                        @Override
-                        public void requestReceived(Pdu message, Channel channel) {
-                            ByteBuf msg = buildAckResponse(message);
-                            channel.sendReplyMessage(message.messageId, msg);
-                            message.close();
-                        }
 
-                        @Override
-                        public void channelClosed(Channel channel) {
-
-                        }
-                    });
-                    return (ServerSideConnection) () -> new Random().nextLong();
-                });
-                acceptor.start();
-                ExecutorService executor = Executors.newCachedThreadPool();
-                try (Channel client = NettyConnector.connect("localhost", 1111, true, 0, 0, new ChannelEventListener() {
-
-                    @Override
-                    public void channelClosed(Channel channel) {
-                        System.out.println("client channelClosed");
-
-                    }
-                }, executor, new EpollEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
-                    for (int i = 0; i < 100; i++) {
-
-                        ByteBuf buffer = buildAckRequest(i);
-                        try (Pdu result = client.sendMessageWithPduReply(i, Unpooled.wrappedBuffer(buffer), 10000)) {
-                            assertEquals(Pdu.TYPE_ACK, result.type);
-                        }
-                    }
-                } finally {
-                    executor.shutdown();
-                }
-            }
-        }
     }
 
 }

--- a/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
@@ -20,14 +20,12 @@
 
 package herddb.network.netty;
 
-import herddb.network.Channel;
-import herddb.network.ChannelEventListener;
-import herddb.network.ServerSideConnection;
 import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
-import herddb.network.netty.NettyChannelAcceptor;
-import herddb.network.netty.NettyConnector;
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.DefaultEventLoopGroup;

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -20,14 +20,14 @@
 
 package herddb.network.netty;
 
-import herddb.network.Channel;
-import herddb.network.ChannelEventListener;
-import herddb.network.ServerSideConnection;
 import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.DefaultEventLoopGroup;

--- a/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
@@ -20,15 +20,12 @@
 
 package herddb.network.netty;
 
-import herddb.network.Channel;
-import herddb.network.ChannelEventListener;
-import herddb.network.ServerSideConnection;
 import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
-import herddb.network.netty.NettyChannelAcceptor;
-import herddb.network.netty.NettyConnector;
-import herddb.network.netty.NetworkUtils;
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
@@ -18,27 +18,34 @@
 
 */
 
-package herddb.network;
+package herddb.network.netty;
 
-import static herddb.network.Utils.buildAckRequest;
-import static herddb.network.Utils.buildAckResponse;
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.ServerSideConnection;
+import static herddb.network.netty.Utils.buildAckRequest;
+import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
 import herddb.network.netty.NettyChannelAcceptor;
 import herddb.network.netty.NettyConnector;
+import herddb.network.netty.NetworkUtils;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.Test;
 
-public class ChannelBenchTest {
+public class NetworkChannelTest {
 
     @Test
     public void test() throws Exception {
         try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor("localhost", 1111, true)) {
+            acceptor.setEnableJVMNetwork(false);
             acceptor.setAcceptor((Channel channel) -> {
                 channel.setMessagesReceiver(new ChannelEventListener() {
                     @Override
@@ -67,7 +74,7 @@ public class ChannelBenchTest {
             }, executor, new NioEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
                 for (int i = 0; i < 100; i++) {
                     ByteBuf buffer = buildAckRequest(i);
-                    try (Pdu result = client.sendMessageWithPduReply(i, buffer, 10000)) {
+                    try (Pdu result = client.sendMessageWithPduReply(i, Unpooled.wrappedBuffer(buffer), 10000)) {
                         assertEquals(Pdu.TYPE_ACK, result.type);
                     }
                 }
@@ -75,7 +82,47 @@ public class ChannelBenchTest {
                 executor.shutdown();
             }
         }
+        if (NetworkUtils.isEnableEpoolNative()) {
+            try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor("localhost", 1111, true)) {
+                acceptor.setEnableJVMNetwork(false);
+                acceptor.setAcceptor((Channel channel) -> {
+                    channel.setMessagesReceiver(new ChannelEventListener() {
+                        @Override
+                        public void requestReceived(Pdu message, Channel channel) {
+                            ByteBuf msg = buildAckResponse(message);
+                            channel.sendReplyMessage(message.messageId, msg);
+                            message.close();
+                        }
 
+                        @Override
+                        public void channelClosed(Channel channel) {
+
+                        }
+                    });
+                    return (ServerSideConnection) () -> new Random().nextLong();
+                });
+                acceptor.start();
+                ExecutorService executor = Executors.newCachedThreadPool();
+                try (Channel client = NettyConnector.connect("localhost", 1111, true, 0, 0, new ChannelEventListener() {
+
+                    @Override
+                    public void channelClosed(Channel channel) {
+                        System.out.println("client channelClosed");
+
+                    }
+                }, executor, new EpollEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
+                    for (int i = 0; i < 100; i++) {
+
+                        ByteBuf buffer = buildAckRequest(i);
+                        try (Pdu result = client.sendMessageWithPduReply(i, Unpooled.wrappedBuffer(buffer), 10000)) {
+                            assertEquals(Pdu.TYPE_ACK, result.type);
+                        }
+                    }
+                } finally {
+                    executor.shutdown();
+                }
+            }
+        }
     }
 
 }

--- a/herddb-net/src/test/java/herddb/network/netty/Utils.java
+++ b/herddb-net/src/test/java/herddb/network/netty/Utils.java
@@ -18,7 +18,7 @@
 
 */
 
-package herddb.network;
+package herddb.network.netty;
 
 import herddb.proto.Pdu;
 import herddb.proto.PduCodec;

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <libs.netty4>4.1.50.Final</libs.netty4>
         <libs.netty4ssl>2.0.28.Final</libs.netty4ssl>
+        <!-- needed in tests for TLS certificate autogeneration on jdk-15+ -->
+        <libs.bouncycastle>1.65</libs.bouncycastle>
         <libs.calcite>1.23.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
         <libs.jackson.mapper>2.10.3</libs.jackson.mapper>
@@ -167,6 +169,11 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
                 <version>${libs.netty4}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>${libs.bouncycastle}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
- Fix local server address (un-)registration issue
- Add bouncycastle bcpkix-jdk15on dependency for tests, in order to make TLS tests work on JDK15
- Defer Netty Epoll library loading, this way in "local" tests (without network) we save 200ms of bootstrap time

Fixes #651 