### PR TITLE
Drop Kryo for PlanCache size estimation

### DIFF
--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -134,10 +134,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
             <exclusions>

--- a/herddb-core/src/main/java/herddb/index/IndexOperation.java
+++ b/herddb-core/src/main/java/herddb/index/IndexOperation.java
@@ -17,8 +17,9 @@
  under the License.
 
  */
-
 package herddb.index;
+
+import herddb.utils.ObjectSizeUtils;
 
 /**
  * Models the usage of a index
@@ -28,4 +29,8 @@ package herddb.index;
 public interface IndexOperation {
 
     String getIndexName();
+
+    default int estimateObjectSizeForCache() {
+        return ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD + ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD /*value*/;
+    }
 }

--- a/herddb-core/src/main/java/herddb/model/DMLStatement.java
+++ b/herddb-core/src/main/java/herddb/model/DMLStatement.java
@@ -20,6 +20,8 @@
 
 package herddb.model;
 
+import herddb.utils.ObjectSizeUtils;
+
 /**
  * Data manimulation statementns
  *
@@ -42,4 +44,8 @@ public abstract class DMLStatement extends TableAwareStatement {
         return this;
     }
 
+    @Override
+    public int estimateObjectSizeForCache() {
+        return super.estimateObjectSizeForCache() + ObjectSizeUtils.BOOLEAN_FIELD_SIZE;
+    }
 }

--- a/herddb-core/src/main/java/herddb/model/ExecutionPlan.java
+++ b/herddb-core/src/main/java/herddb/model/ExecutionPlan.java
@@ -21,6 +21,7 @@
 package herddb.model;
 
 import herddb.model.planner.PlannerOp;
+import herddb.utils.ObjectSizeUtils;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -28,7 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @author enrico.olivelli
  */
