### PR TITLE
Implement correct comparisons with NULLs and fix SEMIJOINs

### DIFF
--- a/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
+++ b/herddb-core/src/main/java/herddb/codec/DataAccessorForFullRecord.java
@@ -28,6 +28,8 @@ import herddb.utils.AbstractDataAccessor;
 import herddb.utils.ByteArrayCursor;
 import herddb.utils.Bytes;
 import herddb.utils.RawString;
+import herddb.utils.SQLRecordPredicateFunctions;
+import herddb.utils.SQLRecordPredicateFunctions.CompareResult;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -72,18 +74,20 @@ public class DataAccessorForFullRecord extends AbstractDataAccessor {
     @Override
     public boolean fieldEqualsTo(int index, Object value) {
         try {
+            SQLRecordPredicateFunctions.CompareResult res;
             if (table.isPrimaryKeyColumn(index)) {
-                return RecordSerializer.compareRawDataFromPrimaryKey(index, record.key, table, value) == 0;
+                res = RecordSerializer.compareRawDataFromPrimaryKey(index, record.key, table, value);
             } else {
-                return RecordSerializer.compareRawDataFromValue(index, record.value, table, value) == 0;
+                res = RecordSerializer.compareRawDataFromValue(index, record.value, table, value);
             }
+            return res == CompareResult.EQUALS;
         } catch (IOException err) {
             throw new IllegalStateException("bad data:" + err, err);
         }
     }
 
     @Override
-    public int fieldCompareTo(int index, Object value) {
+    public SQLRecordPredicateFunctions.CompareResult fieldCompareTo(int index, Object value) {
         try {
             if (table.isPrimaryKeyColumn(index)) {
                 return RecordSerializer.compareRawDataFromPrimaryKey(index, record.key, table, value);

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1362,8 +1362,14 @@ public class TableSpaceManager {
         }
 
         SQLPlannedOperationStatement planned = (SQLPlannedOperationStatement) statement;
-        CompletableFuture<StatementExecutionResult> res =
-                planned.getRootOp().executeAsync(this, transactionContext, context, false, false);
+        CompletableFuture<StatementExecutionResult> res;
+        try {
+            res = planned.getRootOp().executeAsync(this, transactionContext, context, false, false);
+        } catch (HerdDBInternalException err) {
+            // ensure we are able to release locks correctly
+            LOGGER.log(Level.SEVERE, "Internal error", err);
+            res = Futures.exception(err);
+        }
 //        res.whenComplete((ee, err) -> {
 //            LOGGER.log(Level.SEVERE, "COMPLETED " + statement + ": " + ee, err);
 //        });

--- a/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
@@ -192,7 +192,10 @@ public class JoinOp implements PlannerOp {
 
     @Override
     public String toString() {
-        return "JoinOp{" + "leftKeys=" + Arrays.toString(leftKeys) + ", left=" + left + ", rightKeys=" + Arrays.toString(rightKeys) + ", right=" + right + ", fieldNames=" + Arrays.toString(fieldNames) + ", columns=" + Arrays.toString(columns) + ", generateNullsOnLeft=" + generateNullsOnLeft + ", generateNullsOnRight=" + generateNullsOnRight + ", mergeJoin=" + mergeJoin + '}';
+        return "JoinOp{fieldNames=" + Arrays.toString(fieldNames) + ", columns=" + Arrays.toString(columns) + ","
+                + "\ngenerateNullsOnLeft=" + generateNullsOnLeft + ", generateNullsOnRight=" + generateNullsOnRight + ", mergeJoin=" + mergeJoin + ","
+                + "\nleftKeys=" + Arrays.toString(leftKeys) + ",left=" + left + ","
+                + "\nrightKeys=" + Arrays.toString(rightKeys) + ", right=" + right + '}';
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -34,6 +34,7 @@ import herddb.model.TransactionContext;
 import herddb.sql.expressions.CompiledSQLExpression;
 import herddb.utils.AbstractDataAccessor;
 import herddb.utils.DataAccessor;
+import herddb.utils.SQLRecordPredicateFunctions;
 import herddb.utils.Wrapper;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -293,7 +294,7 @@ public class ProjectOp implements PlannerOp {
             }
 
             @Override
-            public int fieldCompareTo(int index, Object value) {
+            public SQLRecordPredicateFunctions.CompareResult fieldCompareTo(int index, Object value) {
                 return wrapped.fieldCompareTo(zeroCopyProjections[index], value);
             }
 

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -163,52 +163,56 @@ public class SortOp implements PlannerOp, TupleComparator {
             int index = fields[i];
             Object value1 = o1.get(index);
             Object value2 = o2.get(index);
-            // this version of compare sorts NULL BEFORE all other values
-            boolean nullLastDirection = nullLastDirections[i];
-            if (nullLastDirection) { // NULL AST
-                // NULL LAST is preferred for us, as it is the default
-                int result = SQLRecordPredicateFunctions.compare(value1, value2);
-                if (result != 0) {
-                    if (directions[i]) { // ASC/DESC
-                        return result;
-                    } else {
-                        return -result;
-                    }
-                }
-                return 0;
-            } else { // NULL FIRST
-                SQLRecordPredicateFunctions.CompareResult resWithNull = SQLRecordPredicateFunctions.compareConsiderNull(value1, value2);
-                if (directions[i]) { // ASC/DEC
-                    switch (resWithNull) {
-                        case EQUALS:
-                            return 0;
-                        case NULL: // ASC NULL FIRST
-                            return -1;
-                        case GREATER:
-                            return 1;
-                        case MINOR:
-                            return -1;
-                        default:
-                            throw new IllegalStateException(resWithNull + "");
-                    }
-                } else {
-                    switch (resWithNull) {
-                        case EQUALS:
-                            return 0;
-                        case NULL: // DESC NULL FIRST
-                            return 1;
-                        case GREATER:
-                            return -1;
-                        case MINOR:
-                            return 1;
-                        default:
-                            throw new IllegalStateException(resWithNull + "");
-                    }
-                }
-            }
+            return compareValues(i, value1, value2);
         }
         // no columns ?
         return 0;
+    }
+
+    private int compareValues(int i, Object value1, Object value2) throws IllegalStateException {
+        // this version of compare sorts NULL BEFORE all other values
+        boolean nullLastDirection = nullLastDirections[i];
+        if (nullLastDirection) { // NULL AST
+            // NULL LAST is preferred for us, as it is the default
+            int result = SQLRecordPredicateFunctions.compare(value1, value2);
+            if (result != 0) {
+                if (directions[i]) { // ASC/DESC
+                    return result;
+                } else {
+                    return -result;
+                }
+            }
+            return 0;
+        } else { // NULL FIRST
+            SQLRecordPredicateFunctions.CompareResult resWithNull = SQLRecordPredicateFunctions.compareConsiderNull(value1, value2);
+            if (directions[i]) { // ASC/DEC
+                switch (resWithNull) {
+                    case EQUALS:
+                        return 0;
+                    case NULL: // ASC NULL FIRST
+                        return -1;
+                    case GREATER:
+                        return 1;
+                    case MINOR:
+                        return -1;
+                    default:
+                        throw new IllegalStateException(resWithNull + "");
+                }
+            } else {
+                switch (resWithNull) {
+                    case EQUALS:
+                        return 0;
+                    case NULL: // DESC NULL FIRST
+                        return 1;
+                    case GREATER:
+                        return -1;
+                    case MINOR:
+                        return 1;
+                    default:
+                        throw new IllegalStateException(resWithNull + "");
+                }
+            }
+        }
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -176,10 +176,12 @@ public class SortOp implements PlannerOp, TupleComparator {
             // NULL LAST is preferred for us, as it is the default
             int result = SQLRecordPredicateFunctions.compare(value1, value2);
             if (result != 0) {
-                if (directions[i]) { // ASC/DESC
+                if (directions[i]) { // ASC
                     return result;
+                } else if (result > 0) { // DESC - invert the result
+                    return -1;
                 } else {
-                    return -result;
+                    return 1;
                 }
             }
             return 0;

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -161,6 +161,7 @@ public class SortOp implements PlannerOp, TupleComparator {
             int index = fields[i];
             Object value1 = o1.get(index);
             Object value2 = o2.get(index);
+            // this version of compare sorts NULL BEFORE all other values
             int result = SQLRecordPredicateFunctions.compare(value1, value2);
             if (result != 0) {
                 if (directions[i]) {

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -64,6 +64,7 @@ import herddb.model.planner.LimitOp;
 import herddb.model.planner.NestedLoopJoinOp;
 import herddb.model.planner.PlannerOp;
 import herddb.model.planner.ProjectOp;
+import herddb.model.planner.SemiJoinOp;
 import herddb.model.planner.SimpleDeleteOp;
 import herddb.model.planner.SimpleInsertOp;
 import herddb.model.planner.SimpleUpdateOp;
@@ -994,10 +995,14 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             fieldNames[i] = col.name;
             columns[i++] = col;
         }
-        return new JoinOp(fieldNames, columns,
-                leftKeys, left, rightKeys, right,
-                generateNullsOnLeft, generateNullsOnRight, false,
-                nonEquiConditions);
+        if (op.isSemiJoin()) {
+            return new SemiJoinOp(fieldNames, columns, leftKeys, left, rightKeys, right);
+        } else {
+            return new JoinOp(fieldNames, columns,
+                    leftKeys, left, rightKeys, right,
+                    generateNullsOnLeft, generateNullsOnRight, false,
+                    nonEquiConditions);
+        }
     }
 
     private List<CompiledSQLExpression> convertJoinNonEquiConditions(final JoinInfo analyzeCondition) throws IllegalStateException {

--- a/herddb-core/src/main/java/herddb/sql/expressions/AccessCurrentRowExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/AccessCurrentRowExpression.java
@@ -23,6 +23,7 @@ package herddb.sql.expressions;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.DataAccessor;
+import herddb.utils.SQLRecordPredicateFunctions;
 import java.util.Arrays;
 
 /**
@@ -56,8 +57,11 @@ public class AccessCurrentRowExpression implements CompiledSQLExpression {
     }
 
     @Override
-    public int opCompareTo(DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
+    public SQLRecordPredicateFunctions.CompareResult opCompareTo(DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
         Object rightValue = right.evaluate(bean, context);
+        if (rightValue == null) {
+            return SQLRecordPredicateFunctions.CompareResult.NULL;
+        }
         return bean.fieldCompareTo(index, rightValue);
     }
 

--- a/herddb-core/src/main/java/herddb/sql/expressions/AccessCurrentRowExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/AccessCurrentRowExpression.java
@@ -49,7 +49,6 @@ public class AccessCurrentRowExpression implements CompiledSQLExpression {
         Object rightValue = right.evaluate(bean, context);
         if (rightValue == null) {
             // NULL is never equal to any other value, even NULL is not equal to NULL
-            System.out.println("opEqualsTo ? " + this.getClass() + " NULL -> false");
             return false;
         }
         return bean.fieldEqualsTo(index, rightValue);

--- a/herddb-core/src/main/java/herddb/sql/expressions/AccessCurrentRowExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/AccessCurrentRowExpression.java
@@ -47,12 +47,21 @@ public class AccessCurrentRowExpression implements CompiledSQLExpression {
     @Override
     public boolean opEqualsTo(DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
         Object rightValue = right.evaluate(bean, context);
+        if (rightValue == null) {
+            // NULL is never equal to any other value, even NULL is not equal to NULL
+            System.out.println("opEqualsTo ? " + this.getClass() + " NULL -> false");
+            return false;
+        }
         return bean.fieldEqualsTo(index, rightValue);
     }
 
     @Override
     public boolean opNotEqualsTo(DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
         Object rightValue = right.evaluate(bean, context);
+        if (rightValue == null) {
+            // NULL is never not-equal to any other value, even NULL is not non-equal to NULL
+            return false;
+        }
         return bean.fieldNotEqualsTo(index, rightValue);
     }
 

--- a/herddb-core/src/main/java/herddb/sql/expressions/CastExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CastExpression.java
@@ -20,6 +20,7 @@
 
 package herddb.sql.expressions;
 
+import herddb.model.ColumnTypes;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.sql.SQLRecordPredicate;
@@ -74,6 +75,11 @@ public class CastExpression implements CompiledSQLExpression {
     public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
         return new CastExpression(wrapped.remapPositionalAccessToToPrimaryKeyAccessor(projection),
                 type);
+    }
+
+    @Override
+    public String toString() {
+        return "CastExpression{" + "wrapped=" + wrapped + ", type=" + ColumnTypes.typeToString(type) + '}';
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThenEqualsExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThenEqualsExpression.java
@@ -22,6 +22,8 @@ package herddb.sql.expressions;
 
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
+import herddb.utils.SQLRecordPredicateFunctions;
+import herddb.utils.SQLRecordPredicateFunctions.CompareResult;
 
 public class CompiledGreaterThenEqualsExpression extends CompiledBinarySQLExpression {
 
@@ -31,7 +33,8 @@ public class CompiledGreaterThenEqualsExpression extends CompiledBinarySQLExpres
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
-        return left.opCompareTo(bean, context, right) >= 0;
+        SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
+        return res == CompareResult.GREATER || res == CompareResult.EQUALS;
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThenExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThenExpression.java
@@ -22,6 +22,7 @@ package herddb.sql.expressions;
 
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
+import herddb.utils.SQLRecordPredicateFunctions;
 
 public class CompiledGreaterThenExpression extends CompiledBinarySQLExpression {
 
@@ -31,7 +32,8 @@ public class CompiledGreaterThenExpression extends CompiledBinarySQLExpression {
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
-        return left.opCompareTo(bean, context, right) > 0;
+        SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
+        return res == SQLRecordPredicateFunctions.CompareResult.GREATER;
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledIsNullExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledIsNullExpression.java
@@ -55,4 +55,10 @@ public class CompiledIsNullExpression implements CompiledSQLExpression {
         return new CompiledIsNullExpression(not,
                 left.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }
+
+    @Override
+    public String toString() {
+        return "CompiledIsNullExpression{" + "left=" + left + ", not=" + not + '}';
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThenEqualsExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThenEqualsExpression.java
@@ -22,6 +22,7 @@ package herddb.sql.expressions;
 
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
+import herddb.utils.SQLRecordPredicateFunctions;
 
 public class CompiledMinorThenEqualsExpression extends CompiledBinarySQLExpression {
 
@@ -31,7 +32,8 @@ public class CompiledMinorThenEqualsExpression extends CompiledBinarySQLExpressi
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
-        return left.opCompareTo(bean, context, right) <= 0;
+        SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
+        return res == SQLRecordPredicateFunctions.CompareResult.MINOR || res == SQLRecordPredicateFunctions.CompareResult.EQUALS;
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThenExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThenExpression.java
@@ -22,6 +22,7 @@ package herddb.sql.expressions;
 
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
+import herddb.utils.SQLRecordPredicateFunctions;
 
 public class CompiledMinorThenExpression extends CompiledBinarySQLExpression {
 
@@ -31,7 +32,8 @@ public class CompiledMinorThenExpression extends CompiledBinarySQLExpression {
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
-        return left.opCompareTo(bean, context, right) < 0;
+        SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
+        return res == SQLRecordPredicateFunctions.CompareResult.MINOR;
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledSQLExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledSQLExpression.java
@@ -47,19 +47,15 @@ public interface CompiledSQLExpression {
     default boolean opEqualsTo(herddb.utils.DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
         Object leftValue = this.evaluate(bean, context);
         if (leftValue == null) {
-            System.out.println("opEqualsTo NULL " + this.getClass() + " ? -> false");
             // NULL is never equal to any other value, even NULL is not equal to NULL
             return false;
         }
         Object rightValue = right.evaluate(bean, context);
         if (rightValue == null) {
-            System.out.println("opEqualsTo " + leftValue + " " + this.getClass() + " NULL -> false");
             // NULL is never equal to any other value, even NULL is not equal to NULL
             return false;
         }
-        boolean res = SQLRecordPredicateFunctions.objectEquals(leftValue, rightValue);
-        System.out.println("opEqualsTo " + leftValue + " " + this.getClass() + " " + rightValue + " -> " + res);
-        return res;
+        return SQLRecordPredicateFunctions.objectEquals(leftValue, rightValue);
     }
 
     default boolean opNotEqualsTo(herddb.utils.DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
@@ -79,9 +75,7 @@ public interface CompiledSQLExpression {
     default SQLRecordPredicateFunctions.CompareResult opCompareTo(herddb.utils.DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
         Object leftValue = this.evaluate(bean, context);
         Object rightValue = right.evaluate(bean, context);
-        SQLRecordPredicateFunctions.CompareResult res = SQLRecordPredicateFunctions.compareConsiderNull(leftValue, rightValue);
-        System.out.println("opCompareTo " + leftValue + " " + this.getClass() + " " + rightValue + " -> " + res);
-        return res;
+        return SQLRecordPredicateFunctions.compareConsiderNull(leftValue, rightValue);
     }
 
     /**

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledSQLExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledSQLExpression.java
@@ -57,10 +57,12 @@ public interface CompiledSQLExpression {
         return SQLRecordPredicateFunctions.objectNotEquals(leftValue, rightValue);
     }
 
-    default int opCompareTo(herddb.utils.DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
+    default SQLRecordPredicateFunctions.CompareResult opCompareTo(herddb.utils.DataAccessor bean, StatementEvaluationContext context, CompiledSQLExpression right) throws StatementExecutionException {
         Object leftValue = this.evaluate(bean, context);
         Object rightValue = right.evaluate(bean, context);
-        return SQLRecordPredicateFunctions.compare(leftValue, rightValue);
+        SQLRecordPredicateFunctions.CompareResult res =  SQLRecordPredicateFunctions.compareConsiderNull(leftValue, rightValue);
+        System.out.println("opCompareTo "+leftValue+" "+this.getClass()+" "+rightValue+" -> "+res);
+        return res;
     }
 
     /**

--- a/herddb-core/src/test/java/herddb/core/SecondaryIndexAccessSuite.java
+++ b/herddb-core/src/test/java/herddb/core/SecondaryIndexAccessSuite.java
@@ -427,8 +427,8 @@ public abstract class SecondaryIndexAccessSuite {
                 System.out.println("indexOperation:" + scan.getPredicate().getIndexOperation());
                 assertNull(scan.getPredicate().getIndexOperation());
                 try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
-                    //  NULL is greater then other values
-                    assertEquals(8, scan1.consume().size());
+                    //  NULL is not greater then other values
+                    assertEquals(6, scan1.consume().size());
                 }
             }
 
@@ -468,8 +468,8 @@ public abstract class SecondaryIndexAccessSuite {
                 System.out.println("indexOperation:" + scan.getPredicate().getIndexOperation());
                 assertNull(scan.getPredicate().getIndexOperation());
                 try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
-                    // null is greater then any other value
-                    assertEquals(7, scan1.consume().size());
+                    // null is not greater then any other value
+                    assertEquals(5, scan1.consume().size());
                 }
             }
 
@@ -499,8 +499,8 @@ public abstract class SecondaryIndexAccessSuite {
                 System.out.println("indexOperation:" + scan.getPredicate().getIndexOperation());
                 assertNull(scan.getPredicate().getIndexOperation());
                 try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
-                    // null is greater then any other value
-                    assertEquals(7, scan1.consume().size());
+                    // null is not greater then any other value
+                    assertEquals(5, scan1.consume().size());
                 }
             }
 
@@ -549,7 +549,7 @@ public abstract class SecondaryIndexAccessSuite {
                 System.out.println("indexOperation:" + scan.getPredicate().getIndexOperation());
                 assertNull(scan.getPredicate().getIndexOperation());
                 try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
-                    assertEquals(6, scan1.consume().size());
+                    assertEquals(5, scan1.consume().size());
                 }
             }
 

--- a/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
@@ -1023,7 +1023,7 @@ public class SimpleJoinTest {
     }
 
     @Test
-    public void testNotExistsWithTransaction() throws Exception {
+    public void testExists() throws Exception {
         String nodeId = "localhost";
         Path dataPath = folder.newFolder("data").toPath();
         Path logsPath = folder.newFolder("logs").toPath();
@@ -1094,7 +1094,24 @@ public class SimpleJoinTest {
                 }
                 TestUtils.commitTransaction(manager, TableSpace.DEFAULT, tx);
             }
+
+            {
+                long tx = TestUtils.beginTransaction(manager, TableSpace.DEFAULT);
+                try (DataScanner scan1 = scan(manager,
+                        " select k1 as kk, v1 as vv from a where 1=1 and ( EXISTS (SELECT 1 FROM b WHERE b.v2=a.k1 AND b.k2 = 1 ))", Collections.emptyList(),
+                        new TransactionContext(tx))) {
+
+                    List<DataAccessor> consume = scan1.consume();
+                    System.out.println("NUM " + consume.size());
+                    for (DataAccessor r : consume) {
+                        System.out.println("RECORD " + r.toMap());
+                    }
+                    assertEquals(1, consume.size());
+                }
+                TestUtils.commitTransaction(manager, TableSpace.DEFAULT, tx);
+            }
         }
+
     }
 }
 

--- a/herddb-utils/src/main/java/herddb/utils/AllNullsDataAccessor.java
+++ b/herddb-utils/src/main/java/herddb/utils/AllNullsDataAccessor.java
@@ -72,8 +72,8 @@ public class AllNullsDataAccessor extends AbstractDataAccessor {
     }
 
     @Override
-    public int fieldCompareTo(int index, Object value) {
-        return SQLRecordPredicateFunctions.compareNullTo(value);
+    public SQLRecordPredicateFunctions.CompareResult fieldCompareTo(int index, Object value) {
+        return SQLRecordPredicateFunctions.CompareResult.NULL;
     }
 
     @Override

--- a/herddb-utils/src/main/java/herddb/utils/AllNullsDataAccessor.java
+++ b/herddb-utils/src/main/java/herddb/utils/AllNullsDataAccessor.java
@@ -63,11 +63,13 @@ public class AllNullsDataAccessor extends AbstractDataAccessor {
 
     @Override
     public boolean fieldEqualsTo(int index, Object value) {
-        return value == null;
+        // NULL is never equals to anything
+        return false;
     }
 
     @Override
     public boolean fieldNotEqualsTo(int index, Object value) {
+        // NULL is never non-equals to anything
         return false;
     }
 

--- a/herddb-utils/src/main/java/herddb/utils/DataAccessor.java
+++ b/herddb-utils/src/main/java/herddb/utils/DataAccessor.java
@@ -53,17 +53,26 @@ public interface DataAccessor {
 
     default boolean fieldEqualsTo(int index, Object value) {
         Object val = get(index);
+        if (val == null) {
+            // NULL is never equal to any other value, even NULL is not equal to NULL
+            return false;
+        }
         return SQLRecordPredicateFunctions.objectEquals(val, value);
     }
 
     default boolean fieldNotEqualsTo(int index, Object value) {
         Object val = get(index);
+        if (val == null) {
+            // NULL is never non-equal to any other value, even NULL is not non-equal to NULL
+            return false;
+        }
         return SQLRecordPredicateFunctions.objectNotEquals(val, value);
     }
 
     default SQLRecordPredicateFunctions.CompareResult fieldCompareTo(int index, Object value) {
         Object val = get(index);
         if (val == null) {
+             // NULL is not comparable
             return SQLRecordPredicateFunctions.CompareResult.NULL;
         }
         return SQLRecordPredicateFunctions.compareConsiderNull(val, value);
@@ -91,12 +100,13 @@ public interface DataAccessor {
 
         @Override
         public boolean fieldEqualsTo(int index, Object value) {
-            return null == value;
+            // nothing is "equal" to NULL
+            return false;
         }
 
         @Override
         public boolean fieldNotEqualsTo(int index, Object value) {
-            // nothing is "not equals" to NULL
+            // nothing is "not equal" to NULL
             return false;
         }
 

--- a/herddb-utils/src/main/java/herddb/utils/DataAccessor.java
+++ b/herddb-utils/src/main/java/herddb/utils/DataAccessor.java
@@ -61,9 +61,12 @@ public interface DataAccessor {
         return SQLRecordPredicateFunctions.objectNotEquals(val, value);
     }
 
-    default int fieldCompareTo(int index, Object value) {
+    default SQLRecordPredicateFunctions.CompareResult fieldCompareTo(int index, Object value) {
         Object val = get(index);
-        return SQLRecordPredicateFunctions.compare(val, value);
+        if (val == null) {
+            return SQLRecordPredicateFunctions.CompareResult.NULL;
+        }
+        return SQLRecordPredicateFunctions.compareConsiderNull(val, value);
     }
 
     default Object[] getValues() {
@@ -98,8 +101,8 @@ public interface DataAccessor {
         }
 
         @Override
-        public int fieldCompareTo(int index, Object value) {
-            return SQLRecordPredicateFunctions.compareNullTo(value);
+        public SQLRecordPredicateFunctions.CompareResult fieldCompareTo(int index, Object value) {
+            return SQLRecordPredicateFunctions.CompareResult.NULL;
         }
 
 

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -64,6 +64,15 @@ public interface SQLRecordPredicateFunctions {
                 return MINOR;
             }
         }
+        public static CompareResult fromLong(long i) {
+            if (i == 0) {
+                return EQUALS;
+            } else if (i > 0) {
+                return GREATER;
+            } else {
+                return MINOR;
+            }
+        }
     }
     /**
      * Compare two values, reporting special cases about NULL.
@@ -94,17 +103,17 @@ public interface SQLRecordPredicateFunctions {
             }
             if (b instanceof Long) {
                 long delta = (Integer) a - (Long) b;
-                return CompareResult.fromInt(delta == 0 ? 0 : delta > 0 ? 1 : -1);
+                return CompareResult.fromLong(delta);
             }
         }
         if (a instanceof Long) {
             if (b instanceof Long) {
                 long delta = (Long) a - (Long) b;
-                return CompareResult.fromInt(delta == 0 ? 0 : delta > 0 ? 1 : -1);
+                return CompareResult.fromLong(delta);
             }
             if (b instanceof java.util.Date) {
                 long delta = ((Long) a) - ((java.util.Date) b).getTime();
-                return CompareResult.fromInt(delta == 0 ? 0 : delta > 0 ? 1 : -1);
+                return CompareResult.fromLong(delta);
             }
         }
         if (a instanceof Number && b instanceof Number) {

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -21,6 +21,7 @@
 package herddb.utils;
 
 import herddb.core.HerdDBInternalException;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,6 +65,14 @@ public interface SQLRecordPredicateFunctions {
             }
         }
     }
+    /**
+     * Compare two values, reporting special cases about NULL.
+     * NULL is not greater or minor than any other value and NULL is not equal to NULL.
+     * @param a
+     * @param b
+     * @return the outcome of the comparation.
+     * @see #compare(java.lang.Object, java.lang.Object)
+     */
     static CompareResult compareConsiderNull(Object a, Object b) {
         if (a == null || b == null) {
             return CompareResult.NULL;
@@ -120,6 +129,15 @@ public interface SQLRecordPredicateFunctions {
         throw new IllegalArgumentException(
                 "uncomparable objects " + a.getClass() + " ('" + a + "') vs " + b.getClass() + " ('" + b + "')");
     }
+
+    /**
+     * Compare two values, NULL are greater than all other values and NULL == NULL.
+     * It follows the general contract of {@link Comparator}
+     * @param a
+     * @param b
+     * @return 1 if a is greater than b, 0 if they are equals to each other and -1 if a is minor than b
+     * @see #compareConsiderNull(java.lang.Object, java.lang.Object)
+     */
     static int compare(Object a, Object b) {
         if (a == null) {
             if (b == null) {

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -49,7 +49,7 @@ public interface SQLRecordPredicateFunctions {
             return 1;
         }
     }
-    static enum CompareResult {
+    enum CompareResult {
         GREATER,
         MINOR,
         EQUALS,


### PR DESCRIPTION
Changes:
- implement correctly SemiJoin plans (select xx from t where exists (xxx where t.x = ....)
- implement correct comparisons against NULLS
- implement "NULLS LAST" and "NULLS FIRST" for ORDER BY (previously it was always "NULLS LAST", now it is the default)