### PR TITLE
Test Apache Calcite 1.24 RC0

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -140,7 +140,7 @@ import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.logical.LogicalTableModify;
-import org.apache.calcite.rel.rules.ReduceExpressionsRule;
+import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -573,7 +573,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             RelOptCluster cluster = logicalPlan.getCluster();
             final RelOptPlanner optPlanner = cluster.getPlanner();
 
-            optPlanner.addRule(ReduceExpressionsRule.FILTER_INSTANCE);
+            optPlanner.addRule(CoreRules.FILTER_REDUCE_EXPRESSIONS);
             RelTraitSet desiredTraits =
                     cluster.traitSet()
                             .replace(EnumerableConvention.INSTANCE);

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <libs.netty4ssl>2.0.28.Final</libs.netty4ssl>
         <!-- needed in tests for TLS certificate autogeneration on jdk-15+ -->
         <libs.bouncycastle>1.65</libs.bouncycastle>
-        <libs.calcite>1.23.0</libs.calcite>
+        <libs.calcite>1.24.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
         <libs.jackson.mapper>2.10.3</libs.jackson.mapper>
         <libs.zookeeper>3.6.1</libs.zookeeper>
@@ -902,4 +902,17 @@
             </modules>
         </profile>
     </profiles>
+    <repositories>
+        <repository>
+            <id>apache-calcite-124</id>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <url>
+                https://repository.apache.org/content/repositories/orgapachecalcite-1096/
+            </url>
+        </repository>
+            
+            
+    </repositories>
 </project>


### PR DESCRIPTION
- Upgrade to Apache Calcite 1.24 RC0 (from staging repository)
- replace deprecated variable with CoreRules.FILTER_REDUCE_EXPRESSIONS
