### PR TITLE
Reduce transitive dependencies on JDBC driver

### DIFF
--- a/herddb-jdbc/pom.xml
+++ b/herddb-jdbc/pom.xml
@@ -36,15 +36,21 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>herddb-core</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.bookkeeper.stats</groupId>
+                    <artifactId>prometheus-metrics-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-        </dependency>
+        </dependency>        
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,11 +188,21 @@
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
                 <version>${libs.calcite}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>net.minidev</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apiguardian</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-linq4j</artifactId>
-                <version>${libs.calcite}</version>
+                <version>${libs.calcite}</version>                
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -333,6 +343,10 @@
                         <artifactId>io.netty</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
@@ -356,6 +370,14 @@
                         <groupId>org.apache.zookeeper</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.rocksdb</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.beust</groupId>
+                        <artifactId>jcommander</artifactId>
+                    </exclusion>                    
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
- fix Netty dependency imported from BookKeeper
- drop RocksDB (not needed but imported from BK, it is a 50MBs jar!)
- drop Prometheus Provider (that brings Jetty)
- drop JCommander
- drop Commons-CLI
- drop net.minidev JSON smart