### PR TITLE
Handle directly server side execution in application threads

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -101,7 +101,7 @@ public class ClientConfiguration {
     public static final boolean PROPERTY_CLIENT_CONNECT_REMOTE_SERVER_DEFAULT = true;
 
     public static final String PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER = "client.network.connect.localvm";
-    public static final boolean PROPERTY_CLIENT_CONNECT_REMOTE_LOCALVM_DEFAULT = true;
+    public static final boolean PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER_DEFAULT = true;
 
 
     public ClientConfiguration(Properties properties) {

--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -100,6 +100,9 @@ public class ClientConfiguration {
     public static final String PROPERTY_CLIENT_CONNECT_REMOTE_SERVER = "client.network.connect.remote";
     public static final boolean PROPERTY_CLIENT_CONNECT_REMOTE_SERVER_DEFAULT = true;
 
+    public static final String PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER = "client.network.connect.localvm";
+    public static final boolean PROPERTY_CLIENT_CONNECT_REMOTE_LOCALVM_DEFAULT = true;
+
 
     public ClientConfiguration(Properties properties) {
         this.properties = new Properties();

--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -156,7 +156,7 @@ public class HDBClient implements AutoCloseable {
     Channel createChannelTo(ServerHostData server, ChannelEventListener eventReceiver) throws IOException {
         final int timeoutms = configuration.getInt(ClientConfiguration.PROPERTY_NETWORK_TIMEOUT, ClientConfiguration.PROPERTY_NETWORK_TIMEOUT_DEFAULT);
         final int timeouts = (int) TimeUnit.MILLISECONDS.toSeconds(timeoutms);
-        final boolean connectLocalVmAllowed = configuration.getBoolean(ClientConfiguration.PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER, false);
+        final boolean connectLocalVmAllowed = configuration.getBoolean(ClientConfiguration.PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER, ClientConfiguration.PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER_DEFAULT);
         if (!connectLocalVmAllowed) {
             return NettyConnector.connectUsingNetwork(server.getHost(), server.getPort(), server.isSsl(), timeoutms, timeouts, eventReceiver, thredpool,
                     networkGroup);

--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -154,10 +154,16 @@ public class HDBClient implements AutoCloseable {
     }
 
     Channel createChannelTo(ServerHostData server, ChannelEventListener eventReceiver) throws IOException {
-        int timeoutms = configuration.getInt(ClientConfiguration.PROPERTY_NETWORK_TIMEOUT, ClientConfiguration.PROPERTY_NETWORK_TIMEOUT_DEFAULT);
-        int timeouts = (int) TimeUnit.MILLISECONDS.toSeconds(timeoutms);
-        return NettyConnector.connect(server.getHost(), server.getPort(), server.isSsl(), timeoutms, timeouts, eventReceiver, thredpool,
-                networkGroup);
+        final int timeoutms = configuration.getInt(ClientConfiguration.PROPERTY_NETWORK_TIMEOUT, ClientConfiguration.PROPERTY_NETWORK_TIMEOUT_DEFAULT);
+        final int timeouts = (int) TimeUnit.MILLISECONDS.toSeconds(timeoutms);
+        final boolean connectLocalVmAllowed = configuration.getBoolean(ClientConfiguration.PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER, false);
+        if (!connectLocalVmAllowed) {
+            return NettyConnector.connectUsingNetwork(server.getHost(), server.getPort(), server.isSsl(), timeoutms, timeouts, eventReceiver, thredpool,
+                    networkGroup);
+        } else {
+            return NettyConnector.connect(server.getHost(), server.getPort(), server.isSsl(), timeoutms, timeouts, eventReceiver, thredpool,
+                    networkGroup);
+        }
     }
 
     StatsLogger getStatsLogger() {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -711,6 +711,8 @@ public class TableSpaceManager {
         ClientConfiguration clientConfiguration = new ClientConfiguration(dbmanager.getTmpDirectory());
         clientConfiguration.set(ClientConfiguration.PROPERTY_CLIENT_USERNAME, dbmanager.getServerToServerUsername());
         clientConfiguration.set(ClientConfiguration.PROPERTY_CLIENT_PASSWORD, dbmanager.getServerToServerPassword());
+        // always use network, we want to run tests with this case
+        clientConfiguration.set(ClientConfiguration.PROPERTY_CLIENT_CONNECT_LOCALVM_SERVER, false);
         try (HDBClient client = new HDBClient(clientConfiguration)) {
             client.setClientSideMetadataProvider(new ClientSideMetadataProvider() {
                 @Override

--- a/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
+++ b/herddb-net/src/main/java/herddb/network/netty/NettyConnector.java
@@ -1,23 +1,22 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.network.netty;
 
 import herddb.network.ChannelEventListener;
@@ -42,6 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.net.ssl.SSLException;
 
 /**
  * Client-side connector
@@ -57,74 +57,81 @@ public class NettyConnector {
             ChannelEventListener receiver, final ExecutorService callbackExecutor, final MultithreadEventLoopGroup networkGroup
     ) throws IOException {
         try {
-            final SslContext sslCtx = !ssl ? null : SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
-
-            Class<? extends Channel> channelType;
-
             InetSocketAddress inet = new InetSocketAddress(host, port);
-            SocketAddress address;
             String hostAddress = NetworkUtils.getAddress(inet);
-
             LocalVMChannelAcceptor localVm = LocalServerRegistry.getLocalServer(hostAddress, port);
-            MultithreadEventLoopGroup group;
             if (localVm != null && socketTimeout <= 0) {
                 // if socketTimeout is greater than zero we cannot use our local transport implement
                 // that timeout would need a timer
                 // it is useful only to detect stuck network problems
                 return localVm.connect(host + ":" + port, receiver, callbackExecutor);
-            } else if (networkGroup == null) {
-                throw new IOException("Connection using network is disabled, cannot connect to " + host + ":" + port);
-            } else {
-                channelType = networkGroup instanceof EpollEventLoopGroup ? EpollSocketChannel.class : NioSocketChannel.class;
-                address = inet;
-                group = networkGroup;
             }
-            Bootstrap b = new Bootstrap();
-            AtomicReference<NettyChannel> result = new AtomicReference<>();
-
-            b.group(group)
-                    .channel(channelType)
-                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout)
-                    .handler(new ChannelInitializer<Channel>() {
-                                 @Override
-                                 public void initChannel(Channel ch) throws Exception {
-                                     try {
-                                         NettyChannel channel = new NettyChannel(host + ":" + port,
-                                                 ch, callbackExecutor);
-                                         result.set(channel);
-                                         channel.setMessagesReceiver(receiver);
-                                         if (ssl) {
-                                             ch.pipeline().addLast(sslCtx.newHandler(ch.alloc(), host, port));
-                                         }
-                                         if (socketTimeout > 0) {
-                                             ch.pipeline().addLast("readTimeoutHandler", new ReadTimeoutHandler(socketTimeout));
-                                         }
-                                         ch.pipeline().addLast("lengthprepender", new LengthFieldPrepender(4));
-                                         ch.pipeline().addLast("lengthbaseddecoder", new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
-//
-                                         ch.pipeline().addLast("messagedecoder", new ProtocolMessageDecoder());
-                                         ch.pipeline().addLast(new ClientInboundMessageHandler(channel));
-                                     } catch (Throwable t) {
-                                         LOGGER.log(Level.SEVERE, "error connecting", t);
-                                         ch.close();
-                                     }
-                                 }
-                             }
-                    );
-
-            LOGGER.log(Level.FINE, "connecting to {0}:{1} ssl={2} address={3}", new Object[]{host, port, ssl, address
-                    }
-            );
-            b.connect(address).sync();
-            NettyChannel nettyChannel = result.get();
-            if (!nettyChannel.isValid()) {
-                throw new IOException("returned channel is not valid");
-            }
-            return nettyChannel;
+            return createNettyChannel(inet, host, port, ssl, connectTimeout, socketTimeout, receiver, callbackExecutor, networkGroup);
         } catch (InterruptedException ex) {
             throw new IOException(ex);
         }
+    }
 
+    public static herddb.network.Channel connectUsingNetwork(String host, int port, boolean ssl, int connectTimeout, int socketTimeout,
+            ChannelEventListener receiver, final ExecutorService callbackExecutor, final MultithreadEventLoopGroup networkGroup) throws IOException, SSLException {
+        try {
+            InetSocketAddress inet = new InetSocketAddress(host, port);
+            return createNettyChannel(inet, host, port, ssl, connectTimeout, socketTimeout,
+                    receiver, callbackExecutor, networkGroup);
+        } catch (InterruptedException ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    private static herddb.network.Channel createNettyChannel(SocketAddress address, String host, int port, boolean ssl, int connectTimeout, int socketTimeout,
+            ChannelEventListener receiver, final ExecutorService callbackExecutor, final MultithreadEventLoopGroup networkGroup) throws IOException, SSLException, InterruptedException {
+        if (networkGroup == null) {
+                throw new IOException("Connection using network is disabled, cannot connect to " + host + ":" + port);
+        }
+        Class<? extends Channel> channelType;
+        MultithreadEventLoopGroup group = networkGroup;
+        final SslContext sslCtx = !ssl ? null : SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+        Bootstrap b = new Bootstrap();
+        AtomicReference<NettyChannel> result = new AtomicReference<>();
+        channelType = networkGroup instanceof EpollEventLoopGroup ? EpollSocketChannel.class : NioSocketChannel.class;
+        b.group(group)
+                .channel(channelType)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    public void initChannel(Channel ch) throws Exception {
+                        try {
+                            NettyChannel channel = new NettyChannel(host + ":" + port,
+                                    ch, callbackExecutor);
+                            result.set(channel);
+                            channel.setMessagesReceiver(receiver);
+                            if (ssl) {
+                                ch.pipeline().addLast(sslCtx.newHandler(ch.alloc(), host, port));
+                            }
+                            if (socketTimeout > 0) {
+                                ch.pipeline().addLast("readTimeoutHandler", new ReadTimeoutHandler(socketTimeout));
+                            }
+                            ch.pipeline().addLast("lengthprepender", new LengthFieldPrepender(4));
+                            ch.pipeline().addLast("lengthbaseddecoder", new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
+//
+                            ch.pipeline().addLast("messagedecoder", new ProtocolMessageDecoder());
+                            ch.pipeline().addLast(new ClientInboundMessageHandler(channel));
+                        } catch (Throwable t) {
+                            LOGGER.log(Level.SEVERE, "error connecting", t);
+                            ch.close();
+                        }
+                    }
+                }
+                );
+        LOGGER.log(Level.FINE, "connecting to {0}:{1} ssl={2} address={3}", new Object[]{host, port, ssl, address
+        }
+        );
+        b.connect(address).sync();
+        NettyChannel nettyChannel = result.get();
+        if (!nettyChannel.isValid()) {
+            throw new IOException("returned channel is not valid");
+        }
+        return nettyChannel;
     }
 
 }

--- a/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
+++ b/herddb-net/src/test/java/herddb/network/netty/LocalChannelTest.java
@@ -21,6 +21,7 @@ package herddb.network.netty;
 
 import static herddb.network.netty.Utils.buildAckRequest;
 import static herddb.network.netty.Utils.buildAckResponse;
+import static herddb.utils.TestUtils.NOOP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -29,6 +30,7 @@ import herddb.network.Channel;
 import herddb.network.ChannelEventListener;
 import herddb.network.ServerSideConnection;
 import herddb.proto.Pdu;
+import herddb.utils.TestUtils;
 import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
 import java.util.Random;
@@ -114,7 +116,7 @@ public class LocalChannelTest {
                 //  closing the server should close the client
                 server.close();
                 assertTrue(client.isClosed());
-                assertTrue(closeNotificationReceived.get());
+                TestUtils.waitForCondition(() -> closeNotificationReceived.get(), NOOP, 100);
             } finally {
                 executor.shutdown();
             }


### PR DESCRIPTION
Follow up of #668 
When using LocalVMChannel we can execute server side peer code in the same thread of the application.

Changes:
- add new client option client.network.connect.localvm to disable connection to localvm server
- force server-to-server communication to use real network (we want tests to test something real)
- add a short-circuit path in LocalVMChannel to call directly the server peer
- server responses still run in the client callback threads (if we want to change this behavior it is better to do it in another patch)