### PR TITLE
Reimplement LocalVM communications without Netty

### DIFF
--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -26,7 +26,6 @@ import herddb.network.ServerHostData;
 import herddb.network.netty.NettyConnector;
 import herddb.network.netty.NetworkUtils;
 import herddb.server.StaticClientSideMetadataProvider;
-import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;

--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -57,8 +57,7 @@ public class HDBClient implements AutoCloseable {
     private final Map<Long, HDBConnection> connections = new ConcurrentHashMap<>();
     private ClientSideMetadataProvider clientSideMetadataProvider;
     private final ExecutorService thredpool;
-    private final MultithreadEventLoopGroup networkGroup;
-    private final DefaultEventLoopGroup localEventsGroup;
+    private final MultithreadEventLoopGroup networkGroup;;
     private final StatsLogger statsLogger;
     private final int maxOperationRetryCount;
     private final int operationRetryDelay;
@@ -84,7 +83,6 @@ public class HDBClient implements AutoCloseable {
                     return t;
                 });
         this.networkGroup = connectRemoteServers ? (NetworkUtils.isEnableEpoolNative() ? new EpollEventLoopGroup() : new NioEventLoopGroup()) : null;
-        this.localEventsGroup = new DefaultEventLoopGroup();
         String mode = configuration.getString(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_LOCAL);
         switch (mode) {
             case ClientConfiguration.PROPERTY_MODE_LOCAL:
@@ -136,9 +134,6 @@ public class HDBClient implements AutoCloseable {
         if (networkGroup != null) {
             networkGroup.shutdownGracefully();
         }
-        if (localEventsGroup != null) {
-            localEventsGroup.shutdownGracefully();
-        }
         if (thredpool != null) {
             thredpool.shutdown();
         }
@@ -163,7 +158,7 @@ public class HDBClient implements AutoCloseable {
         int timeoutms = configuration.getInt(ClientConfiguration.PROPERTY_NETWORK_TIMEOUT, ClientConfiguration.PROPERTY_NETWORK_TIMEOUT_DEFAULT);
         int timeouts = (int) TimeUnit.MILLISECONDS.toSeconds(timeoutms);
         return NettyConnector.connect(server.getHost(), server.getPort(), server.isSsl(), timeoutms, timeouts, eventReceiver, thredpool,
-                networkGroup, localEventsGroup);
+                networkGroup);
     }
 
     StatsLogger getStatsLogger() {

--- a/herddb-net/src/main/java/herddb/network/Channel.java
+++ b/herddb-net/src/main/java/herddb/network/Channel.java
@@ -103,7 +103,7 @@ public abstract class Channel implements AutoCloseable {
     }
 
     public abstract boolean isValid();
-    
+
     public abstract boolean isClosed();
 
     public abstract boolean isLocalChannel();

--- a/herddb-net/src/main/java/herddb/network/Channel.java
+++ b/herddb-net/src/main/java/herddb/network/Channel.java
@@ -103,6 +103,8 @@ public abstract class Channel implements AutoCloseable {
     }
 
     public abstract boolean isValid();
+    
+    public abstract boolean isClosed();
 
     public abstract boolean isLocalChannel();
 

--- a/herddb-net/src/main/java/herddb/network/Channel.java
+++ b/herddb-net/src/main/java/herddb/network/Channel.java
@@ -42,9 +42,10 @@ public abstract class Channel implements AutoCloseable {
     }
 
     protected ChannelEventListener messagesReceiver;
-    protected String name = "unnamed";
+    private final String name;
 
-    public Channel() {
+    public Channel(String name) {
+        this.name = name;
     }
 
     public ChannelEventListener getMessagesReceiver() {
@@ -108,10 +109,6 @@ public abstract class Channel implements AutoCloseable {
 
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
 }

--- a/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
@@ -178,7 +178,9 @@ public abstract class AbstractChannel extends Channel {
         doClose();
         failPendingMessages(socketDescription);
     }
-
+    protected final boolean isClosed() {
+        return closed;
+    }
     private void failPendingMessages(String socketDescription) {
 
         callbacks.forEach((key, callback) -> {

--- a/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
@@ -1,17 +1,21 @@
 /*
- * Copyright 2020 eolivelli.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 package herddb.network.netty;
 

--- a/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2020 eolivelli.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package herddb.network.netty;
+
+import herddb.network.Channel;
+import herddb.network.SendResultCallback;
+import herddb.proto.Pdu;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.bookkeeper.util.collections.ConcurrentLongHashMap;
+import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
+
+/**
+ * Common implementation.
+ * @author eolivelli
+ */
+public abstract class AbstractChannel extends Channel {
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractChannel.class.getName());
+    public static final String ADDRESS_JVM_LOCAL = "jvm-local";
+    private static final AtomicLong idGenerator = new AtomicLong();
+
+    private final ConcurrentLongHashMap<PduCallback> callbacks = new ConcurrentLongHashMap<>();
+    private final ConcurrentLongLongHashMap pendingReplyMessagesDeadline = new ConcurrentLongLongHashMap();
+    private final ExecutorService callbackexecutor;
+    protected boolean ioErrors = false;
+    private final long id = idGenerator.incrementAndGet();
+    private final String remoteAddress;
+
+    public AbstractChannel(
+            String name, String remoteAddress,
+            ExecutorService callbackexecutor
+    ) {
+        super(name);
+        this.callbackexecutor = callbackexecutor;
+        this.remoteAddress = remoteAddress;
+    }
+
+    protected final long pendingCallbacks() {
+        return callbacks.size();
+    }
+
+    public final long getId() {
+        return id;
+    }
+
+    public final void pduReceived(Pdu message) {
+        if (message.isRequest()) {
+            handlePduRequest(message);
+        } else {
+            handlePduResponse(message);
+        }
+    }
+
+    private void handlePduRequest(Pdu request) {
+        submitCallback(() -> {
+            try {
+                messagesReceiver.requestReceived(request, this);
+            } catch (Throwable t) {
+                LOGGER.log(Level.SEVERE, this + ": error " + t, t);
+                close();
+            }
+        });
+    }
+
+    private void handlePduResponse(Pdu pdu) {
+        long replyMessageId = pdu.messageId;
+        if (replyMessageId < 0) {
+            LOGGER.log(Level.SEVERE, "{0}: received response without replyId: type {1}", new Object[]{this, pdu.messageId});
+            pdu.close();
+            return;
+        }
+        final PduCallback callback = callbacks.remove(replyMessageId);
+        pendingReplyMessagesDeadline.remove(replyMessageId);
+        if (callback != null) {
+            submitCallback(() -> {
+                callback.responseReceived(pdu, null);
+            });
+        }
+    }
+
+    public final void sendReplyMessage(long inAnswerTo, ByteBuf message) {
+
+        if (!isValid()) {
+            LOGGER.log(Level.SEVERE, this + " channel not active, discarding reply message " + message);
+            return;
+        }
+
+        sendOneWayMessage(message, new SendResultCallback() {
+
+            @Override
+            public void messageSent(Throwable error) {
+                if (error != null) {
+                    LOGGER.log(Level.SEVERE, this + " error:" + error, error);
+                }
+            }
+        });
+    }
+
+    private void processPendingReplyMessagesDeadline() {
+        List<Long> messagesWithNoReply = new ArrayList<>();
+        long now = System.currentTimeMillis();
+        pendingReplyMessagesDeadline.forEach((messageId, deadline) -> {
+            if (deadline < now) {
+                messagesWithNoReply.add(messageId);
+            }
+        });
+        if (messagesWithNoReply.isEmpty()) {
+            return;
+        }
+        LOGGER.log(Level.SEVERE, "{0} found {1} without reply, channel will be closed", new Object[]{this, messagesWithNoReply});
+        ioErrors = true;
+        for (long messageId : messagesWithNoReply) {
+            PduCallback callback = callbacks.remove(messageId);
+            if (callback != null) {
+                submitCallback(() -> {
+                    callback.responseReceived(null, new IOException(this + " reply timeout expired, channel will be closed"));
+                });
+            }
+        }
+        close();
+    }
+
+    @Override
+    public final void sendRequestWithAsyncReply(long id, ByteBuf message, long timeout, PduCallback callback) {
+
+        if (!isValid()) {
+            callback.responseReceived(null, new Exception(this + " connection is not active"));
+            return;
+        }
+        pendingReplyMessagesDeadline.put(id, System.currentTimeMillis() + timeout);
+        callbacks.put(id, callback);
+        sendOneWayMessage(message, new SendResultCallback() {
+
+            @Override
+            public void messageSent(Throwable error) {
+                if (error != null) {
+                    LOGGER.log(Level.SEVERE, this + ": error while sending reply message to " + message, error);
+                    callback.responseReceived(null, new Exception(this + ": error while sending reply message to " + message, error));
+                }
+            }
+        });
+    }
+
+    private volatile boolean closed = false;
+
+    protected abstract String describeSocket();
+    protected abstract void doClose();
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        LOGGER.log(Level.FINE, "{0}: closing", this);
+        String socketDescription = describeSocket();
+        doClose();
+        failPendingMessages(socketDescription);
+    }
+
+    private void failPendingMessages(String socketDescription) {
+
+        callbacks.forEach((key, callback) -> {
+            pendingReplyMessagesDeadline.remove(key);
+            LOGGER.log(Level.SEVERE, "{0} message {1} was not replied callback:{2}", new Object[]{this, key, callback});
+            submitCallback(() -> {
+                callback.responseReceived(null, new IOException("comunication channel is closed. Cannot wait for pending messages, socket=" + socketDescription));
+            });
+        });
+        pendingReplyMessagesDeadline.clear();
+        callbacks.clear();
+    }
+
+    final void exceptionCaught(Throwable cause) {
+        LOGGER.log(Level.SEVERE, this + " io-error " + cause, cause);
+        ioErrors = true;
+    }
+
+    final void channelClosed() {
+        failPendingMessages(describeSocket());
+        submitCallback(() -> {
+            if (this.messagesReceiver != null) {
+                this.messagesReceiver.channelClosed(this);
+            }
+        });
+    }
+
+    private void submitCallback(Runnable runnable) {
+        try {
+            callbackexecutor.submit(runnable);
+        } catch (RejectedExecutionException stopped) {
+            LOGGER.log(Level.SEVERE, this + " rejected runnable " + runnable + ":" + stopped);
+            try {
+                runnable.run();
+            } catch (Throwable error) {
+                LOGGER.log(Level.SEVERE, this + " error on rejected runnable " + runnable + ":" + error);
+            }
+        }
+    }
+
+    @Override
+    public final String getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    @Override
+    public final void channelIdle() {
+        LOGGER.log(Level.FINEST, "{0} channelIdle", this);
+        processPendingReplyMessagesDeadline();
+    }
+
+}

--- a/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
@@ -178,7 +178,7 @@ public abstract class AbstractChannel extends Channel {
         doClose();
         failPendingMessages(socketDescription);
     }
-   
+
     @Override
     public final boolean isClosed() {
         return closed;

--- a/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
@@ -168,7 +168,7 @@ public abstract class AbstractChannel extends Channel {
     protected abstract void doClose();
 
     @Override
-    public void close() {
+    public final void close() {
         if (closed) {
             return;
         }

--- a/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
@@ -178,7 +178,9 @@ public abstract class AbstractChannel extends Channel {
         doClose();
         failPendingMessages(socketDescription);
     }
-    protected final boolean isClosed() {
+   
+    @Override
+    public final boolean isClosed() {
         return closed;
     }
     private void failPendingMessages(String socketDescription) {

--- a/herddb-net/src/main/java/herddb/network/netty/LocalServerRegistry.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalServerRegistry.java
@@ -20,8 +20,7 @@
 
 package herddb.network.netty;
 
-import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Registry for Local Servers, to bypass network
@@ -30,21 +29,21 @@ import java.util.concurrent.ConcurrentSkipListSet;
  */
 public class LocalServerRegistry {
 
-    private static final Set<String> localServers = new ConcurrentSkipListSet<>();
+    private static final ConcurrentHashMap<String, LocalVMChannelAcceptor> localServers = new ConcurrentHashMap<>();
 
-    static void registerLocalServer(String host, int port, boolean ssl) {
-        localServers.add(composeServerKey(host, port, ssl));
+    static void registerLocalServer(String host, int port, LocalVMChannelAcceptor acceptor) {
+        localServers.put(composeServerKey(host, port), acceptor);
     }
 
-    private static String composeServerKey(String host, int port, boolean ssl) {
-        return host + ":" + port + ":" + ssl;
+    private static String composeServerKey(String host, int port) {
+        return host + ":" + port;
     }
 
-    static void unregisterLocalServer(String host, int port, boolean ssl) {
-        localServers.remove(composeServerKey(host, port, ssl));
+    static void unregisterLocalServer(String host, int port) {
+        localServers.remove(composeServerKey(host, port));
     }
 
-    static boolean isLocalServer(String host, int port, boolean ssl) {
-        return localServers.contains(composeServerKey(host, port, ssl));
+    static LocalVMChannelAcceptor getLocalServer(String host, int port) {
+        return localServers.get(composeServerKey(host, port));
     }
 }

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
@@ -63,16 +63,13 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
     }
 
     @Override
-    public void close() {
-    }
-
-    @Override
     protected String describeSocket() {
         return "jvm-local";
     }
 
     @Override
     protected void doClose() {
+        this.messagesReceiver.channelClosed(this);
     }
 
     @Override
@@ -144,6 +141,7 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
         @Override
         protected void doClose() {
+            this.messagesReceiver.channelClosed(this);
         }
 
         @Override

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
@@ -1,17 +1,21 @@
 /*
- * Copyright 2020 eolivelli.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 package herddb.network.netty;
 

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 eolivelli.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package herddb.network.netty;
+
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.SendResultCallback;
+import herddb.proto.Pdu;
+import herddb.proto.PduCodec;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Short circuit implementation of {@link herddb.network.Channel} for in-VM
+ * communications.
+ *
+ * @author eolivelli
+ */
+public class LocalVMChannel extends AbstractChannel implements Comparable<LocalVMChannel> {
+
+    private ChannelEventListener serverSideViewOfChannel;
+    private final Channel serverSideChannel = new ServerSideLocalVMChannel(ADDRESS_JVM_LOCAL);
+
+    LocalVMChannel(String name, ChannelEventListener clientSidePeer, ExecutorService executorService) {
+        super(name, ADDRESS_JVM_LOCAL, executorService);
+    }
+
+    public Channel getServerSideChannel() {
+        return serverSideChannel;
+    }
+
+    @Override
+    public void sendOneWayMessage(ByteBuf message, SendResultCallback callback) {
+        try {
+            Pdu pdu = PduCodec.decodePdu(message);
+            serverSideViewOfChannel.requestReceived(pdu, serverSideChannel);
+        } catch (IOException ex) {
+            ReferenceCountUtil.safeRelease(message);
+            callback.messageSent(ex);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    protected String describeSocket() {
+        return "jvm-local";
+    }
+
+    @Override
+    protected void doClose() {
+    }
+
+    @Override
+    public boolean isValid() {
+        return !ioErrors;
+    }
+
+    @Override
+    public boolean isLocalChannel() {
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 19 * hash + Objects.hashCode(this.getId());
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final LocalVMChannel other = (LocalVMChannel) obj;
+        if (!Objects.equals(this.getId(), other.getId())) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int compareTo(LocalVMChannel o) {
+        return Long.compare(this.getId(), o.getId());
+    }
+
+    private class ServerSideLocalVMChannel extends Channel {
+
+        public ServerSideLocalVMChannel(String string) {
+            super(string);
+        }
+
+        @Override
+        public void sendOneWayMessage(ByteBuf message, SendResultCallback callback) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void setMessagesReceiver(ChannelEventListener messagesReceiver) {
+            serverSideViewOfChannel = messagesReceiver;
+        }
+
+        @Override
+        public void sendReplyMessage(long inAnswerTo, ByteBuf message) {
+            try {
+                Pdu pdu = PduCodec.decodePdu(message);
+                LocalVMChannel.this.pduReceived(pdu);
+            } catch (IOException ex) {
+                ReferenceCountUtil.safeRelease(message);
+            }
+        }
+
+        @Override
+        public void sendRequestWithAsyncReply(long id, ByteBuf message, long timeout, PduCallback callback) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void channelIdle() {
+        }
+
+        @Override
+        public String getRemoteAddress() {
+            return ADDRESS_JVM_LOCAL;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public boolean isValid() {
+            return LocalVMChannel.this.isValid();
+        }
+
+        @Override
+        public boolean isLocalChannel() {
+            return true;
+        }
+    }
+
+}

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
@@ -34,8 +34,8 @@ import java.util.concurrent.ExecutorService;
  */
 public class LocalVMChannel extends AbstractChannel implements Comparable<LocalVMChannel> {
 
-    private ChannelEventListener serverSideViewOfChannel;
-    private final Channel serverSideChannel;
+
+    private final ServerSideLocalVMChannel serverSideChannel;
     LocalVMChannel(String name, ChannelEventListener clientSidePeer, ExecutorService executorService) {
         super(name, ADDRESS_JVM_LOCAL, executorService);;
         setMessagesReceiver(clientSidePeer);
@@ -55,7 +55,7 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
         }
         try {
             Pdu pdu = PduCodec.decodePdu(message);
-            serverSideViewOfChannel.requestReceived(pdu, serverSideChannel);
+            serverSideChannel.pduReceived(pdu);
         } catch (IOException ex) {
             ReferenceCountUtil.safeRelease(message);
             callback.messageSent(ex);
@@ -71,9 +71,6 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
     protected void doClose() {
         if (messagesReceiver != null) {
             this.messagesReceiver.channelClosed(this);
-        }
-        if (serverSideViewOfChannel != null) {
-            serverSideViewOfChannel.channelClosed(this);
         }
         serverSideChannel.close();
     }
@@ -133,11 +130,6 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
                 ReferenceCountUtil.safeRelease(message);
                 callback.messageSent(ex);
             }
-        }
-
-        @Override
-        public void setMessagesReceiver(ChannelEventListener messagesReceiver) {
-            serverSideViewOfChannel = messagesReceiver;
         }
 
         @Override

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
@@ -37,7 +37,7 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
     private final ServerSideLocalVMChannel serverSideChannel;
     LocalVMChannel(String name, ChannelEventListener clientSidePeer, ExecutorService executorService) {
-        super(name, ADDRESS_JVM_LOCAL, executorService);;
+        super(name, ADDRESS_JVM_LOCAL, executorService);
         setMessagesReceiver(clientSidePeer);
         serverSideChannel = new ServerSideLocalVMChannel(ADDRESS_JVM_LOCAL, ADDRESS_JVM_LOCAL, executorService);
     }
@@ -69,6 +69,7 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
     @Override
     protected void doClose() {
+        // emulate Netty on channel close
         if (messagesReceiver != null) {
             this.messagesReceiver.channelClosed(this);
         }
@@ -139,6 +140,7 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
         @Override
         protected void doClose() {
+            // emulate Netty on channel close
             if (this.messagesReceiver != null) {
                 this.messagesReceiver.channelClosed(this);
             }

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
@@ -36,9 +36,9 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
     private ChannelEventListener serverSideViewOfChannel;
     private final Channel serverSideChannel;
-
     LocalVMChannel(String name, ChannelEventListener clientSidePeer, ExecutorService executorService) {
-        super(name, ADDRESS_JVM_LOCAL, executorService);
+        super(name, ADDRESS_JVM_LOCAL, executorService);;
+        setMessagesReceiver(clientSidePeer);
         serverSideChannel = new ServerSideLocalVMChannel(ADDRESS_JVM_LOCAL, ADDRESS_JVM_LOCAL, executorService);
     }
 
@@ -69,7 +69,13 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
     @Override
     protected void doClose() {
-        this.messagesReceiver.channelClosed(this);
+        if (messagesReceiver != null) {
+            this.messagesReceiver.channelClosed(this);
+        }
+        if (serverSideViewOfChannel != null) {
+            serverSideViewOfChannel.channelClosed(this);
+        }
+        serverSideChannel.close();
     }
 
     @Override
@@ -141,7 +147,10 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
         @Override
         protected void doClose() {
-            this.messagesReceiver.channelClosed(this);
+            if (this.messagesReceiver != null) {
+                this.messagesReceiver.channelClosed(this);
+            }
+            LocalVMChannel.this.close();
         }
 
         @Override

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
@@ -1,17 +1,21 @@
 /*
- * Copyright 2020 eolivelli.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
  */
 package herddb.network.netty;
 

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
@@ -48,7 +48,6 @@ public class LocalVMChannelAcceptor {
         acceptor.createConnection(channel.getServerSideChannel());
         channels.add(channel);
         return channel;
-
     }
 
 }

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 eolivelli.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package herddb.network.netty;
+
+import herddb.network.Channel;
+import herddb.network.ChannelEventListener;
+import herddb.network.ServerSideConnectionAcceptor;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Accepts in-process client connections.
+ */
+public class LocalVMChannelAcceptor {
+    private ServerSideConnectionAcceptor acceptor;
+    private Set<LocalVMChannel> channels = new ConcurrentSkipListSet<>();
+
+    public ServerSideConnectionAcceptor getAcceptor() {
+        return acceptor;
+    }
+
+    public void setAcceptor(ServerSideConnectionAcceptor acceptor) {
+        this.acceptor = acceptor;
+    }
+
+    public void close() {
+        for (LocalVMChannel channel : channels) {
+            channel.close();
+        }
+    }
+
+    public Channel connect(String name, ChannelEventListener clientSidePeer, ExecutorService executorService) {
+        LocalVMChannel channel = new LocalVMChannel(name, clientSidePeer, executorService);
+        acceptor.createConnection(channel.getServerSideChannel());
+        channels.add(channel);
+        return channel;
+
+    }
+
+}

--- a/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
@@ -55,8 +55,7 @@ public class NettyConnector {
 
     public static herddb.network.Channel connect(
             String host, int port, boolean ssl, int connectTimeout, int socketTimeout,
-            ChannelEventListener receiver, final ExecutorService callbackExecutor, final MultithreadEventLoopGroup networkGroup,
-            final DefaultEventLoopGroup localEventsGroup
+            ChannelEventListener receiver, final ExecutorService callbackExecutor, final MultithreadEventLoopGroup networkGroup
     ) throws IOException {
         try {
             final SslContext sslCtx = !ssl ? null : SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();

--- a/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
@@ -68,7 +68,10 @@ public class NettyConnector {
 
             LocalVMChannelAcceptor localVm = LocalServerRegistry.getLocalServer(hostAddress, port);
             MultithreadEventLoopGroup group;
-            if (localVm != null) {
+            if (localVm != null && socketTimeout <= 0) {
+                // if socketTimeout is greater than zero we cannot use our local transport implement
+                // that timeout would need a timer
+                // it is useful only to detect stuck network problems
                 return localVm.connect(host + ":" + port, receiver, callbackExecutor);
             } else if (networkGroup == null) {
                 throw new IOException("Connection using network is disabled, cannot connect to " + host + ":" + port);

--- a/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
@@ -25,7 +25,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;

--- a/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
@@ -28,7 +28,6 @@ import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;

--- a/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/ChannelBenchTest.java
@@ -65,7 +65,7 @@ public class ChannelBenchTest {
                     System.out.println("client channelClosed");
 
                 }
-            }, executor, new NioEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
+            }, executor, new NioEventLoopGroup(10, executor))) {
                 for (int i = 0; i < 100; i++) {
                     ByteBuf buffer = buildAckRequest(i);
                     try (Pdu result = client.sendMessageWithPduReply(i, buffer, 10000)) {

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -24,7 +24,6 @@ import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import herddb.network.Channel;
 import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
@@ -36,6 +35,7 @@ import java.net.InetSocketAddress;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 public class LocalChannelTest {
@@ -62,7 +62,7 @@ public class LocalChannelTest {
                 return (ServerSideConnection) () -> new Random().nextLong();
             });
             acceptor.start();
-            assertTrue(LocalServerRegistry.isLocalServer(NetworkUtils.getAddress(addr), addr.getPort(), true));
+            assertNotNull(LocalServerRegistry.getLocalServer(NetworkUtils.getAddress(addr), addr.getPort()));
             ExecutorService executor = Executors.newCachedThreadPool();
             try (Channel client = NettyConnector.connect(addr.getHostName(), addr.getPort(), true, 0, 0, new ChannelEventListener() {
 
@@ -83,6 +83,6 @@ public class LocalChannelTest {
             }
 
         }
-        assertFalse(LocalServerRegistry.isLocalServer(NetworkUtils.getAddress(addr), addr.getPort(), true));
+        assertNull(LocalServerRegistry.getLocalServer(NetworkUtils.getAddress(addr), addr.getPort()));
     }
 }

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -16,8 +16,7 @@
  specific language governing permissions and limitations
  under the License.
 
-*/
-
+ */
 package herddb.network.netty;
 
 import static herddb.network.netty.Utils.buildAckRequest;
@@ -30,12 +29,17 @@ import herddb.network.Channel;
 import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
+import herddb.proto.PduCodec;
 import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Test;
 
 public class LocalChannelTest {
@@ -86,7 +90,6 @@ public class LocalChannelTest {
         assertNull(LocalServerRegistry.getLocalServer(NetworkUtils.getAddress(addr), addr.getPort()));
     }
 
-
     @Test
     public void testCloseServer() throws Exception {
         InetSocketAddress addr = new InetSocketAddress("localhost", 1111);
@@ -115,6 +118,78 @@ public class LocalChannelTest {
                 server.close();
                 assertTrue(client.isClosed());
                 assertTrue(closeNotificationReceived.get());
+            } finally {
+                executor.shutdown();
+            }
+
+        }
+        assertNull(LocalServerRegistry.getLocalServer(NetworkUtils.getAddress(addr), addr.getPort()));
+    }
+
+    @Test
+    public void testServerPushesData() throws Exception {
+        InetSocketAddress addr = new InetSocketAddress("localhost", 1111);
+        try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor(addr.getHostName(), addr.getPort(), true)) {
+            acceptor.setEnableRealNetwork(false);
+            acceptor.setAcceptor((Channel channel) -> {
+                channel.setMessagesReceiver(new ChannelEventListener() {
+                    @Override
+                    public void requestReceived(Pdu message, Channel channel) {
+                        try {
+                            ByteBuf msg = buildAckResponse(message);
+
+                            // send a message to the client
+                            ByteBuf buffer = buildAckRequest(900);
+                            Pdu response = channel.sendMessageWithPduReply(900, buffer, 10000);
+                            assertEquals(Pdu.TYPE_ACK, response.type);
+
+                            // send the response to the client
+                            channel.sendReplyMessage(message.messageId, msg);
+                            message.close();
+                        } catch (InterruptedException ex) {
+                            ex.printStackTrace();
+                        } catch (TimeoutException ex) {
+                            ex.printStackTrace();
+                        }
+
+                    }
+
+                    @Override
+                    public void channelClosed(Channel channel) {
+
+                    }
+                });
+                return (ServerSideConnection) () -> new Random().nextLong();
+            });
+            acceptor.start();
+            assertNotNull(LocalServerRegistry.getLocalServer(NetworkUtils.getAddress(addr), addr.getPort()));
+            ExecutorService executor = Executors.newCachedThreadPool();
+            CopyOnWriteArrayList<Long> pushedMessagesFromServer = new CopyOnWriteArrayList<>();
+            try (Channel client = NettyConnector.connect(addr.getHostName(), addr.getPort(), true, 0, 0, new ChannelEventListener() {
+                @Override
+                public void requestReceived(Pdu pdu, Channel channel) {
+                    pushedMessagesFromServer.add(pdu.messageId);
+                    assertTrue(pdu.isRequest());
+
+                    ByteBuf msg = buildAckResponse(pdu);
+
+                    // send the response to the server
+                    channel.sendReplyMessage(pdu.messageId, msg);
+                    pdu.close();
+                }
+
+                @Override
+                public void channelClosed(Channel channel) {
+                    System.out.println("client channelClosed");
+
+                }
+            }, executor, null)) {
+
+                ByteBuf buffer = buildAckRequest(134);
+                try (Pdu result = client.sendMessageWithPduReply(134, buffer, 10000)) {
+                    assertEquals(Pdu.TYPE_ACK, result.type);
+                }
+                assertEquals(1, pushedMessagesFromServer.size());
             } finally {
                 executor.shutdown();
             }

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -23,7 +23,6 @@ package herddb.network.netty;
 import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import herddb.network.Channel;
 import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
@@ -36,6 +35,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 public class LocalChannelTest {

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -23,6 +23,9 @@ package herddb.network.netty;
 import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import herddb.network.Channel;
 import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
@@ -33,9 +36,6 @@ import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class LocalChannelTest {
@@ -85,8 +85,8 @@ public class LocalChannelTest {
         }
         assertNull(LocalServerRegistry.getLocalServer(NetworkUtils.getAddress(addr), addr.getPort()));
     }
-    
-    
+
+
     @Test
     public void testCloseServer() throws Exception {
         InetSocketAddress addr = new InetSocketAddress("localhost", 1111);
@@ -100,7 +100,7 @@ public class LocalChannelTest {
             server.start();
             assertNotNull(LocalServerRegistry.getLocalServer(NetworkUtils.getAddress(addr), addr.getPort()));
             ExecutorService executor = Executors.newCachedThreadPool();
-            
+
             AtomicBoolean closeNotificationReceived = new AtomicBoolean();
             try (Channel client = NettyConnector.connect(addr.getHostName(), addr.getPort(), true, 0, 0, new ChannelEventListener() {
 

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -29,7 +29,6 @@ import herddb.network.Channel;
 import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
-import herddb.proto.PduCodec;
 import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
 import java.util.Random;
@@ -38,8 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.junit.Test;
 
 public class LocalChannelTest {

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -71,7 +71,7 @@ public class LocalChannelTest {
                     System.out.println("client channelClosed");
 
                 }
-            }, executor, new NioEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
+            }, executor, null)) {
                 for (int i = 0; i < 100; i++) {
                     ByteBuf buffer = buildAckRequest(i);
                     try (Pdu result = client.sendMessageWithPduReply(i, buffer, 10000)) {

--- a/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
@@ -29,7 +29,6 @@ import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import java.util.Random;

--- a/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
@@ -16,24 +16,30 @@
  specific language governing permissions and limitations
  under the License.
 
-*/
-
+ */
 package herddb.network.netty;
 
 import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
+import static herddb.utils.TestUtils.NOOP;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import herddb.network.Channel;
 import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
+import herddb.utils.TestUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import java.net.InetSocketAddress;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 public class NetworkChannelTest {
@@ -121,4 +127,109 @@ public class NetworkChannelTest {
         }
     }
 
+    @Test
+    public void testCloseServer() throws Exception {
+        InetSocketAddress addr = new InetSocketAddress("localhost", 1111);
+        try (NettyChannelAcceptor server = new NettyChannelAcceptor(addr.getHostName(), addr.getPort(), true)) {
+            server.setEnableJVMNetwork(false);
+            server.setEnableRealNetwork(true);
+            server.setAcceptor((Channel channel) -> {
+                channel.setMessagesReceiver(new ChannelEventListener() {
+                });
+                return (ServerSideConnection) () -> new Random().nextLong();
+            });
+            server.start();
+            ExecutorService executor = Executors.newCachedThreadPool();
+
+            AtomicBoolean closeNotificationReceived = new AtomicBoolean();
+            try (Channel client = NettyConnector.connect(addr.getHostName(), addr.getPort(), true, 0, 0, new ChannelEventListener() {
+
+                @Override
+                public void channelClosed(Channel channel) {
+                    System.out.println("client channelClosed");
+                    closeNotificationReceived.set(true);
+
+                }
+            }, executor, new NioEventLoopGroup(10, executor))) {
+                //  closing the server should eventually close the client
+                server.close();
+                TestUtils.waitForCondition(() -> closeNotificationReceived.get(), NOOP, 100);
+                assertTrue(closeNotificationReceived.get());
+            } finally {
+                executor.shutdown();
+            }
+
+        }
+    }
+
+    @Test
+    public void testServerPushesData() throws Exception {
+        InetSocketAddress addr = new InetSocketAddress("localhost", 1111);
+        try (NettyChannelAcceptor acceptor = new NettyChannelAcceptor(addr.getHostName(), addr.getPort(), true)) {
+            acceptor.setEnableJVMNetwork(false);
+            acceptor.setEnableRealNetwork(true);
+            acceptor.setAcceptor((Channel channel) -> {
+                channel.setMessagesReceiver(new ChannelEventListener() {
+                    @Override
+                    public void requestReceived(Pdu message, Channel channel) {
+                        try {
+                            ByteBuf msg = buildAckResponse(message);
+
+                            // send a message to the client
+                            ByteBuf buffer = buildAckRequest(900);
+                            Pdu response = channel.sendMessageWithPduReply(900, buffer, 10000);
+                            assertEquals(Pdu.TYPE_ACK, response.type);
+
+                            // send the response to the client
+                            channel.sendReplyMessage(message.messageId, msg);
+                            message.close();
+                        } catch (InterruptedException ex) {
+                            ex.printStackTrace();
+                        } catch (TimeoutException ex) {
+                            ex.printStackTrace();
+                        }
+
+                    }
+
+                    @Override
+                    public void channelClosed(Channel channel) {
+
+                    }
+                });
+                return (ServerSideConnection) () -> new Random().nextLong();
+            });
+            acceptor.start();
+            ExecutorService executor = Executors.newCachedThreadPool();
+            CopyOnWriteArrayList<Long> pushedMessagesFromServer = new CopyOnWriteArrayList<>();
+            try (Channel client = NettyConnector.connect(addr.getHostName(), addr.getPort(), true, 0, 0, new ChannelEventListener() {
+                @Override
+                public void requestReceived(Pdu pdu, Channel channel) {
+                    pushedMessagesFromServer.add(pdu.messageId);
+                    assertTrue(pdu.isRequest());
+
+                    ByteBuf msg = buildAckResponse(pdu);
+
+                    // send the response to the server
+                    channel.sendReplyMessage(pdu.messageId, msg);
+                    pdu.close();
+                }
+
+                @Override
+                public void channelClosed(Channel channel) {
+                    System.out.println("client channelClosed");
+
+                }
+            }, executor, new NioEventLoopGroup(10, executor))) {
+
+                ByteBuf buffer = buildAckRequest(134);
+                try (Pdu result = client.sendMessageWithPduReply(134, buffer, 10000)) {
+                    assertEquals(Pdu.TYPE_ACK, result.type);
+                }
+                assertEquals(1, pushedMessagesFromServer.size());
+            } finally {
+                executor.shutdown();
+            }
+
+        }
+    }
 }

--- a/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/NetworkChannelTest.java
@@ -68,7 +68,7 @@ public class NetworkChannelTest {
                     System.out.println("client channelClosed");
 
                 }
-            }, executor, new NioEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
+            }, executor, new NioEventLoopGroup(10, executor))) {
                 for (int i = 0; i < 100; i++) {
                     ByteBuf buffer = buildAckRequest(i);
                     try (Pdu result = client.sendMessageWithPduReply(i, Unpooled.wrappedBuffer(buffer), 10000)) {
@@ -107,7 +107,7 @@ public class NetworkChannelTest {
                         System.out.println("client channelClosed");
 
                     }
-                }, executor, new EpollEventLoopGroup(10, executor), new DefaultEventLoopGroup())) {
+                }, executor, new EpollEventLoopGroup(10, executor))) {
                     for (int i = 0; i < 100; i++) {
 
                         ByteBuf buffer = buildAckRequest(i);


### PR DESCRIPTION
Changes:
    - do not user Local Channels
    - execute server-side logic in the same thread of the calling code
    - do not start the LocalChannel event groups
    - adding new testcases to have direct coverage of modified files

Detailed list of changes:
- moved most of NettyChannel logic to AbstractChannel class
- introduce a new LocalVMChannel that simulates the connection to the server
- a LocalVMChannel contains another Channel implementation, that is the Channel at the server side end



Benefits:
 -in "local" mode the caller code executes the first part of the request processing (planning, valdation....)
- the application will limit itself in using resources, the internal EventLoop is a buffer that adds only complexity to the execution path
- we can expect faster execution in "local mode": unit tests of applications and running in standalone embedded mode
- we won't run TLS in case of LocalVM transport (this was actually a bad side effect of using the same Netty pipeline)

Side effects:
- most of the test cases passes thru the local network system, so we are no more using the Netty stack for the whole suite
- this new code will be the common execution path for embedded database mode
