### PR TITLE
Allow NULL in multi-column secondary indexes

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1742,7 +1742,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             /* If there are indexes e have already forced a page load and previous record has been loaded */
             DataAccessor values = previous.getDataAccessor(table);
             for (AbstractIndexManager index : indexes.values()) {
-                Bytes indexKey = RecordSerializer.serializePrimaryKey(values, index.getIndex(), index.getColumnNames());
+                Bytes indexKey = RecordSerializer.serializeIndexKey(values, index.getIndex(), index.getColumnNames());
                 index.recordDeleted(key, indexKey);
             }
         }
@@ -1880,8 +1880,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             for (AbstractIndexManager index : indexes.values()) {
                 Index indexDef = index.getIndex();
                 String[] indexColumnNames = index.getColumnNames();
-                Bytes indexKeyRemoved = RecordSerializer.serializePrimaryKey(prevValues, indexDef, indexColumnNames);
-                Bytes indexKeyAdded = RecordSerializer.serializePrimaryKey(newValues, indexDef, indexColumnNames);
+                Bytes indexKeyRemoved = RecordSerializer.serializeIndexKey(prevValues, indexDef, indexColumnNames);
+                Bytes indexKeyAdded = RecordSerializer.serializeIndexKey(newValues, indexDef, indexColumnNames);
                 index.recordUpdated(key, indexKeyRemoved, indexKeyAdded);
             }
         }
