### PR TITLE
Miscellaneous fixes about SQL compatibility

### DIFF
--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -568,6 +568,10 @@ public final class RecordSerializer {
                 break;
             case ColumnTypes.TIMESTAMP:
             case ColumnTypes.NOTNULL_TIMESTAMP:
+                if (v instanceof Long) {
+                    //  INSERT INTO TT values"(1, {ts '2012-12-13 10:34:33.15'}, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 0, 0, 0, 0, 0, 0)",
+                    v = new java.sql.Timestamp((Long) v);
+                }
                 if (!(v instanceof java.sql.Timestamp)) {
                     throw new IllegalArgumentException("bad value type for column " + type + ": required java.sql.Timestamp, but was " + v.getClass() + ", toString of value is " + v);
                 }

--- a/herddb-core/src/main/java/herddb/model/planner/NestedLoopJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/NestedLoopJoinOp.java
@@ -167,5 +167,12 @@ public class NestedLoopJoinOp implements PlannerOp {
                 + "\n, condition=" + condition + '}';
     }
 
+    public PlannerOp getLeft() {
+        return left;
+    }
+
+    public PlannerOp getRight() {
+        return right;
+    }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -81,7 +81,8 @@ public class ProjectOp implements PlannerOp {
 
         @Override
         public String toString() {
-            return "BasicProjection{" + "columns=" + columns + ", fieldNames=" + fieldNames + ", fields=" + fields + '}';
+            return "BasicProjection{" + "columns=" + Arrays.toString(columns)
+                    + ", fieldNames=" + Arrays.toString(fieldNames) + ", fields=" + fields + '}';
         }
 
         @Override

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -80,6 +80,11 @@ public class ProjectOp implements PlannerOp {
         }
 
         @Override
+        public String toString() {
+            return "BasicProjection{" + "columns=" + columns + ", fieldNames=" + fieldNames + ", fields=" + fields + '}';
+        }
+
+        @Override
         public DataAccessor map(DataAccessor tuple, StatementEvaluationContext context) throws StatementExecutionException {
             return new RuntimeProjectedDataAccessor(tuple, context);
         }

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleScanOp.java
@@ -73,7 +73,7 @@ public abstract class SimpleScanOp implements PlannerOp {
             StatementEvaluationContext context, boolean lockRequired, boolean forWrite
     ) throws StatementExecutionException {
         DataScanner scan = tableSpaceManager.scan(statement, context, transactionContext, lockRequired, forWrite);
-        return new ScanResult(transactionContext.transactionId, scan);
+        return new ScanResult(scan.getTransactionId(), scan);
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordFunction.java
@@ -21,6 +21,7 @@
 package herddb.sql;
 
 import herddb.codec.RecordSerializer;
+import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.RecordFunction;
 import herddb.model.StatementEvaluationContext;
@@ -80,7 +81,11 @@ public class SQLRecordFunction extends RecordFunction {
                         if (column == null) {
                             throw new StatementExecutionException("unknown column " + columnName + " in table " + table.name);
                         }
-                        return RecordSerializer.convert(column.type, e.evaluate(bean, context));
+                        try {
+                            return RecordSerializer.convert(column.type, e.evaluate(bean, context));
+                        } catch (StatementExecutionException err) {
+                            throw new StatementExecutionException("error on column " + column.name + " (" + ColumnTypes.typeToString(column.type) + "):" + err.getMessage(), err);
+                        }
                     }
                 };
                 return RecordSerializer.buildRecord(previous.value != null ? previous.value.getLength() : 0, table, fieldValueComputer);
@@ -94,7 +99,11 @@ public class SQLRecordFunction extends RecordFunction {
                         if (column == null) {
                             throw new StatementExecutionException("unknown column " + columnName + " in table " + table.name);
                         }
-                        return RecordSerializer.convert(column.type, e.evaluate(DataAccessor.NULL, context));
+                        try {
+                            return RecordSerializer.convert(column.type, e.evaluate(DataAccessor.NULL, context));
+                        } catch (StatementExecutionException err) {
+                            throw new StatementExecutionException("error on column " + column.name + " (" + ColumnTypes.typeToString(column.type) + "):" + err.getMessage(), err);
+                        }
                     }
                 };
                 return RecordSerializer.buildRecord(0, table, fieldValueComputer);

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
@@ -23,6 +23,7 @@ package herddb.sql;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.codec.RecordSerializer;
 import herddb.model.Column;
+import herddb.model.ColumnTypes;
 import herddb.model.ColumnsList;
 import herddb.model.InvalidNullValueForKeyException;
 import herddb.model.Record;
@@ -106,7 +107,11 @@ public class SQLRecordKeyFunction extends RecordFunction {
             if (value == null) {
                 throw new InvalidNullValueForKeyException("error while converting primary key " + pk + ", keys cannot be null");
             }
-            value = RecordSerializer.convert(c.type, value);
+            try {
+                value = RecordSerializer.convert(c.type, value);
+            } catch (StatementExecutionException err) {
+                throw new StatementExecutionException("error on column " + c.name + " (" + ColumnTypes.typeToString(c.type) + "):" + err.getMessage(), err);
+            }
             pk.put(c.name, value);
         }
         try {

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
@@ -35,6 +35,8 @@ import herddb.utils.DataAccessor;
 import herddb.utils.RawString;
 import herddb.utils.SQLRecordPredicateFunctions;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 import java.util.logging.Logger;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.JdbcParameter;
@@ -175,7 +177,7 @@ public class SQLRecordPredicate extends Predicate implements TuplePredicate {
                         return value.toString();
                     }
                     if (value instanceof Timestamp) {
-                        // convert to something like '1970-01-01 01:00:00.0'
+                        // convert to something like '1970-01-01 01:00:00.0' in TimeZone.getDefault().getID() timezone
                         return value.toString();
                     }
                     throw new IllegalArgumentException("Value " + value + " (" + value.getClass() + ") cannot be converted to a STRING");

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
@@ -34,6 +34,7 @@ import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
 import herddb.utils.RawString;
 import herddb.utils.SQLRecordPredicateFunctions;
+import java.sql.Timestamp;
 import java.util.logging.Logger;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.JdbcParameter;
@@ -171,6 +172,10 @@ public class SQLRecordPredicate extends Predicate implements TuplePredicate {
                     }
                     if (value instanceof Number
                             || value instanceof Boolean) {
+                        return value.toString();
+                    }
+                    if (value instanceof Timestamp) {
+                        // convert to something like '1970-01-01 01:00:00.0'
                         return value.toString();
                     }
                     throw new IllegalArgumentException("Value " + value + " (" + value.getClass() + ") cannot be converted to a STRING");

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
@@ -35,8 +35,6 @@ import herddb.utils.DataAccessor;
 import herddb.utils.RawString;
 import herddb.utils.SQLRecordPredicateFunctions;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
 import java.util.logging.Logger;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.JdbcParameter;

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
@@ -210,7 +210,6 @@ public class SQLRecordPredicate extends Predicate implements TuplePredicate {
                     if (value instanceof String) {
                         return Long.parseLong(((String) value));
                     }
-                    new Exception("type " + value.getClass() + " (value  " + value + ") cannot be cast to LONG").printStackTrace();
                     throw new IllegalArgumentException("type " + value.getClass() + " (value  " + value + ") cannot be cast to LONG");
                 }
                 case ColumnTypes.DOUBLE:

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordPredicate.java
@@ -205,6 +205,7 @@ public class SQLRecordPredicate extends Predicate implements TuplePredicate {
                     if (value instanceof String) {
                         return Long.parseLong(((String) value));
                     }
+                    new Exception("type " + value.getClass() + " (value  " + value + ") cannot be cast to LONG").printStackTrace();
                     throw new IllegalArgumentException("type " + value.getClass() + " (value  " + value + ") cannot be cast to LONG");
                 }
                 case ColumnTypes.DOUBLE:

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledFunction.java
@@ -166,4 +166,13 @@ public class CompiledFunction implements CompiledSQLExpression {
         }
     }
 
+    @Override
+    public String toString() {
+        if (roundMultiplier > 0) {
+            return "CompiledFunction{" + "name=" + name + ", parameters=" + parameters + ", roundMultiplier=" + roundMultiplier + ", roundSign=" + roundSign + '}';
+        } else {
+            return "CompiledFunction{" + "name=" + name + ", parameters=" + parameters + '}';
+        }
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledFunction.java
@@ -27,6 +27,7 @@ import herddb.utils.DataAccessor;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.calcite.avatica.util.TimeUnitRange;
 
 public class CompiledFunction implements CompiledSQLExpression {
@@ -93,6 +94,8 @@ public class CompiledFunction implements CompiledSQLExpression {
             }
             case BuiltinFunctions.CURRENT_TIMESTAMP:
                 return context.getCurrentTimestamp();
+            case BuiltinFunctions.RAND:
+                return ThreadLocalRandom.current().nextInt();
             case BuiltinFunctions.ROUND: {
                 Object parValue = parameters.get(0).evaluate(bean, context);
                 if (roundSign == 0) {

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledModuloExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledModuloExpression.java
@@ -1,0 +1,40 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql.expressions;
+
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.utils.SQLRecordPredicateFunctions;
+
+public class CompiledModuloExpression extends CompiledBinarySQLExpression {
+
+    public CompiledModuloExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
+        super(left, right);
+    }
+
+    @Override
+    public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
+        Object leftValue = left.evaluate(bean, context);
+        Object rightValue = right.evaluate(bean, context);
+        return SQLRecordPredicateFunctions.modulo(leftValue, rightValue);
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
@@ -90,6 +90,8 @@ public class SQLExpressionCompiler {
                     return new CompiledMinorThenEqualsExpression(operands[0], operands[1]);
                 case "+":
                     return new CompiledAddExpression(operands[0], operands[1]);
+                case "MOD":
+                    return new CompiledModuloExpression(operands[0], operands[1]);
                 case "-":
                     if (operands.length == 1) {
                         return new CompiledSignedExpression('-', operands[0]);

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
@@ -106,7 +106,12 @@ public class SQLExpressionCompiler {
                 case "/INT":
                     return new CompiledDivideIntExpression(operands[0], operands[1]);
                 case "LIKE":
-                    return new CompiledLikeExpression(operands[0], operands[1]);
+                    if (operands.length == 2) {
+                        return new CompiledLikeExpression(operands[0], operands[1]);
+                    } else{
+                        // ESCAPE
+                        return new CompiledLikeExpression(operands[0], operands[1], operands[2]);
+                    }
                 case "AND":
                     return new CompiledMultiAndExpression(operands);
                 case "OR":

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
@@ -108,7 +108,7 @@ public class SQLExpressionCompiler {
                 case "LIKE":
                     if (operands.length == 2) {
                         return new CompiledLikeExpression(operands[0], operands[1]);
-                    } else{
+                    } else {
                         // ESCAPE
                         return new CompiledLikeExpression(operands[0], operands[1], operands[2]);
                     }

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
@@ -149,6 +149,8 @@ public class SQLExpressionCompiler {
                     return new CompiledFunction(BuiltinFunctions.EXTRACT, Arrays.asList(operands));
                 case BuiltinFunctions.NAME_FLOOR:
                     return new CompiledFunction(BuiltinFunctions.FLOOR, Arrays.asList(operands));
+                case BuiltinFunctions.NAME_RAND:
+                    return new CompiledFunction(BuiltinFunctions.RAND, Arrays.asList(operands));
                 case BuiltinFunctions.NAME_REINTERPRET:
                     if (operands.length != 1) {
                         throw new StatementExecutionException("unsupported use of Reinterpret with " + Arrays.toString(operands));

--- a/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
@@ -20,13 +20,10 @@
 
 package herddb.sql.functions;
 
-import herddb.model.Column;
-import herddb.model.ColumnTypes;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.sql.AggregatedColumnCalculator;
 import herddb.sql.expressions.CompiledSQLExpression;
-import net.sf.jsqlparser.expression.Function;
 import org.apache.calcite.sql.fun.SqlSingleValueAggFunction;
 import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 
@@ -57,6 +54,7 @@ public class BuiltinFunctions {
     public static final String ROUND = "round";
     public static final String EXTRACT = "extract";
     public static final String FLOOR = "floor";
+    public static final String RAND = "rand";
 
     // special
     public static final String CURRENT_TIMESTAMP = "current_timestamp";
@@ -75,26 +73,11 @@ public class BuiltinFunctions {
     public static final String NAME_ROUND = "ROUND";
     public static final String NAME_EXTRACT = "EXTRACT";
     public static final String NAME_FLOOR = "FLOOR";
+    public static final String NAME_RAND = "RAND";
 
     public static final String NAME_REINTERPRET = "Reinterpret";
     // special
     public static final String NAME_CURRENT_TIMESTAMP = "CURRENT_TIMESTAMP";
-
-    public static Column toAggregatedOutputColumn(String fieldName, Function f) {
-        if (f.getName().equalsIgnoreCase(BuiltinFunctions.COUNT)) {
-            return Column.column(fieldName, ColumnTypes.LONG);
-        }
-        if (f.getName().equalsIgnoreCase(BuiltinFunctions.SUM) && f.getParameters() != null && f.getParameters().getExpressions() != null && f.getParameters().getExpressions().size() == 1) {
-            return Column.column(fieldName, ColumnTypes.LONG);
-        }
-        if (f.getName().equalsIgnoreCase(BuiltinFunctions.MIN) && f.getParameters() != null && f.getParameters().getExpressions() != null && f.getParameters().getExpressions().size() == 1) {
-            return Column.column(fieldName, ColumnTypes.LONG);
-        }
-        if (f.getName().equalsIgnoreCase(BuiltinFunctions.MAX) && f.getParameters() != null && f.getParameters().getExpressions() != null && f.getParameters().getExpressions().size() == 1) {
-            return Column.column(fieldName, ColumnTypes.LONG);
-        }
-        return null;
-    }
 
     public static AggregatedColumnCalculator getColumnCalculator(
             String functionName, String fieldName,

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -943,7 +943,6 @@ public class RawSQLTest {
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,d1 timestamp)", Collections.emptyList());
 
             java.sql.Timestamp now = new java.sql.Timestamp(System.currentTimeMillis());
-            java.sql.Timestamp nowPlusOneDayInMillis = new java.sql.Timestamp(now.getTime() + 1000 * 60 * 60 * 24);
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,d1) values(?,?)", Arrays.asList("mykey", now)).getUpdateCount());
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,d1) values(?,?)", Arrays.asList("mykey2", now)).getUpdateCount());
 

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -73,11 +73,14 @@ import herddb.utils.DataAccessor;
 import herddb.utils.MapUtils;
 import herddb.utils.RawString;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -822,6 +825,29 @@ public class RawSQLTest {
             assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql values(?,?,?)", Arrays.asList("mykey2", Integer.valueOf(1234), "value")).getUpdateCount());
 
             assertEquals(2, scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList()).consumeAndClose().size());
+
+            execute(manager, "ALTER TABLE tblspace1.tsql add (t1 timestamp)", Collections.emptyList());
+            assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql values('mykey3',1,'c','1970-01-01 01:00:00.0')", Collections.emptyList()).getUpdateCount());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.tsql where t1='1970-01-01 01:00:00.0'", Collections.emptyList()).consumeAndClose().size());
+
+            // cast timestamp to string
+            SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date timestamp = fmt.parse("1970-01-01 01:00:00.0");
+            fmt.setTimeZone(TimeZone.getDefault());
+            String formattedInLocalServerTime = fmt.format(timestamp);
+
+            // literals are expressed in UTC
+            try (DataScanner scanner = scan(manager, "SELECT cast(t1 as varchar) as ss FROM tblspace1.tsql where t1='1970-01-01 01:00:00.0'", Collections.emptyList())) {
+                int count = 0;
+                for (DataAccessor da : scanner.consume()) {
+                    // the CAST operation is actually executed when we call "get(0)", not during query execution
+                    // this is really cool, we are not spending CPU during query execution, but only when needed
+                    assertEquals(formattedInLocalServerTime, da.get(0));
+                    count++;
+                }
+                assertEquals(1, count);
+            }
 
         }
     }
@@ -1576,7 +1602,7 @@ public class RawSQLTest {
                 assertEquals(Long.valueOf(4), result.get(0).get(0));
                 assertEquals(Long.valueOf(4), result.get(0).get("cc"));
             }
-            
+
             // test "modulo" operator
             try (DataScanner scan1 = scan(manager, "SELECT n1 % 4 as cc FROM tblspace1.tsql where n1 % 4 = 1 and k1='mykey3'", Collections.emptyList())) {
                 List<DataAccessor> result = scan1.consume();

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -1576,6 +1576,14 @@ public class RawSQLTest {
                 assertEquals(Long.valueOf(4), result.get(0).get(0));
                 assertEquals(Long.valueOf(4), result.get(0).get("cc"));
             }
+            
+            // test "modulo" operator
+            try (DataScanner scan1 = scan(manager, "SELECT n1 % 4 as cc FROM tblspace1.tsql where n1 % 4 = 1 and k1='mykey3'", Collections.emptyList())) {
+                List<DataAccessor> result = scan1.consume();
+                assertEquals(1, result.size());
+                assertEquals(Long.valueOf(1), result.get(0).get(0));
+                assertEquals(Long.valueOf(1), result.get(0).get("cc"));
+            }
 
 
         }

--- a/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
@@ -72,7 +72,7 @@ public class SimpleJoinTest {
 
             execute(manager, "CREATE TABLE tblspace1.table1 (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
             execute(manager, "CREATE TABLE tblspace1.table2 (k2 string primary key,n2 int,s2 string)", Collections.emptyList());
-     
+
             execute(manager, "INSERT INTO tblspace1.table1 (k1,n1,s1) values('a',1,'A')", Collections.emptyList());
             execute(manager, "INSERT INTO tblspace1.table1 (k1,n1,s1) values('b',2,'B')", Collections.emptyList());
             execute(manager, "INSERT INTO tblspace1.table2 (k2,n2,s2) values('c',3,'A')", Collections.emptyList());
@@ -89,8 +89,8 @@ public class SimpleJoinTest {
                 assertThat(join.getLeft(), instanceOf(SimpleScanOp.class));
                 assertThat(join.getRight(), instanceOf(SimpleScanOp.class));
                 // we want that the left branch of the join starts the transactoion
-                ScanResult scanResult = ((ScanResult) manager.executePlan(translated.plan, translated.context, TransactionContext.AUTOTRANSACTION_TRANSACTION));                        
-                List<DataAccessor> tuples = scanResult.dataScanner.consumeAndClose(); 
+                ScanResult scanResult = ((ScanResult) manager.executePlan(translated.plan, translated.context, TransactionContext.AUTOTRANSACTION_TRANSACTION));
+                List<DataAccessor> tuples = scanResult.dataScanner.consumeAndClose();
                 assertTrue(scanResult.transactionId > 0);
                 for (DataAccessor t : tuples) {
                     System.out.println("t:" + t);

--- a/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
@@ -286,6 +286,9 @@ public class SimpleOperatorsTest {
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE '%AbBbCc%'", Collections.emptyList())) {
                 assertEquals(1, scan1.consume().size());
             }
+            try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' ILIKE '%AbBbCc%'", Collections.emptyList())) {
+                assertEquals(1, scan1.consume().size());
+            }
 
 
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE ?", Arrays.asList("%AbBbCc%"))) {

--- a/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleOperatorsTest.java
@@ -286,11 +286,16 @@ public class SimpleOperatorsTest {
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE '%AbBbCc%'", Collections.emptyList())) {
                 assertEquals(1, scan1.consume().size());
             }
-            try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' ILIKE '%AbBbCc%'", Collections.emptyList())) {
+            try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBb_c' LIKE '%AbBb+_c%' ESCAPE '+'", Collections.emptyList())) {
                 assertEquals(1, scan1.consume().size());
             }
-
-
+            // default ESCAPE char is '\'
+            try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBb_c' LIKE '%AbBb\\_c%'", Collections.emptyList())) {
+                assertEquals(1, scan1.consume().size());
+            }
+            try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbdc' LIKE '%AbBb\\_c%'", Collections.emptyList())) {
+                assertEquals(0, scan1.consume().size());
+            }
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql WHERE 'AbBbCc' LIKE ?", Arrays.asList("%AbBbCc%"))) {
                 assertEquals(1, scan1.consume().size());
             }

--- a/herddb-core/src/test/java/herddb/core/UpdateTest.java
+++ b/herddb-core/src/test/java/herddb/core/UpdateTest.java
@@ -173,7 +173,7 @@ public class UpdateTest {
                                 "UPDATE tblspace1.tsql set n1 = null WHERE n1=1",
                                 Collections.emptyList(), ctx);
                     });
-            assertEquals("Cannot have null value in non null type integer", error.getMessage());
+            assertEquals("error on column n1 (integer not null):Cannot have null value in non null type integer", error.getMessage());
 
             // multi record failed update
             StatementExecutionException errors =
@@ -182,7 +182,7 @@ public class UpdateTest {
                                 "UPDATE tblspace1.tsql set n1 = null",
                                 Collections.emptyList(), ctx);
                     });
-            assertEquals("Cannot have null value in non null type integer", errors.getMessage());
+            assertEquals("error on column n1 (integer not null):Cannot have null value in non null type integer", errors.getMessage());
 
             commitTransaction(manager, "tblspace1", tx);
 

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -145,7 +145,7 @@ public interface SQLRecordPredicateFunctions {
 
         throw new IllegalArgumentException("cannot add " + a + " and " + b);
     }
-    
+
     static Object modulo(Object a, Object b) throws IllegalArgumentException {
         if (a == null && b == null) {
             return null;
@@ -290,7 +290,7 @@ public interface SQLRecordPredicateFunctions {
         return !objectEquals(a, b);
     }
 
-    static Pattern compileLikePattern(String b) throws HerdDBInternalException {
+    static Pattern compileLikePattern(String b, char escapeChar) throws HerdDBInternalException {
 
         /*
          * We presume that in string there will be 1 or 2 '%' or '_' characters. To avoid multiple array
@@ -303,8 +303,16 @@ public interface SQLRecordPredicateFunctions {
         builder.append("\\Q");
 
         int limit = b.length();
+        boolean escaping = false;
         for (int idx = 0; idx < limit; ++idx) {
             char ch = b.charAt(idx);
+            if (ch == escapeChar) {
+                escaping = true;
+            } else {
+                if (escaping) {
+                    builder.append(ch);
+                    escaping = false;
+                } else {
             switch (ch) {
                 case '%':
                     builder.append("\\E.*\\Q");
@@ -315,6 +323,8 @@ public interface SQLRecordPredicateFunctions {
                 default:
                     builder.append(ch);
                     break;
+            }
+                }
             }
         }
 
@@ -328,11 +338,11 @@ public interface SQLRecordPredicateFunctions {
         }
     }
 
-    static boolean like(Object a, Object b) {
+    static boolean like(Object a, Object b, char escape) {
         if (a == null || b == null) {
             return false;
         }
-        Pattern pattern = compileLikePattern(b.toString());
+        Pattern pattern = compileLikePattern(b.toString(), escape);
         return matches(a, pattern);
     }
 

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -145,6 +145,39 @@ public interface SQLRecordPredicateFunctions {
 
         throw new IllegalArgumentException("cannot add " + a + " and " + b);
     }
+    
+    static Object modulo(Object a, Object b) throws IllegalArgumentException {
+        if (a == null && b == null) {
+            return null;
+        }
+        if (a == null) {
+            a = 0;
+        }
+        if (b == null) {
+            b = 0;
+        }
+        if (a instanceof Long && b instanceof Long) {
+            return (Long) a % (Long) b;
+        }
+        if (a instanceof Integer && b instanceof Integer) {
+            return (long) ((Integer) a % (Integer) b);
+        }
+        if (a instanceof Integer && b instanceof Long) {
+            return ((Integer) a % (Long) b);
+        }
+        if (a instanceof Long && b instanceof Integer) {
+            return ((Long) a % (Integer) b);
+        }
+        if (a instanceof Number && b instanceof Number) {
+            return ((Number) a).doubleValue() % ((Number) b).doubleValue();
+        }
+        if (a instanceof java.sql.Timestamp && b instanceof Long) {
+            // TIMESTAMPADD
+            return new java.sql.Timestamp(((java.sql.Timestamp) a).getTime() % ((Long) b));
+        }
+
+        throw new IllegalArgumentException("cannot perform modulo on " + a + " and " + b);
+    }
 
     static Object subtract(Object a, Object b) throws IllegalArgumentException {
         if (a == null && b == null) {

--- a/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
+++ b/herddb-utils/src/test/java/herddb/utils/SQLRecordPredicateFunctionsTest.java
@@ -33,47 +33,47 @@ public class SQLRecordPredicateFunctionsTest {
 
     @Test
     public void testCompareAndLike() throws Exception {
-        assertTrue(SQLRecordPredicateFunctions.like("test", "test"));
-        assertFalse(SQLRecordPredicateFunctions.like("test", "est"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "test", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "est", '\\'));
 
 
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%%"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "____"));
-        assertFalse(SQLRecordPredicateFunctions.like("test", "___"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "_%"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%_"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "_%_"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%_%"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "____", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "___", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "_%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%_", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "_%_", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%_%", '\\'));
 
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%est"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "test%"));
-        assertFalse(SQLRecordPredicateFunctions.like("test", "a%"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%test%"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "%es%"));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%est", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "test%", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "a%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%test%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "%es%", '\\'));
 
-        assertFalse(SQLRecordPredicateFunctions.like("tesst", "te_t"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "te_t"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "_est"));
-        assertTrue(SQLRecordPredicateFunctions.like("test", "tes_"));
-        assertFalse(SQLRecordPredicateFunctions.like("test", "tes__"));
-        assertFalse(SQLRecordPredicateFunctions.like("test", "__est"));
+        assertFalse(SQLRecordPredicateFunctions.like("tesst", "te_t", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "te_t", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "_est", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("test", "tes_", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "tes__", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("test", "__est", '\\'));
 
-        assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "%(foo)%"));
-        assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "%(fo"));
-        assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "oo)%"));
-        assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo]%"));
-        assertFalse(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo"));
-        assertFalse(SQLRecordPredicateFunctions.like("bar [foo]", "foo]%"));
-        assertTrue(SQLRecordPredicateFunctions.like("bar+foo", "%+%"));
+        assertTrue(SQLRecordPredicateFunctions.like("bar (foo)", "%(foo)%", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "%(fo", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("bar (foo)", "oo)%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo]%", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("bar [foo]", "%[foo", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("bar [foo]", "foo]%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("bar+foo", "%+%", '\\'));
 
-        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "a%"));
-        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "%b"));
-        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "%"));
-        assertFalse(SQLRecordPredicateFunctions.like("ax\nb", "x%"));
-        assertFalse(SQLRecordPredicateFunctions.like("a\nxb", "x%"));
-        assertFalse(SQLRecordPredicateFunctions.like("ax\nb", "%x"));
-        assertFalse(SQLRecordPredicateFunctions.like("a\nxb", "%x"));
+        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "a%", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "%b", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("a\nb", "%", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("ax\nb", "x%", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("a\nxb", "x%", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("ax\nb", "%x", '\\'));
+        assertFalse(SQLRecordPredicateFunctions.like("a\nxb", "%x", '\\'));
 
         assertTrue(SQLRecordPredicateFunctions.compare(1, 2) < 0);
         assertTrue(SQLRecordPredicateFunctions.compare(1, 1) == 0);
@@ -92,6 +92,10 @@ public class SQLRecordPredicateFunctionsTest {
         assertTrue(SQLRecordPredicateFunctions.compare(RawString.of("a"), "a") == 0);
         assertTrue(SQLRecordPredicateFunctions.compare(RawString.of("a"), "b") < 0);
         assertTrue(SQLRecordPredicateFunctions.compare(RawString.of("c"), "a") > 0);
+
+        assertTrue(SQLRecordPredicateFunctions.like("te_st", "te\\_st", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("teast", "te_st", '\\'));
+        assertTrue(SQLRecordPredicateFunctions.like("teaaast", "te%st", '\\'));
 
     }
 


### PR DESCRIPTION
This is a draft Pull Request with a bunch of fixes regarding bug fixes and new needed little features discovered while testing MagNews with HerdDB
- fix autotransaction leak during Join (fix on SimpleScanOp)
- support "Modulo" operator
- support cast between Timestamp and String
-support JDBC {ts 'xxx'} sintax
- fix resultset and transaction leak in case of error during mashalling of resultsets
- send better errors in case of serialization/cast errors
- support LIKE 'escape' clause