### PR TITLE
Create minimal JDBC driver

### DIFF
--- a/herddb-collections/pom.xml
+++ b/herddb-collections/pom.xml
@@ -104,10 +104,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.bookkeeper</groupId>
-            <artifactId>bookkeeper-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-linq4j</artifactId>
         </dependency>

--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -25,6 +25,7 @@ import herddb.client.impl.LeaderChangedException;
 import herddb.client.impl.RetryRequestException;
 import herddb.model.TransactionContext;
 import herddb.network.ServerHostData;
+import herddb.utils.Futures;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.stats.Counter;
 
 /**
@@ -205,7 +205,7 @@ public class HDBConnection implements AutoCloseable {
             tableSpace = discoverTablespace(tableSpace, query);
         }
         if (closed) {
-            return FutureUtils.exception(new HDBException("client is closed"));
+            return Futures.exception(new HDBException("client is closed"));
         }
         CompletableFuture<DMLResult> res = new CompletableFuture<>();
 
@@ -308,7 +308,7 @@ public class HDBConnection implements AutoCloseable {
             tableSpace = discoverTablespace(tableSpace, query);
         }
         if (closed) {
-            return FutureUtils.exception(new HDBException("client is closed"));
+            return Futures.exception(new HDBException("client is closed"));
         }
         CompletableFuture<List<DMLResult>> res = new CompletableFuture<>();
 

--- a/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
@@ -44,6 +44,7 @@ import herddb.model.Transaction;
 import herddb.model.commands.ScanStatement;
 import herddb.storage.DataStorageManagerException;
 import herddb.storage.FullTableScanConsumer;
+import herddb.utils.Futures;
 import herddb.utils.SQLRecordPredicateFunctions;
 import java.util.Collections;
 import java.util.Comparator;
@@ -52,7 +53,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
-import org.apache.bookkeeper.common.concurrent.FutureUtils;
 
 /**
  * System tables
@@ -71,7 +71,7 @@ public abstract class AbstractSystemTableManager implements AbstractTableManager
 
     @Override
     public CompletableFuture<StatementExecutionResult> executeStatementAsync(Statement statement, Transaction transaction, StatementEvaluationContext context) throws StatementExecutionException {
-        return FutureUtils.exception(new StatementExecutionException("not supported on system tables"));
+        return Futures.exception(new StatementExecutionException("not supported on system tables"));
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/planner/InsertOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/InsertOp.java
@@ -42,6 +42,7 @@ import herddb.sql.expressions.CompiledSQLExpression;
 import herddb.sql.expressions.ConstantExpression;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
+import herddb.utils.Futures;
 import herddb.utils.Wrapper;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +51,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.logging.Logger;
-import org.apache.bookkeeper.common.concurrent.FutureUtils;
 
 public class InsertOp implements PlannerOp {
 
@@ -137,7 +137,7 @@ public class InsertOp implements PlannerOp {
                 return tableSpaceManager.executeStatementAsync(statements.get(0), context, transactionContext);
             }
             if (returnValues) {
-                return FutureUtils.exception(new StatementExecutionException("cannot 'return values' on multi-values insert"));
+                return Futures.exception(new StatementExecutionException("cannot 'return values' on multi-values insert"));
             }
             CompletableFuture<StatementExecutionResult> finalResult = new CompletableFuture<>();
 

--- a/herddb-core/src/main/java/herddb/model/planner/PlannerOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/PlannerOp.java
@@ -26,10 +26,10 @@ import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.model.StatementExecutionResult;
 import herddb.model.TransactionContext;
+import herddb.utils.Futures;
 import herddb.utils.Wrapper;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import org.apache.bookkeeper.common.concurrent.FutureUtils;
 
 /**
  * Generic step of planned operation
@@ -74,9 +74,9 @@ public interface PlannerOp extends Wrapper {
         try {
             return CompletableFuture.completedFuture(execute(tableSpaceManager, transactionContext, context, lockRequired, forWrite));
         } catch (StatementExecutionException err) {
-            return FutureUtils.exception(err);
+            return Futures.exception(err);
         } catch (RuntimeException err) {
-            return FutureUtils.exception(new StatementExecutionException(err));
+            return Futures.exception(new StatementExecutionException(err));
         }
     }
 

--- a/herddb-jdbc/pom.xml
+++ b/herddb-jdbc/pom.xml
@@ -87,7 +87,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <id>make-uber</id>
@@ -150,6 +150,95 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make-thin</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>thin</shadedClassifierName>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>${basedir}/thin-dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>jline:jline</exclude>
+                                    <exclude>com.google.protobuf:*</exclude>
+                                    <exclude>org.apache.bookkeeper:*</exclude>
+                                    <exclude>org.apache.zookeeper:*</exclude>
+                                    <exclude>commons-configuration:*</exclude>                                                                        
+                                    <exclude>org.bouncycastle:*</exclude>                                    
+                                    <exclude>net.java.dev.jna:*</exclude>                                    
+                                    <exclude>org.apache.httpcomponents</exclude>
+                                    <exclude>org.jctools:*</exclude>
+                                    <exclude>net.jpountz.lz4:*</exclude>
+                                </excludes>
+                            </artifactSet>                            
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>herddb.org.apache</shadedPattern>                                    
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>herddb.io.netty</shadedPattern>                                    
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>herddb.com.fasterxml</shadedPattern>                                    
+                                </relocation>                               
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>herddb.com.google</shadedPattern>                                    
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>herddb.org.slf4j</shadedPattern>                                    
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.jcp</pattern>
+                                    <shadedPattern>herddb.net.jcp</shadedPattern>                                    
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.sf.jsqlparser</pattern>
+                                    <shadedPattern>herddb.net.sf.jsqlparser</shadedPattern>                                    
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.jpountz</pattern>
+                                    <shadedPattern>herddb.net.jpountz</shadedPattern>                                    
+                                </relocation>   
+                                <relocation>
+                                    <!-- Calcite stuff -->
+                                    <pattern>com.jayway.jsonpath</pattern>
+                                    <shadedPattern>herddb.com.jayway.jsonpath</shadedPattern>                                    
+                                </relocation>                      
+                                
+                                <!-- Cannot relocate org.codehaus.commons.compiler stuff, needed by Calcite
+                                    <relocation>
+                                    <pattern>org.codehaus</pattern>
+                                    <shadedPattern>herddb.org.codehaus</shadedPattern>                                    
+                                </relocation> -->
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>                                        
                                     </excludes>
                                 </filter>
                             </filters>

--- a/herddb-thirdparty/openjpa-test/pom.xml
+++ b/herddb-thirdparty/openjpa-test/pom.xml
@@ -44,10 +44,28 @@
             <version>3.1.1</version>
         </dependency>
         <dependency>
+            <!-- use 'thin' driver, we want OpenJPA users to be able to run tests
+                 using a minimum set of dependencies -->
             <groupId>org.herddb</groupId>
             <artifactId>herddb-jdbc</artifactId>
             <version>${project.version}</version>
+            <classifier>thin</classifier>
+            <exclusions>
+                <!-- workaround to Maven dependency bug,
+                     we don't want to import dependencies of herddb-jdbc project here -->
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.7.0</version>
+             <scope>test</scope>
+        </dependency>        
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/herddb-utils/src/main/java/herddb/utils/Futures.java
+++ b/herddb-utils/src/main/java/herddb/utils/Futures.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.utils;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class Futures {
+
+    private static final Function<Throwable, Exception> DEFAULT_EXCEPTION_HANDLER = cause -> {
+        if (cause instanceof Exception) {
+            return (Exception) cause;
+        } else {
+            return new Exception(cause);
+        }
+    };
+
+    public static <T> CompletableFuture<T> exception(Throwable cause) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        future.completeExceptionally(cause);
+        return future;
+    }
+
+    public static <T> CompletableFuture<List<T>> collect(List<CompletableFuture<T>> futureList) {
+        CompletableFuture<Void> finalFuture =
+                CompletableFuture.allOf(futureList.toArray(new CompletableFuture[futureList.size()]));
+        return finalFuture.thenApply(result
+                -> futureList
+                        .stream()
+                        .map(CompletableFuture::join)
+                        .collect(Collectors.toList()));
+    }
+    
+    public static <T, ExceptionT extends Throwable> T result(
+            CompletableFuture<T> future,            
+            long timeout,
+            TimeUnit timeUnit) throws ExceptionT, TimeoutException, InterruptedException, Exception {
+        return result(future, DEFAULT_EXCEPTION_HANDLER, timeout, timeUnit);
+    }
+    
+     public static <T, ExceptionT extends Throwable> T result(
+            CompletableFuture<T> future) throws ExceptionT, TimeoutException, InterruptedException, Exception {
+        return result(future, DEFAULT_EXCEPTION_HANDLER);
+    }
+
+    public static <T, ExceptionT extends Throwable> T result(
+            CompletableFuture<T> future,
+            Function<Throwable, ExceptionT> exceptionHandler,
+            long timeout,
+            TimeUnit timeUnit) throws ExceptionT, TimeoutException, InterruptedException {
+        try {
+            return future.get(timeout, timeUnit);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } catch (ExecutionException e) {
+            ExceptionT cause = exceptionHandler.apply(e.getCause());
+            if (null == cause) {
+                return null;
+            } else {
+                throw cause;
+            }
+        }
+    }
+        
+    public static <T, ExceptionT extends Throwable> T result(
+        CompletableFuture<T> future, Function<Throwable, ExceptionT> exceptionHandler) throws ExceptionT, InterruptedException {
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } catch (ExecutionException e) {
+            ExceptionT cause = exceptionHandler.apply(e.getCause());
+            if (null == cause) {
+                return null;
+            } else {
+                throw cause;
+            }
+        }
+    }
+}

--- a/herddb-utils/src/main/java/herddb/utils/Futures.java
+++ b/herddb-utils/src/main/java/herddb/utils/Futures.java
@@ -52,14 +52,14 @@ public class Futures {
                         .map(CompletableFuture::join)
                         .collect(Collectors.toList()));
     }
-    
+
     public static <T, ExceptionT extends Throwable> T result(
-            CompletableFuture<T> future,            
+            CompletableFuture<T> future,
             long timeout,
             TimeUnit timeUnit) throws ExceptionT, TimeoutException, InterruptedException, Exception {
         return result(future, DEFAULT_EXCEPTION_HANDLER, timeout, timeUnit);
     }
-    
+
      public static <T, ExceptionT extends Throwable> T result(
             CompletableFuture<T> future) throws ExceptionT, TimeoutException, InterruptedException, Exception {
         return result(future, DEFAULT_EXCEPTION_HANDLER);
@@ -84,7 +84,7 @@ public class Futures {
             }
         }
     }
-        
+
     public static <T, ExceptionT extends Throwable> T result(
         CompletableFuture<T> future, Function<Throwable, ExceptionT> exceptionHandler) throws ExceptionT, InterruptedException {
         try {


### PR DESCRIPTION
- do not use BookKeeper FutureUtils where not needed
- do not use BookKeeper ConcurrentLongHashMap
- creare a new herddb-jdbc-thin driver
- do not depend on bookkeeper-commons package in HerdDB Collections
