### PR TITLE
Use replica=* in diskless-cluster mode for default tablespace

### DIFF
--- a/herddb-cli/src/main/java/herddb/cli/HerdDBCLI.java
+++ b/herddb-cli/src/main/java/herddb/cli/HerdDBCLI.java
@@ -432,14 +432,17 @@ public class HerdDBCLI {
         }
     }
 
-    private static boolean checkNodeExistence(
+    private static boolean checkNodeExistenceUsingClusterMetadataStorageManager(
             ZookeeperMetadataStorageManager metadataStorageManager,
-            String nodeId
+            String nodeId, boolean allowStar
     ) throws MetadataStorageManagerException {
+        if (allowStar && TableSpace.ANY_NODE.equals(nodeId)) {
+            return true;
+        }
         return metadataStorageManager.listNodes().stream().anyMatch(n -> n.nodeId.equals(nodeId));
     }
 
-    private static boolean checkNodeExistence(
+    private static boolean checkNodeExistenceUsingQuery(
             boolean verbose, boolean ignoreerrors, Statement statement, TableSpaceMapper tableSpaceMapper,
             String nodeId
     ) throws SQLException, ScriptException {
@@ -454,7 +457,7 @@ public class HerdDBCLI {
             String newschema, String leader
     ) throws SQLException, ScriptException {
 
-        if (!checkNodeExistence(verbose, ignoreerrors, statement, tableSpaceMapper, leader)) {
+        if (!checkNodeExistenceUsingQuery(verbose, ignoreerrors, statement, tableSpaceMapper, leader)) {
             println("Unknown node " + leader);
             exitCode = 1;
             System.exit(exitCode);
@@ -683,7 +686,7 @@ public class HerdDBCLI {
             System.exit(exitCode);
             return;
         }
-        if (!checkNodeExistence(clusterManager, nodeId)) {
+        if (!checkNodeExistenceUsingClusterMetadataStorageManager(clusterManager, nodeId, false)) {
             println("Unknown node " + nodeId);
             exitCode = 1;
             System.exit(exitCode);
@@ -722,7 +725,7 @@ public class HerdDBCLI {
             exitCode = 1;
             System.exit(exitCode);
         }
-        if (!checkNodeExistence(clusterManager, nodeId)) {
+        if (!checkNodeExistenceUsingClusterMetadataStorageManager(clusterManager, nodeId, true)) {
             println("Unknown node " + nodeId);
             exitCode = 1;
             System.exit(exitCode);

--- a/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/ZookeeperMetadataStorageManager.java
@@ -324,15 +324,17 @@ public class ZookeeperMetadataStorageManager extends MetadataStorageManager {
     }
 
     @Override
-    public void ensureDefaultTableSpace(String localNodeId) throws MetadataStorageManagerException {
+    public void ensureDefaultTableSpace(String localNodeId,
+                                        String initialReplicaList,
+                                        long maxLeaderInactivityTime) throws MetadataStorageManagerException {
         try {
             TableSpaceList list = listTablesSpaces();
             if (!list.tableSpaces.contains(TableSpace.DEFAULT)) {
                 TableSpace tableSpace = TableSpace.builder()
                         .leader(localNodeId)
-                        .replica(localNodeId)
+                        .replica(initialReplicaList)
                         .expectedReplicaCount(1)
-                        .maxLeaderInactivityTime(0)
+                        .maxLeaderInactivityTime(maxLeaderInactivityTime)
                         .name(TableSpace.DEFAULT)
                         .build();
                 createTableSpaceNode(tableSpace);

--- a/herddb-core/src/main/java/herddb/file/FileMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileMetadataStorageManager.java
@@ -274,7 +274,9 @@ public class FileMetadataStorageManager extends MetadataStorageManager {
     }
 
     @Override
-    public void ensureDefaultTableSpace(String localNodeId) throws MetadataStorageManagerException {
+    public void ensureDefaultTableSpace(String localNodeId,
+                                        String initialReplicaList,
+                                        long maxLeaderInactivityTime) throws MetadataStorageManagerException {
         lock.writeLock().lock();
         try {
             TableSpace exists = tableSpaces.get(TableSpace.DEFAULT);

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -142,7 +142,7 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
             recordInserted(key, indexKey);
         });
         long _stop = System.currentTimeMillis();
-        LOGGER.log(Level.INFO, "building index {0} took {1]", new Object[]{index.name, (_stop - _start) + " ms"});
+        LOGGER.log(Level.INFO, "building index {0} took {1}", new Object[]{index.name, (_stop - _start) + " ms"});
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/mem/MemoryMetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/mem/MemoryMetadataStorageManager.java
@@ -152,7 +152,9 @@ public class MemoryMetadataStorageManager extends MetadataStorageManager {
     }
 
     @Override
-    public void ensureDefaultTableSpace(String localNodeId) throws MetadataStorageManagerException {
+    public void ensureDefaultTableSpace(String localNodeId,
+                                        String initialReplicaList,
+                                        long maxLeaderInactivityTime) throws MetadataStorageManagerException {
         lock.writeLock().lock();
         try {
             TableSpace exists = tableSpaces.get(TableSpace.DEFAULT);

--- a/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/metadata/MetadataStorageManager.java
@@ -41,7 +41,7 @@ public abstract class MetadataStorageManager implements AutoCloseable {
 
     public abstract void start() throws MetadataStorageManagerException;
 
-    public abstract void ensureDefaultTableSpace(String localNodeId) throws MetadataStorageManagerException;
+    public abstract void ensureDefaultTableSpace(String localNodeId, String initialReplicaList, long maxLeaderInactivityTime) throws MetadataStorageManagerException;
 
     public abstract void close() throws MetadataStorageManagerException;
 


### PR DESCRIPTION
Changes:
- Use replica=* in diskless-cluster mode for default tablespace
- Set maxLeaderInactivityTime = 1 minute by default (in diskless-cluster mode
- Fix a bug on the cli, the user was not able to set replica=*

This way when you work in diskless-cluster mode by default the database will be available until you have your ZK+BK cluster up and running, with a maximum downtime of 1 minute (the user can change maxLeaderInactivityTime to any value)

Switching leadership in diskless cluster mode is far less expensive than in pure cluster mode because there is no movement of data.
