### PR TITLE
Allow ALTER TABLE to be run in a transaction (with implicit COMMIT before execution)

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1275,7 +1275,8 @@ public class TableSpaceManager {
                     new StatementExecutionException("transaction " + transactionContext.transactionId + " not found on tablespace " + tableSpaceName));
         }
         boolean isTransactionCommand = statement instanceof CommitTransactionStatement
-                || statement instanceof RollbackTransactionStatement;
+                || statement instanceof RollbackTransactionStatement
+                || statement instanceof AlterTableStatement; // AlterTable implictly commits the transaction
         if (transaction != null) {
             transaction.touch();
             if (!isTransactionCommand) {
@@ -1430,7 +1431,16 @@ public class TableSpaceManager {
         }
         try {
             if (transactionContext.transactionId > 0) {
-                throw new StatementExecutionException("ALTER TABLE cannot be executed inside a transaction (txid=" + transactionContext.transactionId + ")");
+                Transaction transaction = transactions.get(transactionContext.transactionId);
+                if (transactionContext.transactionId > 0 && transaction == null) {
+                    throw new StatementExecutionException("transaction " + transactionContext.transactionId + " does not exist on tablespace " + tableSpaceName);
+                }
+                if (transaction != null && !transaction.tableSpace.equals(tableSpaceName)) {
+                    throw new StatementExecutionException("transaction " + transaction.transactionId + " is for tablespace " + transaction.tableSpace + ", not for " + tableSpaceName);
+                }
+                LOGGER.log(Level.INFO, "Implicitly committing transaction " + transactionContext.transactionId + " due to an ALTER TABLE statement in tablespace " + tableSpaceName);
+                commitTransaction(new CommitTransactionStatement(tableSpaceName, transactionContext.transactionId), context).join();
+                transactionContext = TransactionContext.NO_TRANSACTION;
             }
             AbstractTableManager tableManager = tables.get(statement.getTable());
             if (tableManager == null) {
@@ -1452,6 +1462,7 @@ public class TableSpaceManager {
             } catch (Exception err) {
                 throw new StatementExecutionException(err);
             }
+            // HERE tranactionId will be always 0, because transaction is implicitly committed
             return new DDLStatementExecutionResult(transactionContext.transactionId);
         } finally {
             if (lockAcquired) {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1439,7 +1439,11 @@ public class TableSpaceManager {
                     throw new StatementExecutionException("transaction " + transaction.transactionId + " is for tablespace " + transaction.tableSpace + ", not for " + tableSpaceName);
                 }
                 LOGGER.log(Level.INFO, "Implicitly committing transaction " + transactionContext.transactionId + " due to an ALTER TABLE statement in tablespace " + tableSpaceName);
-                commitTransaction(new CommitTransactionStatement(tableSpaceName, transactionContext.transactionId), context).join();
+                try {
+                    commitTransaction(new CommitTransactionStatement(tableSpaceName, transactionContext.transactionId), context).join();
+                } catch (CompletionException err) {
+                    throw new StatementExecutionException(err);
+                }
                 transactionContext = TransactionContext.NO_TRANSACTION;
             }
             AbstractTableManager tableManager = tables.get(statement.getTable());

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1466,7 +1466,7 @@ public class TableSpaceManager {
             } catch (Exception err) {
                 throw new StatementExecutionException(err);
             }
-            // HERE tranactionId will be always 0, because transaction is implicitly committed
+            // Here transactionId is always 0, because transaction is implicitly committed
             return new DDLStatementExecutionResult(transactionContext.transactionId);
         } finally {
             if (lockAcquired) {

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBDatabaseMetadata.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBDatabaseMetadata.java
@@ -641,7 +641,7 @@ public class HerdDBDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Fixes #671 
- Allow ALTER TABLE during a transaction but implicitly issue a COMMIT to the transaction.
- Update JDBC Database metadata accordingly

Very similar to MySQL behavior 
https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html