### PR TITLE
Diskless cluster mode v2

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -1271,9 +1271,6 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     @Override
     public List<Table> loadTables(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
         try {
-//            TODO
-//            String tableSpaceDirectory = getTableSpaceZNode(tableSpace);
-//            ensureZNodeDirectory(tableSpace, tableSpaceDirectory);
             String file = getTablespaceTablesMetadataFile(tableSpace, sequenceNumber);
             LOGGER.log(Level.INFO, "loadTables for tableSpace " + tableSpace + " from " + file + ", sequenceNumber:" + sequenceNumber);
             byte[] content = readZNode(file, new Stat());
@@ -1324,9 +1321,6 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     @Override
     public List<Index> loadIndexes(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
         try {
-//          TODO
-//          String tableSpaceDirectory = getTableSpaceZNode(tableSpace);
-//          ensureZNodeDirectory(tableSpaceDirectory);
             String file = getTablespaceIndexesMetadataFile(tableSpace, sequenceNumber);
 
             LOGGER.log(Level.INFO, "loadIndexes for tableSpace " + tableSpace + " from " + file + ", sequenceNumber:" + sequenceNumber);

--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -58,6 +58,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -86,6 +87,8 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
 import org.apache.zookeeper.ZKUtil;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.Stat;
@@ -102,7 +105,7 @@ import org.apache.zookeeper.data.Stat;
 public class BookKeeperDataStorageManager extends DataStorageManager {
 
     private static final Logger LOGGER = Logger.getLogger(BookKeeperDataStorageManager.class.getName());
-    private static final byte[] EMPTY_PASSWORD = new byte[0];
+    private static final byte[] EMPTY_ARRAY = new byte[0];
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private final Path tmpDirectory;
@@ -120,9 +123,10 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
 
     private final ConcurrentHashMap<String, TableSpacePagesMapping> tableSpaceMappings = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Integer> tableSpaceExpectedReplicaCount = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Integer> tableSpaceZkNodeVersion = new ConcurrentHashMap<>();
+
 
     private final String rootZkNode;
-    private final String baseZkNode;
 
     public static final String FILEEXTENSION_PAGE = ".page";
 
@@ -216,14 +220,14 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             byte[] serialized = MAPPER.writeValueAsBytes(mapping);
             String znode = getTableSpaceMappingZNode(tableSpace);
             LOGGER.log(Level.INFO, "persistTableSpaceMapping " + tableSpace + ", " + mapping + " to " + znode + " JSON " + new String(serialized, StandardCharsets.UTF_8));
-            writeZNode(znode, serialized, null);
+            writeZNodeEnforceOwnership(tableSpace, znode, serialized, null);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }
     }
 
     private void loadTableSpacesAtBoot() throws DataStorageManagerException {
-        List<String> list = zkGetChildren(baseZkNode, false);
+        List<String> list = zkGetChildren(rootZkNode, false);
         LOGGER.log(Level.INFO, "tableSpaces to load: {0}", list);
         for (String tablespace : list) {
             loadTableSpaceMapping(tablespace);
@@ -231,9 +235,17 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     }
 
     private void loadTableSpaceMapping(String tableSpace) throws DataStorageManagerException {
-        String znode = getTableSpaceMappingZNode(tableSpace);
+        String tableSpaceNode = getTableSpaceZNode(tableSpace);
         Stat stat = new Stat();
-        byte[] serialized = readZNode(znode, stat);
+        byte[] exists = readZNode(tableSpaceNode, stat);
+        if (exists == null) {
+            throw new DataStorageManagerException("znode " + tableSpace + " does not exist");
+        }
+        tableSpaceZkNodeVersion.put(tableSpace, stat.getVersion());
+        LOGGER.log(Level.INFO, "loadTableSpaceMapping " + tableSpace + ", tableSpaceZkNodeVersion is " + stat.getVersion());
+
+        String znode = getTableSpaceMappingZNode(tableSpace);
+        byte[] serialized = readZNode(znode, null);
         if (serialized == null) {
             LOGGER.log(Level.INFO, "loadTableSpaceMapping " + tableSpace + ", from " + znode + " was not found");
             tableSpaceMappings.put(tableSpace, new TableSpacePagesMapping());
@@ -246,11 +258,10 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
                 throw new DataStorageManagerException(ex);
             }
         }
-
     }
 
     private String getTableSpaceZNode(String tableSpaceUUID) {
-        return baseZkNode + "/" + tableSpaceUUID;
+        return rootZkNode + "/" + tableSpaceUUID;
     }
 
     public BookKeeperDataStorageManager(String nodeId, Path baseDirectory, ZookeeperMetadataStorageManager zk, BookkeeperCommitLogManager bk) {
@@ -278,7 +289,6 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
         this.zk = zk;
         this.bk = bk;
         this.rootZkNode = zk.getBasePath() + "/data";
-        this.baseZkNode = rootZkNode + "/" + nodeId;
     }
 
     @Override
@@ -289,11 +299,17 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             LOGGER.log(Level.INFO, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
             FileUtils.cleanDirectory(tmpDirectory);
             Files.createDirectories(tmpDirectory);
-            LOGGER.log(Level.INFO, "preparing root znode " + baseZkNode);
-            ensureZNodeDirectory(rootZkNode);
-            ensureZNodeDirectory(baseZkNode);
+            LOGGER.log(Level.INFO, "preparing root znode " + rootZkNode);
+            try {
+                zk.ensureZooKeeper().create(rootZkNode, EMPTY_ARRAY, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                LOGGER.log(Level.INFO, "first boot of this cluster, created " + rootZkNode);
+            } catch (KeeperException.NodeExistsException exists) {
+            }
             loadTableSpacesAtBoot();
-        } catch (IOException err) {
+        } catch (IOException | KeeperException err) {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
             throw new DataStorageManagerException(err);
         }
     }
@@ -329,6 +345,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     public static final String EXTENSION_TABLEORINDExCHECKPOINTINFOFILE = ".checkpoint";
 
     private static boolean isTablespaceCheckPointInfoFile(String name) {
+        name = getFilename(name);
         return (name.startsWith("checkpoint.") && name.endsWith(EXTENSION_TABLEORINDExCHECKPOINTINFOFILE));
     }
 
@@ -391,12 +408,26 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     public void initIndex(String tableSpace, String uuid) throws DataStorageManagerException {
         String indexDir = getIndexDirectory(tableSpace, uuid);
         LOGGER.log(Level.FINE, "initIndex {0} {1} at {2}", new Object[]{tableSpace, uuid, indexDir});
+        createZNode(tableSpace, indexDir, new byte[0], false);
+    }
 
+    @Override
+    public void initTablespace(String tableSpace) throws DataStorageManagerException {
+        LOGGER.log(Level.INFO, "initTablespace {0}", tableSpace);
+
+        blindEnsureTablespaceNodeExists(tableSpace);
+        // load current status
+        loadTableSpaceMapping(tableSpace);
+        // fence out other nodes
+        persistTableSpaceMapping(tableSpace);
+
+    }
+
+    private void blindEnsureTablespaceNodeExists(String tableSpace) throws DataStorageManagerException {
         try {
-            zk.ensureZooKeeper().create(indexDir, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        } catch (KeeperException.NodeExistsException err) {
-            // good, index already booted once
-        } catch (IOException | KeeperException err) {
+            zk.ensureZooKeeper().create(getTableSpaceZNode(tableSpace), EMPTY_ARRAY, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        } catch (KeeperException.NodeExistsException ok){
+        } catch (KeeperException | IOException err){
             throw new DataStorageManagerException(err);
         } catch (InterruptedException err) {
             Thread.currentThread().interrupt();
@@ -408,16 +439,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     public void initTable(String tableSpace, String uuid) throws DataStorageManagerException {
         String tableDir = getTableDirectory(tableSpace, uuid);
         LOGGER.log(Level.FINE, "initTable {0} {1} at {2}", new Object[]{tableSpace, uuid, tableDir});
-        try {
-            zk.ensureZooKeeper().create(tableDir, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        } catch (KeeperException.NodeExistsException err) {
-            // good, table already booted once
-        } catch (IOException | KeeperException err) {
-            throw new DataStorageManagerException(err);
-        } catch (InterruptedException err) {
-            Thread.currentThread().interrupt();
-            throw new DataStorageManagerException(err);
-        }
+        createZNode(tableSpace, tableDir, new byte[0], false);
     }
 
     @Override
@@ -623,13 +645,41 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
         }
     }
 
-    private void writeZNode(String checkpointFile, byte[] content, Stat stat) throws DataStorageManagerException {
+    private void writeZNodeEnforceOwnership(String tableSpace, String path, byte[] content, Stat stat) throws DataStorageManagerException {
         try {
             zkWrites.inc();
+            Op opUpdateRoot = createUpdateTableSpaceRootOp(tableSpace);
+            Op opCreate = Op.create(path, content, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
             try {
-                zk.ensureZooKeeper().create(checkpointFile, content, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-            } catch (KeeperException.NodeExistsException err) {
-                zk.ensureZooKeeper().setData(checkpointFile, content, stat != null ? stat.getVersion() : -1);
+                List<OpResult> multi = zk.ensureZooKeeper().multi(Arrays.asList(opUpdateRoot, opCreate));
+                updateRootZkNodeVersion(tableSpace, multi.get(0));
+            } catch (KeeperException.NodeExistsException ok) {
+                LOGGER.log(Level.INFO, "Node exists " + ok.getPath());
+            }
+
+            opUpdateRoot = createUpdateTableSpaceRootOp(tableSpace);
+            Op opUpdate = Op.setData(path, content, stat != null ? stat.getVersion() : -1);
+            List<OpResult> multi = zk.ensureZooKeeper().multi(Arrays.asList(opUpdateRoot, opUpdate));
+            updateRootZkNodeVersion(tableSpace, multi.get(0));
+        } catch (IOException | KeeperException err) {
+            throw new DataStorageManagerException(err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new DataStorageManagerException(err);
+        }
+    }
+
+    private void createZNode(String tableSpace, String path, byte[] content, boolean errorIfExists) throws DataStorageManagerException {
+        try {
+            zkWrites.inc();
+            Op opUpdateRoot = createUpdateTableSpaceRootOp(tableSpace);
+            Op opCreate = Op.create(path, content, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            List<OpResult> multi = zk.ensureZooKeeper().multi(Arrays.asList(opUpdateRoot, opCreate));
+            updateRootZkNodeVersion(tableSpace, multi.get(0));
+        } catch (KeeperException.NodeExistsException err) {
+            if (errorIfExists) {
+                throw new DataStorageManagerException(err);
             }
         } catch (IOException | KeeperException err) {
             throw new DataStorageManagerException(err);
@@ -639,27 +689,28 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
         }
     }
 
-    private List<String> ensureZNodeDirectoryAndReturnChildren(String znode) throws DataStorageManagerException {
+    private Op createUpdateTableSpaceRootOp(String tableSpace) {
+        String tableSpaceRootNode = getTableSpaceZNode(tableSpace);
+        int tableSpaceRootNodeVersion = tableSpaceZkNodeVersion.get(tableSpace);
+        Op opUpdateRoot = Op.setData(tableSpaceRootNode, new byte[0], tableSpaceRootNodeVersion);
+        LOGGER.log(Level.INFO, "createUpdateTableSpaceRootOp " + tableSpaceRootNode + " version " + tableSpaceRootNodeVersion);
+        return opUpdateRoot;
+    }
+
+    private void updateRootZkNodeVersion(String tableSpace, OpResult ensureLeadership) throws DataStorageManagerException {
+        OpResult.SetDataResult res = (OpResult.SetDataResult) ensureLeadership;
+        LOGGER.log(Level.INFO, "updateRootZkNodeVersion " + tableSpace + " newversion " + res.getStat().getVersion());
+        tableSpaceZkNodeVersion.put(tableSpace, res.getStat().getVersion());
+    }
+
+    private List<String> ensureZNodeDirectoryAndReturnChildren(String tableSpace, String znode) throws DataStorageManagerException {
         try {
             if (zk.ensureZooKeeper().exists(znode, false) != null) {
                 return zkGetChildren(znode);
             } else {
-                zk.ensureZooKeeper().create(znode, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                createZNode(tableSpace, znode, new byte[0], true);
                 return Collections.emptyList();
             }
-        } catch (IOException | KeeperException err) {
-            throw new DataStorageManagerException(err);
-        } catch (InterruptedException err) {
-            Thread.currentThread().interrupt();
-            throw new DataStorageManagerException(err);
-        }
-    }
-
-    private void ensureZNodeDirectory(String znode) throws DataStorageManagerException {
-        try {
-            zk.ensureZooKeeper().create(znode, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-        } catch (KeeperException.NodeExistsException err) {
-            return;
         } catch (IOException | KeeperException err) {
             throw new DataStorageManagerException(err);
         } catch (InterruptedException err) {
@@ -749,14 +800,14 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
 
     private String getLastTableCheckpointFile(String tableSpace, String tableName) throws IOException, KeeperException, InterruptedException {
         String dir = getTableDirectory(tableSpace, tableName);
-        String result = getMostRecentCheckPointFile(dir);
+        String result = getMostRecentCheckPointFile(tableSpace, dir);
         return result;
     }
 
-    private String getMostRecentCheckPointFile(String dir) throws IOException, KeeperException, InterruptedException {
+    private String getMostRecentCheckPointFile(String tableSpace, String dir) throws IOException, KeeperException, InterruptedException {
         String result = null;
         long lastMod = -1;
-        List<String> children = ensureZNodeDirectoryAndReturnChildren(dir);
+        List<String> children = ensureZNodeDirectoryAndReturnChildren(tableSpace, dir);
 
         for (String fullpath : children) {
             if (isTableOrIndexCheckpointsFile(fullpath)) {
@@ -845,7 +896,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             throw new DataStorageManagerException(err);
         }
 
-        writeZNode(checkpointFile, content, stat);
+        writeZNodeEnforceOwnership(tableSpace, checkpointFile, content, stat);
 
         /* Checkpoint pinning */
         final Map<Long, Integer> pins = pinTableAndGetPages(tableSpace, tableName, tableStatus, pin);
@@ -924,7 +975,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
         } catch (IOException err) {
             throw new DataStorageManagerException(err);
         }
-        writeZNode(checkpointFile, content, stat);
+        writeZNodeEnforceOwnership(tableSpace, checkpointFile, content, stat);
 
         /* Checkpoint pinning */
         final Map<Long, Integer> pins = pinIndexAndGetPages(tableSpace, indexName, indexStatus, pin);
@@ -1062,7 +1113,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
                                 .withEnsembleSize(actualEnsembleSize)
                                 .withWriteQuorumSize(actualWriteQuorumSize)
                                 .withAckQuorumSize(actualAckQuorumSize)
-                                .withPassword(EMPTY_PASSWORD)
+                                .withPassword(EMPTY_ARRAY)
                                 .withDigestType(DigestType.CRC32C)
                                 .withCustomMetadata(metadata)
                                 .execute(), BKException.HANDLER);) {
@@ -1154,7 +1205,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
                         .withEnsembleSize(actualEnsembleSize)
                         .withWriteQuorumSize(actualWriteQuorumSize)
                         .withAckQuorumSize(actualAckQuorumSize)
-                        .withPassword(EMPTY_PASSWORD)
+                        .withPassword(EMPTY_ARRAY)
                         .withDigestType(DigestType.CRC32C)
                         .withCustomMetadata(metadata)
                         .execute(), BKException.HANDLER);) {
@@ -1207,8 +1258,9 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     @Override
     public List<Table> loadTables(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
         try {
-            String tableSpaceDirectory = getTableSpaceZNode(tableSpace);
-            ensureZNodeDirectory(tableSpaceDirectory);
+//            TODO
+//            String tableSpaceDirectory = getTableSpaceZNode(tableSpace);
+//            ensureZNodeDirectory(tableSpace, tableSpaceDirectory);
             String file = getTablespaceTablesMetadataFile(tableSpace, sequenceNumber);
             LOGGER.log(Level.INFO, "loadTables for tableSpace " + tableSpace + " from " + file + ", sequenceNumber:" + sequenceNumber);
             byte[] content = readZNode(file, new Stat());
@@ -1259,8 +1311,9 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     @Override
     public List<Index> loadIndexes(LogSequenceNumber sequenceNumber, String tableSpace) throws DataStorageManagerException {
         try {
-            String tableSpaceDirectory = getTableSpaceZNode(tableSpace);
-            ensureZNodeDirectory(tableSpaceDirectory);
+//          TODO
+//          String tableSpaceDirectory = getTableSpaceZNode(tableSpace);
+//          ensureZNodeDirectory(tableSpaceDirectory);
             String file = getTablespaceIndexesMetadataFile(tableSpace, sequenceNumber);
 
             LOGGER.log(Level.INFO, "loadIndexes for tableSpace " + tableSpace + " from " + file + ", sequenceNumber:" + sequenceNumber);
@@ -1336,7 +1389,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             }
 
             dout.flush();
-            writeZNode(fileTables, buffer.toByteArray(), null);
+            writeZNodeEnforceOwnership(tableSpace, fileTables, buffer.toByteArray(), null);
         } catch (IOException err) {
             throw new DataStorageManagerException(err);
         }
@@ -1360,7 +1413,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             }
 
             dout.flush();
-            writeZNode(fileIndexes, buffer.toByteArray(), null);
+            writeZNodeEnforceOwnership(tableSpace, fileIndexes, buffer.toByteArray(), null);
         } catch (IOException err) {
             throw new DataStorageManagerException(err);
         }
@@ -1412,7 +1465,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
 
         String checkPointFile = getTablespaceCheckPointInfoFile(tableSpace, sequenceNumber);
 
-        LOGGER.log(Level.INFO, "checkpoint for " + tableSpace + " at " + sequenceNumber + " to " + checkPointFile);
+        LOGGER.log(Level.INFO, "checkpoint for {0} at {1} to {2}", new Object[]{tableSpace, sequenceNumber, checkPointFile});
 
         try (VisibleByteArrayOutputStream buffer = new VisibleByteArrayOutputStream();
                 ExtendedDataOutputStream dout = new ExtendedDataOutputStream(buffer)) {
@@ -1424,7 +1477,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             dout.writeZLong(sequenceNumber.offset);
 
             dout.flush();
-            writeZNode(checkPointFile, buffer.toByteArray(), null);
+            writeZNodeEnforceOwnership(tableSpace, checkPointFile, buffer.toByteArray(), null);
         } catch (IOException err) {
             throw new DataStorageManagerException(err);
         }
@@ -1637,7 +1690,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
             }
 
             dout.flush();
-            writeZNode(checkPointFile, buffer.toByteArray(), null);
+            writeZNodeEnforceOwnership(tableSpace, checkPointFile, buffer.toByteArray(), null);
         } catch (IOException err) {
             throw new DataStorageManagerException(err);
         }

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -141,6 +141,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
     private String serverToServerPassword = ClientConfiguration.PROPERTY_CLIENT_PASSWORD_DEFAULT;
     private boolean errorIfNotLeader = true;
     private final ServerConfiguration serverConfiguration;
+    private final String mode;
     private ConnectionsInfoProvider connectionsInfoProvider;
     private long checkpointPeriod;
     private long abandonedTransactionsTimeout;
@@ -185,6 +186,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
             StatsLogger statsLogger
     ) {
         this.serverConfiguration = configuration;
+        this.mode = serverConfiguration.getString(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_STANDALONE);
         this.tmpDirectory = tmpDirectory;
         int asyncWorkerThreads = configuration.getInt(ServerConfiguration.PROPERTY_ASYNC_WORKER_THREADS,
                 ServerConfiguration.PROPERTY_ASYNC_WORKER_THREADS_DEFAULT);
@@ -426,7 +428,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 .ssl(hostData.isSsl())
                 .nodeId(nodeId)
                 .build();
-        if (!serverConfiguration.getString(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_STANDALONE).equals(ServerConfiguration.PROPERTY_MODE_LOCAL)) {
+        if (!mode.equals(ServerConfiguration.PROPERTY_MODE_LOCAL)) {
             LOGGER.log(Level.INFO, "Registering on metadata storage manager my data: {0}", nodeMetadata);
         }
         metadataStorageManager.registerNode(nodeMetadata);
@@ -539,7 +541,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
             return;
         }
 
-        if (tableSpace.replicas.contains(nodeId) && !tablesSpaces.containsKey(tableSpaceName)) {
+        if (tableSpace.isNodeAssignedToTableSpace(nodeId) && !tablesSpaces.containsKey(tableSpaceName)) {
             LOGGER.log(Level.INFO, "Booting tablespace {0} on {1}, uuid {2}", new Object[]{tableSpaceName, nodeId, tableSpace.uuid});
             long _start = System.currentTimeMillis();
             CommitLog commitLog = commitLogManager.createCommitLog(tableSpace.uuid, tableSpace.name, nodeId);
@@ -551,27 +553,31 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 if (serverConfiguration.getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT)) {
                     JMXUtils.registerTableSpaceManagerStatsMXBean(tableSpaceName, manager.getStats());
                 }
+                planner.clearCache();
             } catch (DataStorageManagerException | LogNotAvailableException | MetadataStorageManagerException | DDLException t) {
                 LOGGER.log(Level.SEVERE, "Error Booting tablespace {0} on {1}", new Object[]{tableSpaceName, nodeId});
                 LOGGER.log(Level.SEVERE, "Error", t);
                 tablesSpaces.remove(tableSpaceName);
+                planner.clearCache();
                 try {
                     manager.close();
                 } catch (Throwable t2) {
                     LOGGER.log(Level.SEVERE, "Other Error", t2);
+                    t.addSuppressed(t2);
                 }
                 throw t;
             }
             return;
         }
 
-        if (tablesSpaces.containsKey(tableSpaceName) && !tableSpace.replicas.contains(nodeId)) {
+        if (tablesSpaces.containsKey(tableSpaceName) && !tableSpace.isNodeAssignedToTableSpace(nodeId)) {
             LOGGER.log(Level.INFO, "Tablespace {0} on {1} is not more in replica list {3}, uuid {2}", new Object[]{tableSpaceName, nodeId, tableSpace.uuid, tableSpace.replicas + ""});
             stopTableSpace(tableSpaceName, tableSpace.uuid);
             return;
         }
 
-        if (tableSpace.replicas.size() < tableSpace.expectedReplicaCount) {
+        if (!tableSpace.isNodeAssignedToTableSpace("*")
+                && tableSpace.replicas.size() < tableSpace.expectedReplicaCount) {
             List<NodeMetadata> nodes = metadataStorageManager.listNodes();
             LOGGER.log(Level.WARNING, "Tablespace {0} is underreplicated expectedReplicaCount={1}, replicas={2}, nodes={3}", new Object[]{tableSpaceName, tableSpace.expectedReplicaCount, tableSpace.replicas, nodes});
             List<String> availableOtherNodes = nodes.stream().map(n -> {
@@ -857,6 +863,10 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
 
     public String getVirtualTableSpaceId() {
         return virtualTableSpaceId;
+    }
+
+    public String getMode() {
+        return mode;
     }
 
     void submit(Runnable runnable) {
@@ -1315,6 +1325,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
             LOGGER.log(Level.SEVERE, "node " + nodeId + " cannot close for reboot tablespace " + tableSpace, err);
         }
         tablesSpaces.remove(tableSpace);
+        planner.clearCache();
         if (uuid != null) {
             metadataStorageManager.updateTableSpaceReplicaState(
                     TableSpaceReplicaState

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -553,12 +553,10 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 if (serverConfiguration.getBoolean(ServerConfiguration.PROPERTY_JMX_ENABLE, ServerConfiguration.PROPERTY_JMX_ENABLE_DEFAULT)) {
                     JMXUtils.registerTableSpaceManagerStatsMXBean(tableSpaceName, manager.getStats());
                 }
-                planner.clearCache();
             } catch (DataStorageManagerException | LogNotAvailableException | MetadataStorageManagerException | DDLException t) {
                 LOGGER.log(Level.SEVERE, "Error Booting tablespace {0} on {1}", new Object[]{tableSpaceName, nodeId});
                 LOGGER.log(Level.SEVERE, "Error", t);
                 tablesSpaces.remove(tableSpaceName);
-                planner.clearCache();
                 try {
                     manager.close();
                 } catch (Throwable t2) {
@@ -1325,7 +1323,6 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
             LOGGER.log(Level.SEVERE, "node " + nodeId + " cannot close for reboot tablespace " + tableSpace, err);
         }
         tablesSpaces.remove(tableSpace);
-        planner.clearCache();
         if (uuid != null) {
             metadataStorageManager.updateTableSpaceReplicaState(
                     TableSpaceReplicaState

--- a/herddb-core/src/main/java/herddb/core/PostCheckpointAction.java
+++ b/herddb-core/src/main/java/herddb/core/PostCheckpointAction.java
@@ -27,17 +27,19 @@ package herddb.core;
  */
 public abstract class PostCheckpointAction implements Runnable {
 
+    public final String tableSpace;
     public final String tableName;
     public final String description;
 
-    public PostCheckpointAction(String tableName, String description) {
+    public PostCheckpointAction(String tableSpace, String tableName, String description) {
+        this.tableSpace = tableSpace;
         this.tableName = tableName;
         this.description = description;
     }
 
     @Override
     public String toString() {
-        return "PostCheckpointAction on " + tableName + ": " + description;
+        return "PostCheckpointAction on " + tableSpace + "." + tableName + ": " + description;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -286,6 +286,17 @@ public class FileDataStorageManager extends DataStorageManager {
         }
     }
 
+    @Override
+    public void initTablespace(String tableSpace) throws DataStorageManagerException {
+        Path tablespaceDir = getTablespaceDirectory(tableSpace);
+        LOGGER.log(Level.FINE, "initTablespace {0} at {1}", new Object[]{tableSpace, tablespaceDir});
+        try {
+            Files.createDirectories(tablespaceDir);
+        } catch (IOException err) {
+            throw new DataStorageManagerException(err);
+        }
+    }
+
 
     @Override
     public List<Record> readPage(String tableSpace, String tableName, Long pageId) throws DataStorageManagerException {

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -660,7 +660,7 @@ public class FileDataStorageManager extends DataStorageManager {
                     && !tableStatus.activePages.containsKey(pageId)
                     && pageId < maxPageId) {
                 LOGGER.log(Level.FINEST, "checkpoint file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted after checkpoint end");
-                result.add(new DeleteFileAction(tableName, "delete page " + pageId + " file " + p.toAbsolutePath(), p));
+                result.add(new DeleteFileAction(tableSpace, tableName, "delete page " + pageId + " file " + p.toAbsolutePath(), p));
             }
         }
 
@@ -670,7 +670,7 @@ public class FileDataStorageManager extends DataStorageManager {
                     TableStatus status = readTableStatusFromFile(p);
                     if (logPosition.after(status.sequenceNumber) && !checkpoints.contains(status.sequenceNumber)) {
                         LOGGER.log(Level.FINEST, "checkpoint metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
-                        result.add(new DeleteFileAction(tableName, "delete checkpoint metadata file " + p.toAbsolutePath(), p));
+                        result.add(new DeleteFileAction(tableSpace, tableName, "delete checkpoint metadata file " + p.toAbsolutePath(), p));
                     }
                 }
             }
@@ -738,7 +738,7 @@ public class FileDataStorageManager extends DataStorageManager {
                     && !indexStatus.activePages.contains(pageId)
                     && pageId < maxPageId) {
                 LOGGER.log(Level.FINEST, "checkpoint file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted after checkpoint end");
-                result.add(new DeleteFileAction(indexName, "delete page " + pageId + " file " + p.toAbsolutePath(), p));
+                result.add(new DeleteFileAction(tableSpace, indexName, "delete page " + pageId + " file " + p.toAbsolutePath(), p));
             }
         }
 
@@ -748,7 +748,7 @@ public class FileDataStorageManager extends DataStorageManager {
                     IndexStatus status = readIndexStatusFromFile(p);
                     if (logPosition.after(status.sequenceNumber) && !checkpoints.contains(status.sequenceNumber)) {
                         LOGGER.log(Level.FINEST, "checkpoint metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
-                        result.add(new DeleteFileAction(indexName, "delete checkpoint metadata file " + p.toAbsolutePath(), p));
+                        result.add(new DeleteFileAction(tableSpace, indexName, "delete checkpoint metadata file " + p.toAbsolutePath(), p));
                     }
                 }
             }
@@ -1220,22 +1220,22 @@ public class FileDataStorageManager extends DataStorageManager {
                             LogSequenceNumber logPositionInFile = readLogSequenceNumberFromIndexMetadataFile(tableSpace, p);
                             if (sequenceNumber.after(logPositionInFile)) {
                                 LOGGER.log(Level.FINEST, "indexes metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
-                                result.add(new DeleteFileAction("indexes", "delete indexesmetadata file " + p.toAbsolutePath(), p));
+                                result.add(new DeleteFileAction(tableSpace, "indexes", "delete indexesmetadata file " + p.toAbsolutePath(), p));
                             }
                         } catch (DataStorageManagerException ignore) {
                             LOGGER.log(Level.SEVERE, "Unparsable indexesmetadata file " + p.toAbsolutePath(), ignore);
-                            result.add(new DeleteFileAction("indexes", "delete unparsable indexesmetadata file " + p.toAbsolutePath(), p));
+                            result.add(new DeleteFileAction(tableSpace, "indexes", "delete unparsable indexesmetadata file " + p.toAbsolutePath(), p));
                         }
                     } else if (isTablespaceTablesMetadataFile(p)) {
                         try {
                             LogSequenceNumber logPositionInFile = readLogSequenceNumberFromTablesMetadataFile(tableSpace, p);
                             if (sequenceNumber.after(logPositionInFile)) {
                                 LOGGER.log(Level.FINEST, "tables metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
-                                result.add(new DeleteFileAction("tables", "delete tablesmetadata file " + p.toAbsolutePath(), p));
+                                result.add(new DeleteFileAction(tableSpace, "tables", "delete tablesmetadata file " + p.toAbsolutePath(), p));
                             }
                         } catch (DataStorageManagerException ignore) {
                             LOGGER.log(Level.SEVERE, "Unparsable tablesmetadata file " + p.toAbsolutePath(), ignore);
-                            result.add(new DeleteFileAction("transactions", "delete unparsable tablesmetadata file " + p.toAbsolutePath(), p));
+                            result.add(new DeleteFileAction(tableSpace, "transactions", "delete unparsable tablesmetadata file " + p.toAbsolutePath(), p));
                         }
                     }
                 }
@@ -1288,7 +1288,7 @@ public class FileDataStorageManager extends DataStorageManager {
                         LogSequenceNumber logPositionInFile = readLogSequenceNumberFromCheckpointInfoFile(tableSpace, p);
                         if (sequenceNumber.after(logPositionInFile)) {
                             LOGGER.log(Level.FINEST, "checkpoint info file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
-                            result.add(new DeleteFileAction("checkpoint", "delete checkpoint info file " + p.toAbsolutePath(), p));
+                            result.add(new DeleteFileAction(tableSpace, "checkpoint", "delete checkpoint info file " + p.toAbsolutePath(), p));
                         }
                     } catch (DataStorageManagerException ignore) {
                         LOGGER.log(Level.SEVERE, "unparsable checkpoint info file " + p.toAbsolutePath(), ignore);
@@ -1529,11 +1529,11 @@ public class FileDataStorageManager extends DataStorageManager {
                         LogSequenceNumber logPositionInFile = readLogSequenceNumberFromTransactionsFile(tableSpace, p);
                         if (sequenceNumber.after(logPositionInFile)) {
                             LOGGER.log(Level.FINEST, "transactions metadata file " + p.toAbsolutePath() + ". will be deleted after checkpoint end");
-                            result.add(new DeleteFileAction("transactions", "delete transactions file " + p.toAbsolutePath(), p));
+                            result.add(new DeleteFileAction(tableSpace, "transactions", "delete transactions file " + p.toAbsolutePath(), p));
                         }
                     } catch (DataStorageManagerException ignore) {
                         LOGGER.log(Level.SEVERE, "Unparsable transactions file " + p.toAbsolutePath(), ignore);
-                        result.add(new DeleteFileAction("transactions", "delete unparsable transactions file " + p.toAbsolutePath(), p));
+                        result.add(new DeleteFileAction(tableSpace, "transactions", "delete unparsable transactions file " + p.toAbsolutePath(), p));
                     }
                 }
             }
@@ -1547,8 +1547,8 @@ public class FileDataStorageManager extends DataStorageManager {
 
         private final Path p;
 
-        public DeleteFileAction(String tableName, String description, Path p) {
-            super(tableName, description);
+        public DeleteFileAction(String tableSpace, String tableName, String description, Path p) {
+            super(tableSpace, tableName, description);
             this.p = p;
         }
 

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -326,7 +326,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
         List<PostCheckpointAction> result = new ArrayList<>();
 
         for (long pageId : pagesForTable) {
-            result.add(new PostCheckpointAction(tableName, "drop page " + pageId) {
+            result.add(new PostCheckpointAction(tableSpace, tableName, "drop page " + pageId) {
                 @Override
                 public void run() {
                     // remove only after checkpoint completed
@@ -348,7 +348,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
                     }
                 }
 
-                result.add(new PostCheckpointAction(tableName, "drop table checkpoint " + oldStatus) {
+                result.add(new PostCheckpointAction(tableSpace, tableName, "drop table checkpoint " + oldStatus) {
                     @Override
                     public void run() {
                         // remove only after checkpoint completed
@@ -395,7 +395,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
         List<PostCheckpointAction> result = new ArrayList<>();
 
         for (long pageId : pagesForIndex) {
-            result.add(new PostCheckpointAction(indexName, "drop page " + pageId) {
+            result.add(new PostCheckpointAction(tableSpace, indexName, "drop page " + pageId) {
                 @Override
                 public void run() {
                     // remove only after checkpoint completed
@@ -416,7 +416,7 @@ public class MemoryDataStorageManager extends DataStorageManager {
                     }
                 }
 
-                result.add(new PostCheckpointAction(indexName, "drop index checkpoint " + oldStatus) {
+                result.add(new PostCheckpointAction(tableSpace, indexName, "drop index checkpoint " + oldStatus) {
                     @Override
                     public void run() {
                         // remove only after checkpoint completed

--- a/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryDataStorageManager.java
@@ -137,6 +137,10 @@ public class MemoryDataStorageManager extends DataStorageManager {
     }
 
     @Override
+    public void initTablespace(String tableSpace) throws DataStorageManagerException {
+    }
+
+    @Override
     public void initIndex(String tableSpace, String indexName) throws DataStorageManagerException {
     }
 

--- a/herddb-core/src/main/java/herddb/model/TableSpace.java
+++ b/herddb-core/src/main/java/herddb/model/TableSpace.java
@@ -41,7 +41,7 @@ public class TableSpace {
 
     public static final String DEFAULT = "herd";
     public static final String ANY_NODE = "*";
-    
+
     public final String uuid;
 
     public final String name;

--- a/herddb-core/src/main/java/herddb/model/TableSpace.java
+++ b/herddb-core/src/main/java/herddb/model/TableSpace.java
@@ -40,7 +40,8 @@ import java.util.UUID;
 public class TableSpace {
 
     public static final String DEFAULT = "herd";
-
+    public static final String ANY_NODE = "*";
+    
     public final String uuid;
 
     public final String name;
@@ -82,7 +83,7 @@ public class TableSpace {
     }
 
     public boolean isNodeAssignedToTableSpace(String nodeId) {
-        return this.replicas.contains(nodeId) || this.replicas.contains("*");
+        return this.replicas.contains(nodeId) || this.replicas.contains(ANY_NODE);
     }
 
     public static Builder builder() {
@@ -209,7 +210,7 @@ public class TableSpace {
             if (leaderId == null || leaderId.isEmpty()) {
                 leaderId = replicas.iterator().next();
             }
-            if (!replicas.contains(leaderId) && !replicas.contains("*")) {
+            if (!replicas.contains(leaderId) && !replicas.contains(ANY_NODE)) {
                 throw new IllegalArgumentException("leader " + leaderId + " must be in replica list " + replicas);
             }
             if (expectedReplicaCount <= 0) {

--- a/herddb-core/src/main/java/herddb/model/TableSpace.java
+++ b/herddb-core/src/main/java/herddb/model/TableSpace.java
@@ -81,6 +81,10 @@ public class TableSpace {
         this.metadataStorageCreationTime = metadataStorageCreationTime;
     }
 
+    public boolean isNodeAssignedToTableSpace(String nodeId) {
+        return this.replicas.contains(nodeId) || this.replicas.contains("*");
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -205,7 +209,7 @@ public class TableSpace {
             if (leaderId == null || leaderId.isEmpty()) {
                 leaderId = replicas.iterator().next();
             }
-            if (!replicas.contains(leaderId)) {
+            if (!replicas.contains(leaderId) && !replicas.contains("*")) {
                 throw new IllegalArgumentException("leader " + leaderId + " must be in replica list " + replicas);
             }
             if (expectedReplicaCount <= 0) {

--- a/herddb-core/src/main/java/herddb/server/Server.java
+++ b/herddb-core/src/main/java/herddb/server/Server.java
@@ -196,10 +196,6 @@ public class Server implements AutoCloseable, ServerSideConnectionAcceptor<Serve
                 realData);
 
         if (nodeId.isEmpty()) {
-            if (ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER.equals(mode)) {
-                throw new RuntimeException("With " + ServerConfiguration.PROPERTY_MODE + "="
-                        + mode + " you must assign " + ServerConfiguration.PROPERTY_NODEID + " explicitly in your server configuration file");
-            }
             LocalNodeIdManager localNodeIdManager = buildLocalNodeIdManager();
             try {
                 nodeId = localNodeIdManager.readLocalNodeId();

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -918,9 +918,6 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             }
             predicate = new SQLRecordPredicate(table, null, where);
             TableSpaceManager tableSpaceManager = manager.getTableSpaceManager(tableSpace);
-            if (tableSpaceManager == null) {
-                throw new StatementExecutionException("tablespace " + tableSpace + " is not ready");
-            }
             IndexOperation op = scanForIndexAccess(where, table, tableSpaceManager);
             predicate.setIndexOperation(op);
             CompiledSQLExpression filterPk = findFiltersOnPrimaryKey(table, where);
@@ -1337,7 +1334,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             }
         }
 
-        if (result == null) {
+        if (result == null && tableSpaceManager != null) {
             Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
             if (indexes != null) {
                 // TODO: use some kind of statistics, maybe using an index is more expensive than a full table scan

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -918,7 +918,9 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             }
             predicate = new SQLRecordPredicate(table, null, where);
             TableSpaceManager tableSpaceManager = manager.getTableSpaceManager(tableSpace);
-
+            if (tableSpaceManager == null) {
+                throw new StatementExecutionException("tablespace " + tableSpace + " is not ready");
+            }
             IndexOperation op = scanForIndexAccess(where, table, tableSpaceManager);
             predicate.setIndexOperation(op);
             CompiledSQLExpression filterPk = findFiltersOnPrimaryKey(table, where);

--- a/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/storage/DataStorageManager.java
@@ -70,6 +70,8 @@ public abstract class DataStorageManager implements AutoCloseable {
     public void tableSpaceMetadataUpdated(String tableSpace, int expectedReplicaCount) {
     }
 
+    public abstract void initTablespace(String tableSpace) throws DataStorageManagerException;
+
     @FunctionalInterface
     public interface DataReader<X> {
 

--- a/herddb-core/src/test/java/herddb/core/TestUtils.java
+++ b/herddb-core/src/test/java/herddb/core/TestUtils.java
@@ -61,9 +61,13 @@ public class TestUtils {
         return execute(manager, query, parameters, TransactionContext.NO_TRANSACTION);
     }
 
-    public static StatementExecutionResult execute(DBManager manager, String query, List<Object> parameters, TransactionContext transactionContext) throws StatementExecutionException {
-        TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, query, parameters, true, true, false, -1);
+    public static StatementExecutionResult execute(DBManager manager, String tableSpace, String query, List<Object> parameters, TransactionContext transactionContext) throws StatementExecutionException {
+        TranslatedQuery translated = manager.getPlanner().translate(tableSpace, query, parameters, true, true, false, -1);
         return manager.executePlan(translated.plan, translated.context, transactionContext);
+    }
+
+    public static StatementExecutionResult execute(DBManager manager, String query, List<Object> parameters, TransactionContext transactionContext) throws StatementExecutionException {
+        return execute(manager, TableSpace.DEFAULT, query, parameters, transactionContext);
     }
 
     public static DataScanner scan(DBManager manager, String query, List<Object> parameters) throws StatementExecutionException {

--- a/herddb-core/src/test/java/herddb/server/DisklessClusterTest.java
+++ b/herddb-core/src/test/java/herddb/server/DisklessClusterTest.java
@@ -64,7 +64,7 @@ public class DisklessClusterTest {
     }
 
     @Test
-    public void testSwitchServerWithoutInitialServerLostAndNoRecoveryFromLog() throws Exception {
+    public void testSwitchServerWithFirstServerLostAndNoRecoveryFromLog() throws Exception {
         ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
         serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
         serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER);
@@ -130,7 +130,7 @@ public class DisklessClusterTest {
     }
 
     @Test
-    public void testSwitchServerAutoMatic() throws Exception {
+    public void testSwitchServerAutomatically() throws Exception {
 
         ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
         serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);


### PR DESCRIPTION
This is a second version of the experimental diskless-cluster mode.

Recap about "diskless cluster mode":
With mode=diskless-cluster we are storing data pages and index pages on BookKeeper instead of the local disk.
In this mode the local disk is used only for tmpDirectory, to swap temporary resulsets (that do not survive to the restart of the server).
In order to store data on BK we created BookKeeperDataStorageManager, and generally this works this way:
- it mimics FiledataStorageManager behaviour
- metadata are stored on ZooKeeper
- real data (and index) pages are saved in BK Ledgers (one page per ledger....this is for the initial implementation, we could improve it in the future, but actually it makes it easy to perform deletion of data)
- the mapping from tablaspace,iddatapage -> idledger is stored on ZooKeeper
- in v1 we stored all of the metadata in znodes children of a znode with name equals to the nodeId of the server, this way each node was independent from the others
- in v1 leader and followers behave like in traditional "cluster" mode, in which followers tail the log and replay "locally" the data, this is not really "locally" because with BookKeeperDataStorageManager we are storing data to Bookies
- for instance in v1 when you have 3 nodes, each node handles datapages independently and this leads to a huge waste of space due the high level of write amplification (please also note that probably you will write to BK with 3/3/3 replication configuration, that is keeping 3 copies of each entry !)


Differences from v1:
- only the leader maintains the data, followers do nothing
- use ZooKeeper "multi" to ensure leadership for every write to data store metadata (mutl is like a 'transaction' in ZK, every operation must succeed in order to complete the whole operation, otherwise the batch does not have visible effects) 
- followers only start the TableSpaceManager and announce themselves on tablespacereplicastate
- allow 'replica:*' in CREATE/ALTER TABLESPACE command in order to allow ANY node to become replica and eventually leader in case of dead leader (you have to set maxleaderinactivitytime explicitly)
- add more test cases

Problems with v1 addressed by this PR:
- if you had 3 replicas with replicationfactor=3 you were going to have 9 copies of datapage !!
- there was no strong guarantee that only one node can write to the datapages
- there were no tests about the running of two "leaders" (the old leader MUST not be able to perform checkpoints or 'store' data to the storage layer) 
- there was no way to say "every node can handle this tablespace"