### PR TITLE
SELECTS that contain the 'from' string does not work with tablespace autodiscovery

### DIFF
--- a/herddb-core/src/main/java/herddb/utils/QueryUtils.java
+++ b/herddb-core/src/main/java/herddb/utils/QueryUtils.java
@@ -46,7 +46,7 @@ public class QueryUtils {
      * Prefix for INSERT before tablespace.tablename
      */
     private static final String PREFIX_INSERT = "(?i)insert\\W+into\\W+";
-    
+
     /**
      * Prefix for UPSERT before tablespace.tablename
      */

--- a/herddb-core/src/main/java/herddb/utils/QueryUtils.java
+++ b/herddb-core/src/main/java/herddb/utils/QueryUtils.java
@@ -46,6 +46,11 @@ public class QueryUtils {
      * Prefix for INSERT before tablespace.tablename
      */
     private static final String PREFIX_INSERT = "insert\\W+into\\W+";
+    
+    /**
+     * Prefix for UPSERT before tablespace.tablename
+     */
+    private static final String PREFIX_UPSERT = "upsert\\W+into\\W+";
 
     /**
      * Prefix for DELETE before tablespace.tablename
@@ -90,6 +95,7 @@ public class QueryUtils {
             "(?:" + PREFIX_SELECT
                     + "|" + PREFIX_UPDATE
                     + "|" + PREFIX_INSERT
+                    + "|" + PREFIX_UPSERT
                     + "|" + PREFIX_DELETE
                     + "|" + PREFIX_TABLE_CREATE
                     + "|" + PREFIX_TABLE_DROP

--- a/herddb-core/src/main/java/herddb/utils/QueryUtils.java
+++ b/herddb-core/src/main/java/herddb/utils/QueryUtils.java
@@ -35,58 +35,58 @@ public class QueryUtils {
     /**
      * Prefix for SELECT before tablespace.tablename
      */
-    private static final String PREFIX_SELECT = "select.+\\W+from\\W+";
+    private static final String PREFIX_SELECT = "(?i)select.+[^a-zA-Z_0-9'\"]+from[^a-zA-Z_0-9'\"]+";
 
     /**
      * Prefix for UPDATE before tablespace.tablename
      */
-    private static final String PREFIX_UPDATE = "update\\W+";
+    private static final String PREFIX_UPDATE = "(?i)update\\W+";
 
     /**
      * Prefix for INSERT before tablespace.tablename
      */
-    private static final String PREFIX_INSERT = "insert\\W+into\\W+";
+    private static final String PREFIX_INSERT = "(?i)insert\\W+into\\W+";
     
     /**
      * Prefix for UPSERT before tablespace.tablename
      */
-    private static final String PREFIX_UPSERT = "upsert\\W+into\\W+";
+    private static final String PREFIX_UPSERT = "(?i)upsert\\W+into\\W+";
 
     /**
      * Prefix for DELETE before tablespace.tablename
      */
-    private static final String PREFIX_DELETE = "delete\\W+from\\W+";
+    private static final String PREFIX_DELETE = "(?i)delete.+[^a-zA-Z_0-9'\"]+from[^a-zA-Z_0-9'\"]+";
 
     /**
      * Prefix for TABLE CREATE before tablespace.tablename
      */
-    private static final String PREFIX_TABLE_CREATE = "create\\W+table\\W+";
+    private static final String PREFIX_TABLE_CREATE = "(?i)create\\W+table\\W+";
 
     /**
      * Prefix for TABLE DROP before tablespace.tablename
      */
-    private static final String PREFIX_TABLE_DROP = "drop\\W+table\\W+";
+    private static final String PREFIX_TABLE_DROP = "(?i)drop\\W+table\\W+";
 
     /**
      * Prefix for TRUNCATE TABLE before tablespace.tablename
      */
-    private static final String PREFIX_TABLE_TRUNCATE = "truncate\\W+table\\W+";
+    private static final String PREFIX_TABLE_TRUNCATE = "(?i)truncate\\W+table\\W+";
 
     /**
      * Prefix for TABLE ALTER before tablespace.tablename
      */
-    private static final String PREFIX_TABLE_ALTER = "alter\\W+table\\W+";
+    private static final String PREFIX_TABLE_ALTER = "(?i)alter\\W+table\\W+";
 
     /**
      * Prefix for INDEX CREATE before tablespace.tablename
      */
     private static final String PREFIX_INDEX_CREATE =
-            "create\\W+(?:(" + Index.TYPE_HASH + "|" + Index.TYPE_BRIN + ")\\W+)?index\\W+.+\\W+on\\W+";
+            "(?i)create\\W+(?:(" + Index.TYPE_HASH + "|" + Index.TYPE_BRIN + ")\\W+)?index\\W+.+\\W+on\\W+";
 
     /**
      * Prefix for INDEX DROP before tablespace.tablename
      */
-    private static final String PREFIX_INDEX_DROP = "drop\\W+index\\W+";
+    private static final String PREFIX_INDEX_DROP = "(?i)drop\\W+index\\W+";
 
     /**
      * Combines prefixes and add tablespace.tablename groups

--- a/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
+++ b/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
@@ -64,7 +64,7 @@ public class QueryUtilsTest {
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into myts.test values(?,?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "INSERT INTO myts.a SELECT * FROM myts.c M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='Into' AND H.FIELD_VALUE LIKE 'aaa'))"));
     }
- 
+
     @Test
     public void testDiscoverTablespaceFromUpsert() {
         String defaultTableSpace = TableSpace.DEFAULT;

--- a/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
+++ b/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
@@ -22,6 +22,10 @@ package herddb.utils;
 
 import static org.junit.Assert.assertEquals;
 import herddb.model.TableSpace;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -41,6 +45,7 @@ public class QueryUtilsTest {
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "select a.b from myts.test"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "select a.b from myts.test where foo='bar'"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "select * from myts.test"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "SELECT COUNT(M.id) FROM myts.a M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='From' AND H.FIELD_VALUE LIKE 'aaa'))"));
     }
 
     @Test
@@ -61,7 +66,16 @@ public class QueryUtilsTest {
         assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into test values(?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into myts.test(a,b) values(?,?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into myts.test values(?,?,?,?)"));
-
+    }
+    
+    @Test
+    public void testDiscoverTablespaceFromUpsert() {
+        String defaultTableSpace = TableSpace.DEFAULT;
+        String theTableSpace = "myts";
+        assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into test(a,b) values(?,?,?)"));
+        assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into test values(?,?,?)"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into myts.test(a,b) values(?,?,?,?)"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into myts.test values(?,?,?,?)"));
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
+++ b/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
@@ -66,6 +66,7 @@ public class QueryUtilsTest {
         assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into test values(?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into myts.test(a,b) values(?,?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into myts.test values(?,?,?,?)"));
+	assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "INSERT INTO myts.a M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='Into' AND H.FIELD_VALUE LIKE 'aaa'))"));
     }
     
     @Test
@@ -76,6 +77,20 @@ public class QueryUtilsTest {
         assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into test values(?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into myts.test(a,b) values(?,?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into myts.test values(?,?,?,?)"));
+	assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "UPSERT INTO myts.a M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='Into' AND H.FIELD_VALUE LIKE 'aaa'))"));
+    }
+
+    @Test
+    public void testDiscoverTablespaceFromDelete() {
+        String defaultTableSpace = TableSpace.DEFAULT;
+        String theTableSpace = "myts";
+        assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "delete * from test"));
+        assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, ""));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "delete a from myts.test"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "delete a.b from myts.test"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "delete a.b from myts.test where foo='bar'"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "delete * from myts.test"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "DELTE FROM myts.a M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='From' AND H.FIELD_VALUE LIKE 'aaa'))"));
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
+++ b/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
@@ -66,9 +66,9 @@ public class QueryUtilsTest {
         assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into test values(?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into myts.test(a,b) values(?,?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "insert into myts.test values(?,?,?,?)"));
-	assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "INSERT INTO myts.a M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='Into' AND H.FIELD_VALUE LIKE 'aaa'))"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "INSERT INTO myts.a SELECT * FROM myts.c M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='Into' AND H.FIELD_VALUE LIKE 'aaa'))"));
     }
-    
+ 
     @Test
     public void testDiscoverTablespaceFromUpsert() {
         String defaultTableSpace = TableSpace.DEFAULT;
@@ -77,7 +77,7 @@ public class QueryUtilsTest {
         assertEquals(defaultTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into test values(?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into myts.test(a,b) values(?,?,?,?)"));
         assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "upsert into myts.test values(?,?,?,?)"));
-	assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "UPSERT INTO myts.a M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='Into' AND H.FIELD_VALUE LIKE 'aaa'))"));
+        assertEquals(theTableSpace, QueryUtils.discoverTablespace(defaultTableSpace, "UPSERT INTO myts.a SELECT * FROM myts.c M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='Into' AND H.FIELD_VALUE LIKE 'aaa'))"));
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
+++ b/herddb-core/src/test/java/herddb/utils/QueryUtilsTest.java
@@ -22,10 +22,6 @@ package herddb.utils;
 
 import static org.junit.Assert.assertEquals;
 import herddb.model.TableSpace;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
TableSpace autodetection does not work in these cases:
- UPSERT statements
- statements like `SELECT COUNT(M.id) FROM myts.a M WHERE 1=1 AND (M.id IN (SELECT H.id FROM myts.b AS H WHERE H.FIELD_NAME='From' AND H.FIELD_VALUE LIKE 'aaa'))`

The problem is that the query contains a string literal 'from'