@@ -2038,7 +2038,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             /* Standard insert */
             DataAccessor values = record.getDataAccessor(table);
             for (AbstractIndexManager index : indexes.values()) {
-                Bytes indexKey = RecordSerializer.serializePrimaryKey(values, index.getIndex(), index.getColumnNames());
+                Bytes indexKey = RecordSerializer.serializeIndexKey(values, index.getIndex(), index.getColumnNames());
                 index.recordInserted(key, indexKey);
             }
         }

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -136,8 +136,8 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
         Table table = tableManager.getTable();
         tableManager.scanForIndexRebuild(r -> {
             DataAccessor values = r.getDataAccessor(table);
-            Bytes key = RecordSerializer.serializePrimaryKey(values, table, table.primaryKey);
-            Bytes indexKey = RecordSerializer.serializePrimaryKey(values, index, index.columnNames);
+            Bytes key = RecordSerializer.serializeIndexKey(values, table, table.primaryKey);
+            Bytes indexKey = RecordSerializer.serializeIndexKey(values, index, index.columnNames);
 //            LOGGER.log(Level.SEVERE, "adding " + key + " -> " + values);
             recordInserted(key, indexKey);
         });

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -296,8 +296,8 @@ public class BRINIndexManager extends AbstractIndexManager {
         AtomicLong count = new AtomicLong();
         tableManager.scanForIndexRebuild(r -> {
             DataAccessor values = r.getDataAccessor(table);
-            Bytes key = RecordSerializer.serializePrimaryKey(values, table, table.primaryKey);
-            Bytes indexKey = RecordSerializer.serializePrimaryKey(values, index, index.columnNames);
+            Bytes key = RecordSerializer.serializeIndexKey(values, table, table.primaryKey);
+            Bytes indexKey = RecordSerializer.serializeIndexKey(values, index, index.columnNames);
 //            LOGGER.log(Level.SEVERE, "adding " + key + " -> " + values);
             recordInserted(key, indexKey);
             count.incrementAndGet();

--- a/herddb-core/src/main/java/herddb/model/Index.java
+++ b/herddb-core/src/main/java/herddb/model/Index.java
@@ -61,9 +61,7 @@ public class Index implements ColumnsList {
 
     @Override
     public boolean allowNullsForIndexedValues() {
-        // for single column indexes we can support null values
-        // they usually won't be indexed, but this fact depends on the index implemention.
-        return columnNames.length == 1;
+        return true;
     }
 
     private Index(

--- a/herddb-core/src/main/java/herddb/model/planner/DeleteOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/DeleteOp.java
@@ -85,7 +85,7 @@ public class DeleteOp implements PlannerOp {
                     transactionId = transactionIdFromScanner;
                     transactionContext = new TransactionContext(transactionId);
                 }
-                Bytes key = RecordSerializer.serializePrimaryKey(row, table, table.getPrimaryKey());
+                Bytes key = RecordSerializer.serializeIndexKey(row, table, table.getPrimaryKey());
                 DMLStatement deleteStatement = new DeleteStatement(tableSpace, tableName,
                         null, new RawKeyEquals(key));
 

--- a/herddb-core/src/main/java/herddb/model/planner/UpdateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UpdateOp.java
@@ -93,7 +93,7 @@ public class UpdateOp implements PlannerOp {
                     transactionId = transactionIdFromScanner;
                     transactionContext = new TransactionContext(transactionId);
                 }
-                Bytes key = RecordSerializer.serializePrimaryKey(row, table, table.getPrimaryKey());
+                Bytes key = RecordSerializer.serializeIndexKey(row, table, table.getPrimaryKey());
                 Predicate pred = new RawKeyEquals(key);
                 DMLStatement updateStatement = new UpdateStatement(tableSpace, tableName,
                         null, this.recordFunction, pred)

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -60,36 +60,48 @@ public interface SQLRecordPredicateFunctions {
         } else if (b == null) {
             return -1;
         }
-        if (a instanceof RawString && b instanceof RawString) {
-            return ((RawString) a).compareTo((RawString) b);
-        }
-        if (a instanceof RawString && b instanceof String) {
-            return ((RawString) a).compareToString((String) b);
+        if (a instanceof RawString) {
+            if (b instanceof RawString) {
+                return ((RawString) a).compareTo((RawString) b);
+            }
+            if (b instanceof String) {
+                return ((RawString) a).compareToString((String) b);
+            }
         }
         if (a instanceof String && b instanceof RawString) {
             return -((RawString) b).compareToString((String) a);
         }
-        if (a instanceof Integer && b instanceof Integer) {
-            return (Integer) a - (Integer) b;
+        if (a instanceof Integer) {
+            if (b instanceof Integer) {
+                return (Integer) a - (Integer) b;
+            }
+            if (b instanceof Long) {
+                long delta = (Integer) a - (Long) b;
+                return delta == 0 ? 0 : delta > 0 ? 1 : -1;
+            }
         }
-        if (a instanceof Long && b instanceof Long) {
-            double delta = (Long) a - (Long) b;
-            return delta == 0 ? 0 : delta > 0 ? 1 : -1;
+        if (a instanceof Long) {
+            if (b instanceof Long) {
+                long delta = (Long) a - (Long) b;
+                return delta == 0 ? 0 : delta > 0 ? 1 : -1;
+            }
+            if (b instanceof java.util.Date) {
+                long delta = ((Long) a) - ((java.util.Date) b).getTime();
+                return delta == 0 ? 0 : delta > 0 ? 1 : -1;
+            }
         }
         if (a instanceof Number && b instanceof Number) {
             return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
         }
-        if (a instanceof java.util.Date && b instanceof java.util.Date) {
-            long delta = ((java.util.Date) a).getTime() - ((java.util.Date) b).getTime();
-            return delta == 0 ? 0 : delta > 0 ? 1 : -1;
-        }
-        if (a instanceof java.util.Date && b instanceof java.lang.Long) {
-            long delta = ((java.util.Date) a).getTime() - ((Long) b);
-            return delta == 0 ? 0 : delta > 0 ? 1 : -1;
-        }
-        if (a instanceof Long && b instanceof java.util.Date) {
-            long delta = ((Long) a) - ((java.util.Date) b).getTime();
-            return delta == 0 ? 0 : delta > 0 ? 1 : -1;
+        if (a instanceof java.util.Date) {
+            if (b instanceof java.util.Date) {
+                long delta = ((java.util.Date) a).getTime() - ((java.util.Date) b).getTime();
+                return delta == 0 ? 0 : delta > 0 ? 1 : -1;
+            }
+            if (b instanceof java.lang.Long) {
+                long delta = ((java.util.Date) a).getTime() - ((Long) b);
+                return delta == 0 ? 0 : delta > 0 ? 1 : -1;
+            }
         }
         if (a instanceof Comparable && b instanceof Comparable && a.getClass() == b.getClass()) {
             return ((Comparable) a).compareTo(b);

--- a/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/VisibleByteArrayOutputStream.java
@@ -106,6 +106,11 @@ public class VisibleByteArrayOutputStream extends OutputStream {
         count += len;
     }
 
+    @Override
+    public void write(byte b[]) {
+        write(b, 0, b.length);
+    }
+
     public void writeTo(OutputStream out) throws IOException {
         out.write(buf, 0, count);
     }


### PR DESCRIPTION
- Allow NULL values in multi-column secondary indexes
- If the first column is NULL the record is not indexed
- Serialize other columns up to the first NULL, in order to allow SecondaryIndexPrefixScans
- Add tests about RecordSerializer
- Clean up default buffer sizes (4kb is too much for keys)
- reorganize `compare(Object a, Object b)` in order to reduce the number of "instanceof" (we can't get rid of them)

Closes #625 