-public class ExecutionPlan {
+public final class ExecutionPlan {
 
     private static final AtomicLong ID = new AtomicLong();
     private final long id = ID.incrementAndGet();
@@ -54,14 +55,21 @@ public class ExecutionPlan {
     }
 
     public void validateContext(StatementEvaluationContext context) throws StatementExecutionException {
-        if (mainStatement != null) {
-            mainStatement.validateContext(context);
-        }
+        mainStatement.validateContext(context);
     }
 
     @Override
     public String toString() {
         return "Plan" + id;
+    }
+
+    /**
+     * Estimate Object size for the PlanCache.
+     * see {@link ObjectSizeUtils} for the limitations of this computation.
+     */
+    public int estimateObjectSizeForCache() {
+        // ignore Calcite object
+        return mainStatement.estimateObjectSizeForCache();
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/Predicate.java
+++ b/herddb-core/src/main/java/herddb/model/Predicate.java
@@ -22,6 +22,7 @@ package herddb.model;
 
 import herddb.index.IndexOperation;
 import herddb.utils.Bytes;
+import herddb.utils.ObjectSizeUtils;
 import herddb.utils.Wrapper;
 
 /**
@@ -54,6 +55,14 @@ public abstract class Predicate implements Wrapper {
 
     public PrimaryKeyMatchOutcome matchesRawPrimaryKey(Bytes key, StatementEvaluationContext context) throws StatementExecutionException {
         return PrimaryKeyMatchOutcome.NEED_FULL_RECORD_EVALUATION;
+    }
+
+    protected final int indexOperationObjectSizeForCache() {
+        return indexOperation != null ? indexOperation.estimateObjectSizeForCache() : 0;
+    }
+
+    public int estimateObjectSizeForCache() {
+        return ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD;
     }
 
     public enum PrimaryKeyMatchOutcome {

--- a/herddb-core/src/main/java/herddb/model/Statement.java
+++ b/herddb-core/src/main/java/herddb/model/Statement.java
@@ -20,6 +20,8 @@
 
 package herddb.model;
 
+import static herddb.utils.ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD;
+import herddb.utils.ObjectSizeUtils;
 import herddb.utils.Wrapper;
 
 /**
@@ -45,6 +47,14 @@ public abstract class Statement implements Wrapper {
     }
 
     public void validateContext(StatementEvaluationContext context) throws StatementExecutionException {
+    }
+
+    /**
+     * Estimate Object size for the PlanCache.
+     * see {@link ObjectSizeUtils} for the limitations of this computation.
+     */
+    public int estimateObjectSizeForCache() {
+        return DEFAULT_OBJECT_SIZE_OVERHEAD + ObjectSizeUtils.stringSize(tableSpace);
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/TableAwareStatement.java
+++ b/herddb-core/src/main/java/herddb/model/TableAwareStatement.java
@@ -20,6 +20,8 @@
 
 package herddb.model;
 
+import herddb.utils.ObjectSizeUtils;
+
 /**
  * Statements on a single table
  *
@@ -42,6 +44,11 @@ public abstract class TableAwareStatement extends Statement {
     public boolean supportsTransactionAutoCreate() {
         /* This instruction will autocreate a transaction if issued */
         return true;
+    }
+
+    @Override
+    public int estimateObjectSizeForCache() {
+        return super.estimateObjectSizeForCache() + ObjectSizeUtils.stringSize(table);
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/commands/DeleteStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/DeleteStatement.java
@@ -79,4 +79,9 @@ public class DeleteStatement extends DMLStatement {
         return "DeleteStatement{" + "predicate=" + predicate + '}';
     }
 
+    @Override
+    public int estimateObjectSizeForCache() {
+        return super.estimateObjectSizeForCache() + predicate.estimateObjectSizeForCache();
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/model/commands/InsertStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/InsertStatement.java
@@ -24,6 +24,7 @@ import herddb.model.ConstValueRecordFunction;
 import herddb.model.DMLStatement;
 import herddb.model.Record;
 import herddb.model.RecordFunction;
+import herddb.utils.ObjectSizeUtils;
 
 /**
  * Insert a new record
@@ -66,5 +67,11 @@ public final class InsertStatement extends DMLStatement {
     public String toString() {
         return String.format("InsertStatement={ keyfunction=%s valuesFunction=%s}",
                              keyFunction.toString(), valuesFunction.toString());
+    }
+
+    @Override
+    public int estimateObjectSizeForCache() {
+        return super.estimateObjectSizeForCache() + ObjectSizeUtils.BOOLEAN_FIELD_SIZE
+                + keyFunction.estimateObjectSizeForCache() + valuesFunction.estimateObjectSizeForCache();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
@@ -28,6 +28,7 @@ import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableAwareStatement;
 import herddb.model.TupleComparator;
+import herddb.utils.ObjectSizeUtils;
 
 /**
  * Lookup a bunch record with a condition
@@ -122,4 +123,26 @@ public class ScanStatement extends TableAwareStatement {
     public void setTableDef(Table table) {
         this.tableDef = table;
     }
+
+    @Override
+    public int estimateObjectSizeForCache() {
+        int res = super.estimateObjectSizeForCache() + ObjectSizeUtils.BOOLEAN_FIELD_SIZE;
+        if (predicate != null) {
+            res += predicate.estimateObjectSizeForCache();
+        }
+        // tableDef is a shared object, it does not have a real impact
+        // on heap usage for the cache
+        if (limits != null) {
+            res += ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD;
+        }
+        if (comparator != null) {
+            res += ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD;
+        }
+        if (projection != null) {
+            res += ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD;
+        }
+        return res;
+    }
+
+
 }

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
@@ -159,4 +159,9 @@ public class SQLRecordPredicate extends Predicate implements TuplePredicate {
         return super.unwrap(clazz);
     }
 
+    @Override
+    public int estimateObjectSizeForCache() {
+        return where.estimateObjectSizeForCache();
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledBinarySQLExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledBinarySQLExpression.java
@@ -23,6 +23,7 @@ package herddb.sql.expressions;
 import herddb.model.Column;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
+import herddb.utils.ObjectSizeUtils;
 import java.util.Collections;
 import java.util.List;
 
@@ -86,6 +87,11 @@ public abstract class CompiledBinarySQLExpression implements CompiledSQLExpressi
     @Override
     public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
         throw new IllegalStateException("no implemented");
+    }
+
+    @Override
+    public int estimateObjectSizeForCache() {
+        return ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD + right.estimateObjectSizeForCache() + left.estimateObjectSizeForCache();
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledSQLExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledSQLExpression.java
@@ -23,6 +23,7 @@ package herddb.sql.expressions;
 import herddb.model.Predicate;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
+import herddb.utils.ObjectSizeUtils;
 import herddb.utils.SQLRecordPredicateFunctions;
 import java.util.Collections;
 import java.util.List;
@@ -33,11 +34,6 @@ import java.util.List;
  * @author enrico.olivelli
  */
 public interface CompiledSQLExpression {
-
-    interface BinaryExpressionBuilder {
-
-        CompiledSQLExpression build(boolean not, CompiledSQLExpression left, CompiledSQLExpression right);
-    }
 
     /**
      * Evaluates the expression
@@ -105,5 +101,13 @@ public interface CompiledSQLExpression {
      */
     default CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
         throw new IllegalStateException("not implemented for " + this.getClass());
+    }
+
+    /**
+     * Estimate Object size for the PlanCache.
+     * see {@link ObjectSizeUtils} for the limitations of this computation.
+     */
+    default int estimateObjectSizeForCache() {
+        return ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD;
     }
 }

--- a/herddb-core/src/main/java/herddb/utils/ObjectSizeUtils.java
+++ b/herddb-core/src/main/java/herddb/utils/ObjectSizeUtils.java
@@ -17,26 +17,27 @@
  under the License.
 
  */
-
-package herddb.model;
-
-import herddb.utils.ObjectSizeUtils;
+package herddb.utils;
 
 /**
- * Generic representation of a value computed on a Record
- *
- * @author enrico.olivelli
+ * Simple utilities for dealing with Object sizes. <br>
+ * Please note that this is only used as an estimate of the actual memory used
+ * by a plan. We are not computing an exact size: <ul>
+ * <li>there is no way to do it in Java currently
+ * <li>even if it was possible we should not take into account references to
+ * objects that are already retained by the system, like refs to Table
+ * definitions or cached constants
+ * </ul>
  */
-public abstract class RecordFunction {
+public final class ObjectSizeUtils {
 
-    public abstract byte[] computeNewValue(Record previous, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException;
+    public static final int DEFAULT_OBJECT_SIZE_OVERHEAD = 16;
+    public static final int BOOLEAN_FIELD_SIZE = 4;
 
-    /**
-     * Estimate Object size for the PlanCache.
-     * see {@link ObjectSizeUtils} for the limitations of this computation.
-     */
-    public int estimateObjectSizeForCache() {
-        return ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD;
+    public static int stringSize(String s) {
+        return DEFAULT_OBJECT_SIZE_OVERHEAD + (s != null ? s.length() : 0);
     }
 
+    private ObjectSizeUtils() {
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -451,11 +451,6 @@
                 <version>2.4</version>
             </dependency>
             <dependency>
-                <groupId>com.esotericsoftware</groupId>
-                <artifactId>kryo</artifactId>
-                <version>4.0.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>2.4.6</version>


### PR DESCRIPTION
Problem description:
- We are using Kryo in order to have an estimate of the bytes used by an ExecutionPlan
- This estimate is not accurate but it is very costly, especially it impacts the startup time of the system
- We can use another way of performing this computation, still not very accurate but at least we will save resources
- Dropping Kryo will also reduce the overall footprint of Maven dependencies imposed to users of HerdDB 

Implementation:
- drop Kryo dependency
- add an explicit computation of the estimated weight of ExecutionPlans for the planner cache 

 Please note that we are only computing an estimate of the actual memory used  by a plan. We are not computing an exact size:
 - there is no way to do it in Java currently
 - even if it was possible we should not take into account references to objects that are already retained by the system, like refs to Table definitions or cached constants