### PR TITLE
Issue 661: Use tablespace replication factor (expectedreplicacount) as configuration for BK write quorum size

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1790,6 +1790,10 @@ public class TableSpaceManager {
         }
     }
 
+    public boolean isClosed() {
+        return closed;
+    }
+
     private static class TableSpaceCheckpoint {
 
         private final LogSequenceNumber sequenceNumber;

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -194,7 +194,12 @@ public class TableSpaceManager {
         return tableSpaceUUID;
     }
 
-    public TableSpaceManager(String nodeId, String tableSpaceName, String tableSpaceUUID, MetadataStorageManager metadataStorageManager, DataStorageManager dataStorageManager, CommitLog log, DBManager manager, boolean virtual) {
+    public TableSpaceManager(String nodeId, String tableSpaceName,
+                             String tableSpaceUUID,
+                             int expectedReplicaCount,
+                             MetadataStorageManager metadataStorageManager,
+                             DataStorageManager dataStorageManager,
+                             CommitLog log, DBManager manager, boolean virtual) {
         this.nodeId = nodeId;
         this.dbmanager = manager;
         this.callbacksExecutor = dbmanager.getCallbacksExecutor();
@@ -206,6 +211,7 @@ public class TableSpaceManager {
         this.virtual = virtual;
         this.tablespaceStasLogger = this.dbmanager.getStatsLogger().scope(this.tableSpaceName);
         this.checkpointTimeStats = this.tablespaceStasLogger.getOpStatsLogger("checkpointTime");
+        this.dataStorageManager.tableSpaceMetadataUpdated(tableSpaceUUID, expectedReplicaCount);
     }
 
     private void bootSystemTables() {
@@ -238,7 +244,7 @@ public class TableSpaceManager {
 
         bootSystemTables();
         if (virtual) {
-            startAsLeader();
+            startAsLeader(1);
         } else {
             recover(tableSpaceInfo);
 
@@ -246,7 +252,7 @@ public class TableSpaceManager {
 
             tableSpaceInfo = metadataStorageManager.describeTableSpace(tableSpaceName);
             if (tableSpaceInfo.leaderId.equals(nodeId)) {
-                startAsLeader();
+                startAsLeader(tableSpaceInfo.expectedReplicaCount);
             } else {
                 startAsFollower();
             }
@@ -785,6 +791,14 @@ public class TableSpaceManager {
         return result;
     }
 
+    void metadataUpdated(TableSpace tableSpace) {
+        if (!tableSpace.uuid.equals(this.tableSpaceUUID)) {
+            throw new IllegalArgumentException();
+        }
+        log.metadataUpdated(tableSpace.expectedReplicaCount);
+        dataStorageManager.tableSpaceMetadataUpdated(tableSpace.uuid, tableSpace.expectedReplicaCount);
+    }
+
     private static class CheckpointFuture extends CompletableFuture {
 
         private final String tableName;
@@ -1149,7 +1163,7 @@ public class TableSpaceManager {
         dbmanager.submit(followerThread);
     }
 
-    void startAsLeader() throws DataStorageManagerException, DDLException, LogNotAvailableException {
+    void startAsLeader(int expectedReplicaCount) throws DataStorageManagerException, DDLException, LogNotAvailableException {
         if (virtual) {
 
         } else {
@@ -1159,7 +1173,7 @@ public class TableSpaceManager {
 
             // every pending transaction MUST be rollback back
             List<Long> pending_transactions = new ArrayList<>(this.transactions.keySet());
-            log.startWriting();
+            log.startWriting(expectedReplicaCount);
             LOGGER.log(Level.INFO, "startAsLeader {0} tablespace {1} log, there were {2} pending transactions to be rolledback", new Object[]{nodeId, tableSpaceName, pending_transactions.size()});
             for (long tx : pending_transactions) {
                 forceTransactionRollback(tx);

--- a/herddb-core/src/main/java/herddb/file/FileCommitLog.java
+++ b/herddb-core/src/main/java/herddb/file/FileCommitLog.java
@@ -739,7 +739,7 @@ public class FileCommitLog extends CommitLog {
     }
 
     @Override
-    public void startWriting() throws LogNotAvailableException {
+    public void startWriting(int expectedReplicaCount) throws LogNotAvailableException {
         ensureDirectories();
         this.spool.start();
     }

--- a/herddb-core/src/main/java/herddb/log/CommitLog.java
+++ b/herddb-core/src/main/java/herddb/log/CommitLog.java
@@ -55,6 +55,9 @@ public abstract class CommitLog implements AutoCloseable {
         return true;
     }
 
+    public void metadataUpdated(int expectedReplicaCount) {
+    }
+
     public interface FollowerContext extends AutoCloseable {
 
         @Override
@@ -79,7 +82,7 @@ public abstract class CommitLog implements AutoCloseable {
 
     public abstract LogSequenceNumber getLastSequenceNumber();
 
-    public abstract void startWriting() throws LogNotAvailableException;
+    public abstract void startWriting(int expectedReplicaCount) throws LogNotAvailableException;
 
     public abstract void clear() throws LogNotAvailableException;
 

--- a/herddb-core/src/main/java/herddb/mem/MemoryCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryCommitLogManager.java
@@ -107,7 +107,7 @@ public class MemoryCommitLogManager extends CommitLogManager {
             }
 
             @Override
-            public void startWriting() throws LogNotAvailableException {
+            public void startWriting(int expectedReplicaCount) throws LogNotAvailableException {
             }
 
             @Override

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -67,6 +67,9 @@ public abstract class DataStorageManager implements AutoCloseable {
 
     public abstract void initTable(String tableSpace, String uuid) throws DataStorageManagerException;
 
+    public void tableSpaceMetadataUpdated(String tableSpace, int expectedReplicaCount) {
+    }
+
     @FunctionalInterface
     public interface DataReader<X> {
 

--- a/herddb-core/src/test/java/herddb/cluster/ExpectedReplicaCountTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ExpectedReplicaCountTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.cluster;
+
+import static org.junit.Assert.assertEquals;
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.client.HDBConnection;
+import herddb.core.TestUtils;
+import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.utils.ZKTestEnv;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeperAdmin;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.test.TestStatsProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests about expectedreplicacount persistence guarantees
+ *
+ * @author enrico.olivelli
+ */
+public class ExpectedReplicaCountTest {
+
+    private static final Logger LOG = Logger.getLogger(ExpectedReplicaCountTest.class.getName());
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        testEnv.startBookieAndInitCluster();
+        // as expectedreplicacount is 2 we need at least two bookies
+        testEnv.startNewBookie();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Test
+    public void testDisklessClusterReplication() throws Exception {
+
+        TestStatsProvider statsProvider = new TestStatsProvider();
+
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        try (Server server_1 = new Server(serverconfig_1)) {
+            server_1.start();
+            server_1.waitForStandaloneBoot();
+
+            TestUtils.execute(server_1.getManager(),
+                    "CREATE TABLESPACE 'ttt','leader:" + server_1.getNodeId() + "','expectedreplicacount:2'",
+                    Collections.emptyList());
+
+            // perform some writes
+            ClientConfiguration clientConfiguration = new ClientConfiguration();
+            clientConfiguration.set(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_CLUSTER);
+            clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+            clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+            clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+            StatsLogger logger = statsProvider.getStatsLogger("ds");
+            try (HDBClient client1 = new HDBClient(clientConfiguration, logger)) {
+                try (HDBConnection connection = client1.openConnection()) {
+
+                    // create table and insert data
+                    connection.executeUpdate(TableSpace.DEFAULT, "CREATE TABLE ttt.t1(k1 int primary key, n1 int)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                    connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(1,1)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                    connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(2,1)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                    connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(3,1)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+
+                    // flush data pages to BK
+                    server_1.getManager().checkpoint();
+
+                    Set<Long> initialLedgers = new HashSet<>();
+                    // verify that every ledger has ensemble size 2
+                    try (BookKeeper bk = createBookKeeper();) {
+                        BookKeeperAdmin admin = new BookKeeperAdmin(bk);
+                        for (long lId : admin.listLedgers()) {
+                            LedgerMetadata md = bk.getLedgerManager().readLedgerMetadata(lId).get().getValue();
+                            if ("ttt".equals(new String(md.getCustomMetadata().get("tablespaceuuid"), StandardCharsets.UTF_8))) {
+                                assertEquals(2, md.getEnsembleSize());
+                                assertEquals(2, md.getWriteQuorumSize());
+                                assertEquals(2, md.getAckQuorumSize());
+                                initialLedgers.add(lId);
+                            }
+                        }
+                    }
+
+                    BookkeeperCommitLog log = (BookkeeperCommitLog) server_1.getManager().getTableSpaceManager("ttt").getLog();
+                    final long currentLedgerId = log.getWriter().getLedgerId();
+
+                    // downsize to expectedreplicacount = 1
+                    TestUtils.execute(server_1.getManager(),
+                            "ALTER TABLESPACE 'ttt','leader:" + server_1.getNodeId() + "','expectedreplicacount:1'",
+                            Collections.emptyList());
+
+                    // the TableSpaceManager will roll a new ledger
+                    herddb.utils.TestUtils.waitForCondition(() -> {
+                        long newLedgerId = log.getWriter().getLedgerId();
+                        return newLedgerId != currentLedgerId;
+                    }, herddb.utils.TestUtils.NOOP, 100);
+
+                    // write some other record
+                    connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO ttt.t1(k1,n1) values(4,1)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+
+                    // flush data pages
+                    server_1.getManager().checkpoint();
+
+                    // verify that every ledger has ensemble size 2 or 1
+                    try (BookKeeper bk = createBookKeeper();) {
+                        BookKeeperAdmin admin = new BookKeeperAdmin(bk);
+                        for (long lId : admin.listLedgers()) {
+                            LedgerMetadata md = bk.getLedgerManager().readLedgerMetadata(lId).get().getValue();
+                            if ("ttt".equals(new String(md.getCustomMetadata().get("tablespaceuuid"), StandardCharsets.UTF_8))) {
+                                if (initialLedgers.contains(lId)) {
+                                    assertEquals(2, md.getEnsembleSize());
+                                    assertEquals(2, md.getWriteQuorumSize());
+                                    assertEquals(2, md.getAckQuorumSize());
+                                } else {
+                                    assertEquals(1, md.getEnsembleSize());
+                                    assertEquals(1, md.getWriteQuorumSize());
+                                    assertEquals(1, md.getAckQuorumSize());
+                                }
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+
+    protected BookKeeper createBookKeeper() throws Exception {
+        org.apache.bookkeeper.conf.ClientConfiguration clientConfiguration = new org.apache.bookkeeper.conf.ClientConfiguration();
+        clientConfiguration.setZkServers(testEnv.getAddress());
+        clientConfiguration.setZkLedgersRootPath(ServerConfiguration.PROPERTY_BOOKKEEPER_LEDGERS_PATH_DEFAULT);
+        return BookKeeper.forConfig(clientConfiguration).build();
+    }
+}

--- a/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
@@ -80,6 +80,8 @@ public class RetryOnLeaderChangedTest {
     public void beforeSetup() throws Exception {
         testEnv = new ZKTestEnv(folder.newFolder().toPath());
         testEnv.startBookieAndInitCluster();
+        // as expectedreplicacount is 2 we need at least two bookies
+        testEnv.startNewBookie();
     }
 
     @After

--- a/herddb-core/src/test/java/herddb/cluster/TablespaceReplicasStateTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/TablespaceReplicasStateTest.java
@@ -101,7 +101,7 @@ public class TablespaceReplicasStateTest {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -174,7 +174,7 @@ public class TablespaceReplicasStateTest {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/BookKeeperCommitLogTest.java
@@ -88,7 +88,7 @@ public class BookKeeperCommitLogTest {
             LogSequenceNumber lsn2;
             LogSequenceNumber lsn3;
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
-                writer.startWriting();
+                writer.startWriting(1);
                 lsn1 = writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
                 lsn2 = writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber();
                 lsn3 = writer.log(LogEntryFactory.beginTransaction(3), true).getLogSequenceNumber();
@@ -129,14 +129,14 @@ public class BookKeeperCommitLogTest {
             LogSequenceNumber lsn2;
             LogSequenceNumber lsn3;
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
-                writer.startWriting();
+                writer.startWriting(1);
                 lsn1 = writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
                 lsn2 = writer.log(LogEntryFactory.beginTransaction(2), true).getLogSequenceNumber();
 
                 // a new leader starts, from START_OF_TIME
                 try (BookkeeperCommitLog writer2 = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
                     writer2.recovery(LogSequenceNumber.START_OF_TIME, (a, b) -> {}, true);
-                    writer2.startWriting();
+                    writer2.startWriting(1);
                     lsn3 = writer2.log(LogEntryFactory.beginTransaction(3), true).getLogSequenceNumber();
                 }
 
@@ -185,7 +185,7 @@ public class BookKeeperCommitLogTest {
             CommitLogResult res3;
 
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
-                writer.startWriting();
+                writer.startWriting(1);
                 res1 = writer.log(LogEntryFactory.beginTransaction(1), false);
                 res2 = writer.log(LogEntryFactory.beginTransaction(2), false);
                 res3 = writer.log(LogEntryFactory.beginTransaction(3), true);
@@ -230,7 +230,7 @@ public class BookKeeperCommitLogTest {
             logManager.start();
 
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
-                writer.startWriting();
+                writer.startWriting(1);
 
                 writer.log(LogEntryFactory.beginTransaction(1), true).getLogSequenceNumber();
 
@@ -286,7 +286,7 @@ public class BookKeeperCommitLogTest {
             logManager.start();
 
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
-                writer.startWriting();
+                writer.startWriting(1);
 
                 // many async writes
                 writer.log(LogEntryFactory.beginTransaction(1), false).getLogSequenceNumber();
@@ -352,7 +352,7 @@ public class BookKeeperCommitLogTest {
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
                 // do not pollute the count with NOOP entries
                 writer.setWriteLedgerHeader(false);
-                writer.startWriting();
+                writer.startWriting(1);
                 for (int i = 0; i < numberOfEntries; i++) {
                     writer.log(entry, false);
                 }
@@ -399,7 +399,7 @@ public class BookKeeperCommitLogTest {
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
                 // do not pollute the count with NOOP entries
                 writer.setWriteLedgerHeader(false);
-                writer.startWriting();
+                writer.startWriting(1);
                 for (int i = 0; i < numberOfEntries; i++) {
                     writer.log(entry, false);
                     if (i == 70) {
@@ -445,7 +445,7 @@ public class BookKeeperCommitLogTest {
             logManager.start();
 
             try (BookkeeperCommitLog writer = logManager.createCommitLog(tableSpaceUUID, name, nodeid);) {
-                writer.startWriting();
+                writer.startWriting(1);
 
                 // create a ledger, up to 0.14.x no "logical" write happens, so Bookies are not aware of the
                 // the ledger

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/LedgerClosedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/LedgerClosedTest.java
@@ -110,7 +110,7 @@ public class LedgerClosedTest extends BookkeeperFailuresBase {
 
             // set server2 as new leader
             server.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 2, 0),
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 1, 0),
                     StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // stop server1

--- a/herddb-core/src/test/java/herddb/cluster/bookkeeper/MultiBookieTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/bookkeeper/MultiBookieTest.java
@@ -96,7 +96,7 @@ public class MultiBookieTest extends BookkeeperFailuresBase {
                     DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
                     "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootAsNewLeaderTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootAsNewLeaderTest.java
@@ -107,7 +107,7 @@ public class BootAsNewLeaderTest extends MultiServerBase {
 
             // set forcibly server2 as new leader
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
         }
 
@@ -212,7 +212,7 @@ public class BootAsNewLeaderTest extends MultiServerBase {
                     DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
                     "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
@@ -319,7 +319,7 @@ public class BootAsNewLeaderTest extends MultiServerBase {
             // but server1 is not writing so it won't know from BK
             // it will see his new role from zookeeper (with a 'watch' notification)
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // data should  be downloaded again from the other server,
             // but the new leader is server_2 itself
@@ -336,7 +336,7 @@ public class BootAsNewLeaderTest extends MultiServerBase {
 
             // make server_1 leader again
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // now server_2 must be able to boot, downloading data from server_1 and easing local state
             try (Server server_2 = new Server(serverconfig_2)) {
@@ -349,7 +349,7 @@ public class BootAsNewLeaderTest extends MultiServerBase {
 
             // make server_2 leader again
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             // stop server_1
             server_1.close();

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
@@ -627,7 +627,7 @@ public class BootFollowerTest extends MultiServerBase {
                 server_3.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2", "server3")), "server1", 3, 15000), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2", "server3")), "server1", 1, 15000), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
                 assertTrue(server_3.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));

--- a/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/BootFollowerTest.java
@@ -123,7 +123,7 @@ public class BootFollowerTest extends MultiServerBase {
                 server_2.getManager().setActivatorPauseStatus(false);
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -204,7 +204,7 @@ public class BootFollowerTest extends MultiServerBase {
                     DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
                     "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
@@ -298,7 +298,7 @@ public class BootFollowerTest extends MultiServerBase {
                     DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
                     "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
@@ -447,7 +447,7 @@ public class BootFollowerTest extends MultiServerBase {
                 }
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
                 LogSequenceNumber lastSequenceNumberServer2 = server_2.getManager().getTableSpaceManager(TableSpace.DEFAULT).getLog().getLastSequenceNumber();
@@ -511,7 +511,7 @@ public class BootFollowerTest extends MultiServerBase {
                     TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             try (Server server_2 = new Server(serverconfig_2)) {
                 server_2.start();

--- a/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
@@ -101,7 +101,7 @@ public class ChangeRoleTest extends MultiServerBase {
 
             // set forcibly server2 as new follower
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             assertEquals(0, server2MemoryManager.getDataPageReplacementPolicy().size());
             assertEquals(0, server2MemoryManager.getPKPageReplacementPolicy().size());
@@ -130,7 +130,7 @@ public class ChangeRoleTest extends MultiServerBase {
 
             // start tablespace on server2, as let it become leader
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server2", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             server_2.waitForTableSpaceBoot(TableSpace.DEFAULT, true);
 

--- a/herddb-core/src/test/java/herddb/cluster/follower/EdgeCasesFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/EdgeCasesFollowerTest.java
@@ -114,7 +114,7 @@ public class EdgeCasesFollowerTest extends MultiServerBase {
                     DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             TranslatedQuery translated = server_1.getManager().getPlanner().translate(TableSpace.DEFAULT,
                     "SELECT * FROM " + TableSpace.DEFAULT + ".t1 WHERE s=1",
@@ -280,7 +280,7 @@ public class EdgeCasesFollowerTest extends MultiServerBase {
                     TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
         }
 
         String tableSpaceUUID;

--- a/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
@@ -307,7 +307,7 @@ public class SimpleFollowerTest extends MultiServerBase {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 

--- a/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/SimpleFollowerTest.java
@@ -259,7 +259,7 @@ public class SimpleFollowerTest extends MultiServerBase {
                 assertTrue(server_2.getManager().isTableSpaceLocallyRecoverable(server_1.getMetadataStorageManager().describeTableSpace(TableSpace.DEFAULT)));
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
             }
         }
@@ -395,7 +395,7 @@ public class SimpleFollowerTest extends MultiServerBase {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -462,7 +462,7 @@ public class SimpleFollowerTest extends MultiServerBase {
                     TransactionContext.NO_TRANSACTION);
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
 
 

--- a/herddb-core/src/test/java/herddb/core/ReplicatedAlterTableTest.java
+++ b/herddb-core/src/test/java/herddb/core/ReplicatedAlterTableTest.java
@@ -47,7 +47,7 @@ public class ReplicatedAlterTableTest extends ReplicatedLogtestcase {
         final String tableSpaceName = "tblspace1";
         try (DBManager manager1 = startDBManager("node1")) {
 
-            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 2, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 1, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             assertTrue(manager1.waitForTablespace(tableSpaceName, 10000, true));
             try (DBManager manager2 = startDBManager("node2")) {
                 assertTrue(manager2.waitForTablespace(tableSpaceName, 10000, false));

--- a/herddb-core/src/test/java/herddb/core/ReplicatedLogtestcase.java
+++ b/herddb-core/src/test/java/herddb/core/ReplicatedLogtestcase.java
@@ -42,7 +42,7 @@ public abstract class ReplicatedLogtestcase {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-    private ZKTestEnv testEnv;
+    protected ZKTestEnv testEnv;
 
     @Before
     public void beforeSetup() throws Exception {

--- a/herddb-core/src/test/java/herddb/core/SimpleRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleRecoveryTest.java
@@ -950,7 +950,7 @@ public class SimpleRecoveryTest {
                 log.recovery(LogSequenceNumber.START_OF_TIME, (n, e) -> {
                 }, false);
 
-                log.startWriting();
+                log.startWriting(1);
 
                 /* Insert an entry for a unknown transaction id */
                 LogEntry entry = new LogEntry(System.currentTimeMillis(), LogEntryType.INSERT, 1024, "t1", key, value);
@@ -1034,7 +1034,7 @@ public class SimpleRecoveryTest {
                 log.recovery(LogSequenceNumber.START_OF_TIME, (n, e) -> {
                 }, false);
 
-                log.startWriting();
+                log.startWriting(1);
 
                 /* Insert an entry for a unknown transaction id */
                 LogEntry entry = new LogEntry(System.currentTimeMillis(), LogEntryType.DELETE, 1024, "t1", key, null);
@@ -1120,7 +1120,7 @@ public class SimpleRecoveryTest {
                 log.recovery(LogSequenceNumber.START_OF_TIME, (n, e) -> {
                 }, false);
 
-                log.startWriting();
+                log.startWriting(1);
 
                 /* Insert an entry for a unknown transaction id */
                 LogEntry entry = new LogEntry(System.currentTimeMillis(), LogEntryType.UPDATE, 1024, "t1", key, value2);

--- a/herddb-core/src/test/java/herddb/core/SimpleReplicationTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleReplicationTest.java
@@ -48,7 +48,7 @@ public class SimpleReplicationTest extends ReplicatedLogtestcase {
         final String tableSpaceName = "t2";
         try (DBManager manager1 = startDBManager("node1")) {
 
-            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 2, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 1, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             assertTrue(manager1.waitForTablespace(tableSpaceName, 10000, true));
             try (DBManager manager2 = startDBManager("node2")) {
                 assertTrue(manager2.waitForTablespace(tableSpaceName, 10000, false));

--- a/herddb-core/src/test/java/herddb/core/UnderreplicationTest.java
+++ b/herddb-core/src/test/java/herddb/core/UnderreplicationTest.java
@@ -37,8 +37,13 @@ public class UnderreplicationTest extends ReplicatedLogtestcase {
 
     @Test
     public void test() throws Exception {
+        // we want replication factor = 2, we need two bookies
+        testEnv.startNewBookie();
+
         final String tableSpaceName = "t2";
         try (DBManager manager1 = startDBManager("node1")) {
+            // setting expectedReplicaCount = 2
+            // the system will automatically add node2 as soon as it is available
             manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1")), "node1", 2, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             assertTrue(manager1.waitForTablespace(tableSpaceName, 10000, true));
             try (DBManager manager2 = startDBManager("node2")) {

--- a/herddb-core/src/test/java/herddb/data/consistency/ConsistencyCheckDuringRecoveryTest.java
+++ b/herddb-core/src/test/java/herddb/data/consistency/ConsistencyCheckDuringRecoveryTest.java
@@ -57,7 +57,7 @@ public class ConsistencyCheckDuringRecoveryTest extends ReplicatedLogtestcase {
             }
         });
         try (DBManager manager1 = startDBManager("node1")) {
-            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 2, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 1, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             manager1.waitForTablespace(tableSpaceName, 10000, true);
             try (DBManager manager2 = startDBManager("node2")) {
                 manager2.waitForTablespace(tableSpaceName, 10000, false);

--- a/herddb-core/src/test/java/herddb/data/consistency/MultiNodeConsistencyCheckTest.java
+++ b/herddb-core/src/test/java/herddb/data/consistency/MultiNodeConsistencyCheckTest.java
@@ -58,7 +58,7 @@ public class MultiNodeConsistencyCheckTest extends ReplicatedLogtestcase {
             }
         });
         try (DBManager manager1 = startDBManager("node1")) {
-            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 2, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager1.executeStatement(new CreateTableSpaceStatement(tableSpaceName, new HashSet<>(Arrays.asList("node1", "node2")), "node1", 1, 0, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             manager1.waitForTablespace(tableSpaceName, 10000, true);
             try (DBManager manager2 = startDBManager("node2")) {
                 manager2.waitForTablespace(tableSpaceName, 10000, false);

--- a/herddb-core/src/test/java/herddb/file/FileCommitLogTest.java
+++ b/herddb-core/src/test/java/herddb/file/FileCommitLogTest.java
@@ -60,7 +60,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (CommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 for (int i = 0; i < 10_000; i++) {
                     log.log(LogEntryFactory.beginTransaction(0), false);
                     writeCount++;
@@ -98,7 +98,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (CommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 for (int i = 0; i < 100; i++) {
                     log.log(LogEntryFactory.beginTransaction(0), true).getLogSequenceNumber();
                     writeCount++;
@@ -160,7 +160,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (CommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 for (int i = 0; i < 100; i++) {
                     log.log(LogEntryFactory.beginTransaction(0), true).getLogSequenceNumber();
                     writeCount++;
@@ -214,7 +214,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (CommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 for (int i = 0; i < 100; i++) {
                     log.log(LogEntryFactory.beginTransaction(0), true);
                     writeCount++;
@@ -257,7 +257,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (FileCommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 for (int i = 0; i < 10_000; i++) {
                     log.log(LogEntryFactory.beginTransaction(0), false);
                     writeCount++;
@@ -309,7 +309,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (FileCommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 for (int i = 0; i < 10_000; i++) {
                     log.log(LogEntryFactory.beginTransaction(0), false);
                     writeCount++;
@@ -360,7 +360,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (FileCommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 log.log(LogEntryFactory.beginTransaction(0), true).getLogSequenceNumber();
                 writeCount = 1;
             }
@@ -401,7 +401,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (FileCommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 CopyOnWriteArrayList<LogSequenceNumber> completed = new CopyOnWriteArrayList<>();
 
                 CommitLogResult future = log.log(LogEntryFactory.beginTransaction(0), true);
@@ -459,7 +459,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (FileCommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 CopyOnWriteArrayList<LogSequenceNumber> completed = new CopyOnWriteArrayList<>();
 
                 CommitLogResult future = log.log(LogEntryFactory.beginTransaction(0), true);
@@ -517,7 +517,7 @@ public class FileCommitLogTest {
             int writeCount = 0;
             final long _startWrite = System.currentTimeMillis();
             try (FileCommitLog log = manager.createCommitLog("tt", "aa", "nodeid")) {
-                log.startWriting();
+                log.startWriting(1);
                 for (int i = 0; i < 10_000; i++) {
                     log.log(LogEntryFactory.beginTransaction(0), false);
                     writeCount++;

--- a/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
@@ -121,7 +121,7 @@ public class ClientMultiServerTest {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -162,7 +162,7 @@ public class ClientMultiServerTest {
 
                     // switch leader to server2
                     server_2.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                            newReplicaList, "server2", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                            newReplicaList, "server2", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                     // wait that server_1 leaves leadership
                     for (int i = 0; i < 100; i++) {
@@ -281,7 +281,7 @@ public class ClientMultiServerTest {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -314,7 +314,7 @@ public class ClientMultiServerTest {
                     }
                     // switch leader to server2
                     server_2.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                            new HashSet<>(Arrays.asList("server1", "server2")), "server2", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                            new HashSet<>(Arrays.asList("server1", "server2")), "server2", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                     // wait that server_1 leaves leadership
                     for (int i = 0; i < 100; i++) {

--- a/herddb-core/src/test/java/herddb/server/EmbeddedBookieTest.java
+++ b/herddb-core/src/test/java/herddb/server/EmbeddedBookieTest.java
@@ -111,7 +111,7 @@ public class EmbeddedBookieTest {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 
@@ -144,7 +144,7 @@ public class EmbeddedBookieTest {
                     }
                     // switch leader to server2
                     server_2.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                            new HashSet<>(Arrays.asList("server1", "server2")), "server2", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                            new HashSet<>(Arrays.asList("server1", "server2")), "server2", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                     // wait that server_1 leaves leadership
                     for (int i = 0; i < 100; i++) {

--- a/herddb-core/src/test/java/herddb/server/LedgerManagementTest.java
+++ b/herddb-core/src/test/java/herddb/server/LedgerManagementTest.java
@@ -88,7 +88,7 @@ public class LedgerManagementTest {
                     .build();
             server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                    new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             BookkeeperCommitLog log = (BookkeeperCommitLog) server_1.getManager().getTableSpaceManager(TableSpace.DEFAULT).getLog();
             LedgersInfo actualLedgersList = log.getActualLedgersList();

--- a/herddb-core/src/test/java/herddb/server/MaxLeaderInactivityTest.java
+++ b/herddb-core/src/test/java/herddb/server/MaxLeaderInactivityTest.java
@@ -53,6 +53,8 @@ public class MaxLeaderInactivityTest {
     public void beforeSetup() throws Exception {
         testEnv = new ZKTestEnv(folder.newFolder().toPath());
         testEnv.startBookieAndInitCluster();
+        // as expectedreplicacount is 2 we need at least two bookies
+        testEnv.startNewBookie();
     }
 
     @After

--- a/herddb-core/src/test/java/herddb/server/UseVirtualTableSpaceIdWithZookKeeperTest.java
+++ b/herddb-core/src/test/java/herddb/server/UseVirtualTableSpaceIdWithZookKeeperTest.java
@@ -111,7 +111,7 @@ public class UseVirtualTableSpaceIdWithZookKeeperTest {
                 server_2.start();
 
                 server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
-                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 2, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+                        new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
                 assertTrue(server_2.getManager().waitForTablespace(TableSpace.DEFAULT, 60000, false));
 


### PR DESCRIPTION
List of changes:
- use expectedreplicacount as minimum ensemblesize/writequorumsize/ackquorumsize
- allow to force ensemblesize/writequorumsize/ackquorumsize per-server, in order to allow a backward compatible configuration, this configuration will be a minimum ensemble size, if expectedreplicacount is greater that this value it will be ignored