### PR TITLE
Implement Unique Indexes

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookKeeperDataStorageManager.java
@@ -294,7 +294,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
     @Override
     public void start() throws DataStorageManagerException {
         try {
-            LOGGER.log(Level.INFO, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+            LOGGER.log(Level.FINE, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
             FileUtils.cleanDirectory(tmpDirectory);
             Files.createDirectories(tmpDirectory);
             LOGGER.log(Level.INFO, "preparing root znode " + rootZkNode);
@@ -314,7 +314,7 @@ public class BookKeeperDataStorageManager extends DataStorageManager {
 
     @Override
     public void close() throws DataStorageManagerException {
-        LOGGER.log(Level.INFO, "cleaning tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+        LOGGER.log(Level.FINE, "cleaning tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
         try {
             FileUtils.cleanDirectory(tmpDirectory);
         } catch (IOException err) {

--- a/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
@@ -218,7 +218,8 @@ public abstract class AbstractIndexManager implements AutoCloseable {
     final void onTransactionCommit(Transaction transaction, boolean recovery) throws DataStorageManagerException {
         if (createdInTransaction > 0) {
             if (transaction.transactionId != createdInTransaction) {
-                throw new DataStorageManagerException("this indexManager is available only on transaction " + createdInTransaction);
+                throw new DataStorageManagerException("this indexManager (" + getIndexName() + ") is available only on transaction " + createdInTransaction
+                        + " and not in transaction " + transaction.transactionId);
             }
             createdInTransaction = 0;
         }
@@ -234,6 +235,9 @@ public abstract class AbstractIndexManager implements AutoCloseable {
         }
     }
 
+    public long getCreatedInTransaction() {
+        return createdInTransaction;
+    }
 
     public final boolean isAvailable() {
         return createdInTransaction == 0;

--- a/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
@@ -56,7 +56,7 @@ public abstract class AbstractIndexManager implements AutoCloseable {
     protected long createdInTransaction;
     private final boolean unique;
     private final ILocalLockManager lockManager;
- 
+
     public AbstractIndexManager(Index index, AbstractTableManager tableManager,
                                              DataStorageManager dataStorageManager, String tableSpaceUUID,
                                              CommitLog log, long createdInTransaction,
@@ -226,15 +226,15 @@ public abstract class AbstractIndexManager implements AutoCloseable {
             transaction.releaseLocksOnTable(getIndexName(), lockManager);
         }
     }
-    
-    
+
+
     final void onTransactionRollback(Transaction transaction) {
         if (lockManager != null) {
             transaction.releaseLocksOnTable(getIndexName(), lockManager);
         }
     }
-    
-    
+
+
     public final boolean isAvailable() {
         return createdInTransaction == 0;
     }

--- a/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
@@ -1,23 +1,22 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.core;
 
 import herddb.index.IndexOperation;
@@ -32,6 +31,8 @@ import herddb.model.Transaction;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.utils.Bytes;
+import herddb.utils.ILocalLockManager;
+import herddb.utils.LocalLockManager;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,9 @@ public abstract class AbstractIndexManager implements AutoCloseable {
      * This value is not empty until the transaction who creates the table does not commit
      */
     protected long createdInTransaction;
-
+    private final boolean unique;
+    private final ILocalLockManager lockManager;
+ 
     public AbstractIndexManager(Index index, AbstractTableManager tableManager, DataStorageManager dataStorageManager, String tableSpaceUUID, CommitLog log, long createdInTransaction) {
         this.index = index;
         this.createdInTransaction = createdInTransaction;
@@ -61,6 +64,20 @@ public abstract class AbstractIndexManager implements AutoCloseable {
         this.dataStorageManager = dataStorageManager;
         this.tableSpaceUUID = tableSpaceUUID;
         this.log = log;
+        this.unique = index.unique;
+        if (unique) {
+            lockManager = new LocalLockManager();
+        } else {
+            lockManager = null;
+        }
+    }
+
+    public final boolean isUnique() {
+        return unique;
+    }
+
+    public ILocalLockManager getLockManager() {
+        return lockManager;
     }
 
     public final Index getIndex() {
@@ -132,10 +149,8 @@ public abstract class AbstractIndexManager implements AutoCloseable {
     public abstract void unpinCheckpoint(LogSequenceNumber sequenceNumber) throws DataStorageManagerException;
 
     /**
-     * Basic function of the index. The index returns the list of PKs of the table which match the predicate
-     * (IndexOperation) Beare that this function could return a super set of the list of the PKs which actually match
-     * the predicate. TableManager will check every record againts the (WHERE) Predicate in order to ensure the final
-     * result
+     * Basic function of the index. The index returns the list of PKs of the table which match the predicate (IndexOperation) Beare that this function could return a super set of the list of the PKs
+     * which actually match the predicate. TableManager will check every record againts the (WHERE) Predicate in order to ensure the final result
      *
      * @param operation
      * @param context
@@ -146,8 +161,7 @@ public abstract class AbstractIndexManager implements AutoCloseable {
     protected abstract Stream<Bytes> scanner(IndexOperation operation, StatementEvaluationContext context, TableContext tableContext) throws StatementExecutionException;
 
     /**
-     * This function is called from the TableManager to perform scans. It usually have to deal with a JOIN on the
-     * KeyToPageIndex of the TableManager
+     * This function is called from the TableManager to perform scans. It usually have to deal with a JOIN on the KeyToPageIndex of the TableManager
      *
      * @param operation
      * @param context
@@ -185,9 +199,8 @@ public abstract class AbstractIndexManager implements AutoCloseable {
     /**
      * Truncate the index from persist storage
      * <p>
-     * Differs from {@link #dropIndexData()} because it leaves in place every support structure needed by
-     * index runtime (for example if index is persisted into a directory it doesn't delete the directory
-     * itself). The index will continue to work but without current data that will be erased
+     * Differs from {@link #dropIndexData()} because it leaves in place every support structure needed by index runtime (for example if index is persisted into a directory it doesn't delete the
+     * directory itself). The index will continue to work but without current data that will be erased
      * </p>
      *
      * @throws DataStorageManagerException
@@ -213,4 +226,6 @@ public abstract class AbstractIndexManager implements AutoCloseable {
      * Erase the index. Out-side the scope of a transaction
      */
     public abstract void truncate() throws DataStorageManagerException;
+
+    public abstract boolean containsKey(Bytes key)  throws DataStorageManagerException;
 }

--- a/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractIndexManager.java
@@ -227,5 +227,5 @@ public abstract class AbstractIndexManager implements AutoCloseable {
      */
     public abstract void truncate() throws DataStorageManagerException;
 
-    public abstract boolean containsKey(Bytes key)  throws DataStorageManagerException;
+    public abstract boolean valueAlreadyMapped(Bytes key, Bytes primaryKey)  throws DataStorageManagerException;
 }

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -1146,7 +1146,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 } catch (Exception err) {
                     LOGGER.log(Level.SEVERE, "error during shutdown", err);
                 }
-                LOGGER.log(Level.INFO, "{0} activator stopped", nodeId);
+                LOGGER.log(Level.FINE, "{0} activator stopped", nodeId);
             } catch (RuntimeException err) {
                 LOGGER.log(Level.SEVERE, "fatal activator erro", err);
             }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -41,7 +41,6 @@ import herddb.model.DMLStatementExecutionResult;
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.DuplicatePrimaryKeyException;
-import herddb.model.UniqueIndexContraintViolationException;
 import herddb.model.GetResult;
 import herddb.model.Index;
 import herddb.model.Predicate;
@@ -59,6 +58,7 @@ import herddb.model.Table;
 import herddb.model.TableContext;
 import herddb.model.Transaction;
 import herddb.model.TupleComparator;
+import herddb.model.UniqueIndexContraintViolationException;
 import herddb.model.commands.DeleteStatement;
 import herddb.model.commands.GetStatement;
 import herddb.model.commands.InsertStatement;
@@ -1323,7 +1323,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                                         uniqueIndexLock.lockHandle = lockForIndex;
                                     }
                                     if (index.valueAlreadyMapped(indexKey, actual.key)) {
-                                        throw new UniqueIndexContraintViolationException(index.getIndexName(), indexKey, "Value "+indexKey+" already present in index "+index.getIndexName());
+                                        throw new UniqueIndexContraintViolationException(index.getIndexName(), indexKey, "Value " + indexKey + " already present in index " + index.getIndexName());
                                     }
                                 } else {
                                     RecordSerializer.validateIndexableValue(values, index.getIndex(), index.getColumnNames());
@@ -1333,7 +1333,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     } catch (IllegalArgumentException | StatementExecutionException err) {
                         locksManager.releaseLock(lockHandle);
                         StatementExecutionException finalError;
-                        if (! (err instanceof StatementExecutionException)) {
+                        if (!(err instanceof StatementExecutionException)) {
                             finalError = new StatementExecutionException(err.getMessage(), err);
                         } else {
                             finalError = (StatementExecutionException) err;
@@ -1474,7 +1474,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     } catch (IllegalArgumentException | StatementExecutionException err) {
                         locksManager.releaseLock(lockHandle);
                         StatementExecutionException finalError;
-                        if (! (err instanceof StatementExecutionException)) {
+                        if (!(err instanceof StatementExecutionException)) {
                             finalError = new StatementExecutionException(err.getMessage(), err);
                         } else {
                             finalError = (StatementExecutionException) err;

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -41,6 +41,7 @@ import herddb.model.DMLStatementExecutionResult;
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.DuplicatePrimaryKeyException;
+import herddb.model.UniqueIndexContraintViolationException;
 import herddb.model.GetResult;
 import herddb.model.Index;
 import herddb.model.Predicate;
@@ -1152,7 +1153,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 LockHandle lockForIndex = lockForWrite(key, transaction, index.getIndexName(), index.getLockManager());
                 uniqueIndexLock.lockHandle = lockForIndex;
                 if (index.containsKey(uniqueIndexLock.key)) {
-                    res = Futures.exception(new DuplicatePrimaryKeyException(key, "key " + key + ", already exists in table " + table.name + " inside transaction " + transaction.transactionId+" on UNIQUE index "+index.getIndexName()));                    
+                    res = Futures.exception(new UniqueIndexContraintViolationException(index.getIndexName(), key, "key " + key + ", already exists in table " + table.name + " on UNIQUE index "+index.getIndexName()));                    
                 }
                 if (res != null) {
                     break;

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1135,7 +1135,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         RecordSerializer.validateIndexableValue(values, index.getIndex(), index.getColumnNames());
                     }
                 }
-            } catch (IllegalArgumentException err) {
+            } catch (IllegalArgumentException | herddb.utils.IllegalDataAccessException err) {
                 return Futures.exception(new StatementExecutionException(err.getMessage(), err));
             }
         }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1595,7 +1595,7 @@ public class TableSpaceManager {
 
             Map<String, AbstractIndexManager> indexesOnTable = indexesByTable.get(tableNameNormalized);
             if (indexesOnTable != null) {
-                for (String index : indexesOnTable.keySet()) {
+                for (String index : new ArrayList<>(indexesOnTable.keySet())) {
                     LogEntry entry = LogEntryFactory.dropIndex(index, transaction);
                     CommitLogResult pos = log.log(entry, entry.transactionId <= 0);
                     apply(pos, entry, false);
@@ -1725,28 +1725,17 @@ public class TableSpaceManager {
                 ServerConfiguration.PROPERTY_READLOCK_TIMEOUT_DEFAULT
         );
         AbstractIndexManager indexManager;
-        if (index.unique) {
-            switch (index.type) {
-                case Index.TYPE_HASH:
-                    indexManager = new MemoryHashIndexManager(index, tableManager, log, dataStorageManager, this, tableSpaceUUID, transaction,
-                                writeLockTimeout, readLockTimeout);
-                    break;
-                default:
-                    throw new DataStorageManagerException("invalid UNIQUE index type " + index.type);
-            }
-        } else {
-            switch (index.type) {
-                case Index.TYPE_HASH:
-                    indexManager = new MemoryHashIndexManager(index, tableManager, log, dataStorageManager, this, tableSpaceUUID, transaction,
-                                writeLockTimeout, readLockTimeout);
-                    break;
-                case Index.TYPE_BRIN:
-                    indexManager = new BRINIndexManager(index, dbmanager.getMemoryManager(), tableManager, log, dataStorageManager, this, tableSpaceUUID, transaction,
-                                writeLockTimeout, readLockTimeout);
-                    break;
-                default:
-                    throw new DataStorageManagerException("invalid NON-UNIQUE index type " + index.type);
-            }
+        switch (index.type) {
+            case Index.TYPE_HASH:
+                indexManager = new MemoryHashIndexManager(index, tableManager, log, dataStorageManager, this, tableSpaceUUID, transaction,
+                        writeLockTimeout, readLockTimeout);
+                break;
+            case Index.TYPE_BRIN:
+                indexManager = new BRINIndexManager(index, dbmanager.getMemoryManager(), tableManager, log, dataStorageManager, this, tableSpaceUUID, transaction,
+                        writeLockTimeout, readLockTimeout);
+                break;
+            default:
+                throw new DataStorageManagerException("invalid NON-UNIQUE index type " + index.type);
         }
         indexes.put(index.name, indexManager);
 

--- a/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
@@ -219,7 +219,7 @@ public abstract class AbstractSystemTableManager implements AbstractTableManager
         throw new InvalidTableException("cannot alter system tables");
     }
 
-    protected abstract Iterable<Record> buildVirtualRecordList() throws StatementExecutionException;
+    protected abstract Iterable<Record> buildVirtualRecordList(Transaction transaction) throws StatementExecutionException;
 
     private final Comparator<Record> sortByPk = new Comparator<Record>() {
         @Override
@@ -248,7 +248,7 @@ public abstract class AbstractSystemTableManager implements AbstractTableManager
         Predicate predicate = statement.getPredicate();
         MaterializedRecordSet recordSet = tableSpaceManager.getDbmanager().getRecordSetFactory()
                 .createRecordSet(table.columnNames, table.columns);
-        Iterable<Record> data = buildVirtualRecordList();
+        Iterable<Record> data = buildVirtualRecordList(transaction);
         StreamSupport
                 .stream(data.spliterator(), false)
                 .filter(record -> {

--- a/herddb-core/src/main/java/herddb/core/system/SysclientsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysclientsTableManager.java
@@ -26,6 +26,7 @@ import herddb.core.stats.ConnectionsInfoProvider;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
@@ -51,7 +52,7 @@ public class SysclientsTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
         ConnectionsInfoProvider connectionsInfoProvider = tableSpaceManager.getDbmanager().getConnectionsInfoProvider();
         if (connectionsInfoProvider == null) {
             return Collections.emptyList();

--- a/herddb-core/src/main/java/herddb/core/system/SyscolumnsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SyscolumnsTableManager.java
@@ -26,6 +26,7 @@ import herddb.model.Column;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.sql.DatabaseMetaData;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,8 +58,8 @@ public class SyscolumnsTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
-        List<Table> tables = tableSpaceManager.getAllCommittedTables();
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
+        List<Table> tables = tableSpaceManager.getAllVisibleTables(transaction);
         List<Record> result = new ArrayList<>();
         for (Table t : tables) {
             int pos = 1;

--- a/herddb-core/src/main/java/herddb/core/system/SysconfigTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysconfigTableManager.java
@@ -25,6 +25,7 @@ import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import herddb.server.ServerConfiguration;
 import java.util.stream.Collectors;
 
@@ -48,7 +49,7 @@ public class SysconfigTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
         ServerConfiguration configuration = tableSpaceManager.getDbmanager().getServerConfiguration();
         return configuration.keys()
                 .stream()

--- a/herddb-core/src/main/java/herddb/core/system/SysindexcolumnsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexcolumnsTableManager.java
@@ -29,6 +29,7 @@ import herddb.model.ColumnTypes;
 import herddb.model.Index;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,8 +63,8 @@ public class SysindexcolumnsTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
-        List<Table> tables = tableSpaceManager.getAllCommittedTables();
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
+        List<Table> tables = tableSpaceManager.getAllVisibleTables(transaction);
         List<Record> result = new ArrayList<>();
         tables.forEach(r -> {
             // PK

--- a/herddb-core/src/main/java/herddb/core/system/SysindexcolumnsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexcolumnsTableManager.java
@@ -99,7 +99,7 @@ public class SysindexcolumnsTableManager extends AbstractSystemTableManager {
                                 "column_name", cc.name,
                                 "ordinal_position", pos++,
                                 "clustered", 0,
-                                "unique", 0
+                                "unique", index.unique ? 1: 0
                         ));
                     }
                 });

--- a/herddb-core/src/main/java/herddb/core/system/SysindexcolumnsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexcolumnsTableManager.java
@@ -99,7 +99,7 @@ public class SysindexcolumnsTableManager extends AbstractSystemTableManager {
                                 "column_name", cc.name,
                                 "ordinal_position", pos++,
                                 "clustered", 0,
-                                "unique", index.unique ? 1: 0
+                                "unique", index.unique ? 1 : 0
                         ));
                     }
                 });

--- a/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
@@ -26,6 +26,7 @@ import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,8 +56,8 @@ public class SysindexesTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
-        List<Table> tables = tableSpaceManager.getAllCommittedTables();
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
+        List<Table> tables = tableSpaceManager.getAllVisibleTables(transaction);
         return tables
                 .stream()
                 .flatMap((Table r) -> {

--- a/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
@@ -45,7 +45,7 @@ public class SysindexesTableManager extends AbstractSystemTableManager {
             .column("index_name", ColumnTypes.STRING)
             .column("index_uuid", ColumnTypes.STRING)
             .column("index_type", ColumnTypes.STRING)
-            .column("unique", ColumnTypes.STRING)
+            .column("unique", ColumnTypes.INTEGER)
             .primaryKey("table_name", false)
             .primaryKey("index_name", false)
             .build();
@@ -73,7 +73,7 @@ public class SysindexesTableManager extends AbstractSystemTableManager {
                         "index_name", r.name,
                         "index_uuid", r.uuid,
                         "index_type", r.type,
-                        "unique", r.unique ? "true" : "false"
+                        "unique", r.unique ? 1 : 0
                 ))
                 .collect(Collectors.toList());
     }

--- a/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysindexesTableManager.java
@@ -45,6 +45,7 @@ public class SysindexesTableManager extends AbstractSystemTableManager {
             .column("index_name", ColumnTypes.STRING)
             .column("index_uuid", ColumnTypes.STRING)
             .column("index_type", ColumnTypes.STRING)
+            .column("unique", ColumnTypes.STRING)
             .primaryKey("table_name", false)
             .primaryKey("index_name", false)
             .build();
@@ -71,7 +72,8 @@ public class SysindexesTableManager extends AbstractSystemTableManager {
                         "table_name", r.table,
                         "index_name", r.name,
                         "index_uuid", r.uuid,
-                        "index_type", r.type
+                        "index_type", r.type,
+                        "unique", r.unique ? "true" : "false"
                 ))
                 .collect(Collectors.toList());
     }

--- a/herddb-core/src/main/java/herddb/core/system/SyslogstatusManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SyslogstatusManager.java
@@ -27,6 +27,7 @@ import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.StatementExecutionException;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,7 +56,7 @@ public class SyslogstatusManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() throws StatementExecutionException {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) throws StatementExecutionException {
         boolean isVirtual = tableSpaceManager.isVirtual();
         boolean isLeader = tableSpaceManager.isLeader();
         LogSequenceNumber logSequenceNumber = isVirtual ? null : tableSpaceManager.getLog().getLastSequenceNumber();

--- a/herddb-core/src/main/java/herddb/core/system/SysnodesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysnodesTableManager.java
@@ -28,6 +28,7 @@ import herddb.model.NodeMetadata;
 import herddb.model.Record;
 import herddb.model.StatementExecutionException;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -53,7 +54,7 @@ public class SysnodesTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() throws StatementExecutionException {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) throws StatementExecutionException {
         try {
             Collection<NodeMetadata> nodes = tableSpaceManager.getMetadataStorageManager().listNodes();
             List<Record> result = new ArrayList<>();

--- a/herddb-core/src/main/java/herddb/core/system/SysstatementsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysstatementsTableManager.java
@@ -26,6 +26,7 @@ import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,7 +56,7 @@ public class SysstatementsTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
         ConcurrentHashMap<Long, RunningStatementInfo> runningStatements = tableSpaceManager.getDbmanager().getRunningStatements().getRunningStatements();
         List<Record> result = new ArrayList<>();
         long now = System.currentTimeMillis();

--- a/herddb-core/src/main/java/herddb/core/system/SystablesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SystablesTableManager.java
@@ -25,6 +25,7 @@ import herddb.core.TableSpaceManager;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -51,8 +52,8 @@ public class SystablesTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
-        List<Table> tables = tableSpaceManager.getAllCommittedTables();
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
+        List<Table> tables = tableSpaceManager.getAllVisibleTables(transaction);
         return tables
                 .stream()
                 .map(r -> RecordSerializer.makeRecord(table,

--- a/herddb-core/src/main/java/herddb/core/system/SystablespacereplicastateTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SystablespacereplicastateTableManager.java
@@ -29,6 +29,7 @@ import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableSpace;
 import herddb.model.TableSpaceReplicaState;
+import herddb.model.Transaction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -59,7 +60,7 @@ public class SystablespacereplicastateTableManager extends AbstractSystemTableMa
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() throws StatementExecutionException {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) throws StatementExecutionException {
         try {
             Collection<String> names = tableSpaceManager.getMetadataStorageManager().listTableSpaces();
             long now = System.currentTimeMillis();

--- a/herddb-core/src/main/java/herddb/core/system/SystablespacesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SystablespacesTableManager.java
@@ -28,6 +28,7 @@ import herddb.model.Record;
 import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableSpace;
+import herddb.model.Transaction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -57,7 +58,7 @@ public class SystablespacesTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() throws StatementExecutionException {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) throws StatementExecutionException {
         try {
             Collection<String> names = tableSpaceManager.getMetadataStorageManager().listTableSpaces();
             List<Record> result = new ArrayList<>();

--- a/herddb-core/src/main/java/herddb/core/system/SystablestatsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SystablestatsTableManager.java
@@ -27,6 +27,7 @@ import herddb.core.stats.TableManagerStats;
 import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
+import herddb.model.Transaction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -62,8 +63,8 @@ public class SystablestatsTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
-        List<Table> tables = tableSpaceManager.getAllCommittedTables();
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
+        List<Table> tables = tableSpaceManager.getAllVisibleTables(transaction);
         List<Record> result = new ArrayList<>();
         for (Table r : tables) {
             AbstractTableManager tableManager = tableSpaceManager.getTableManager(r.name);

--- a/herddb-core/src/main/java/herddb/core/system/SystransactionsTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SystransactionsTableManager.java
@@ -50,7 +50,7 @@ public class SystransactionsTableManager extends AbstractSystemTableManager {
     }
 
     @Override
-    protected Iterable<Record> buildVirtualRecordList() {
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
         List<Transaction> transactions = tableSpaceManager.getTransactions();
         List<Record> result = new ArrayList<>();
         for (Transaction tx : transactions) {

--- a/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
+++ b/herddb-core/src/main/java/herddb/file/FileDataStorageManager.java
@@ -158,9 +158,9 @@ public class FileDataStorageManager extends DataStorageManager {
     @Override
     public void start() throws DataStorageManagerException {
         try {
-            LOGGER.log(Level.INFO, "ensuring directory {0}", baseDirectory.toAbsolutePath().toString());
+            LOGGER.log(Level.FINE, "ensuring directory {0}", baseDirectory.toAbsolutePath().toString());
             Files.createDirectories(baseDirectory);
-            LOGGER.log(Level.INFO, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+            LOGGER.log(Level.FINE, "preparing tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
             FileUtils.cleanDirectory(tmpDirectory);
             Files.createDirectories(tmpDirectory);
         } catch (IOException err) {
@@ -170,7 +170,7 @@ public class FileDataStorageManager extends DataStorageManager {
 
     @Override
     public void close() throws DataStorageManagerException {
-        LOGGER.log(Level.INFO, "cleaning tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
+        LOGGER.log(Level.FINE, "cleaning tmp directory {0}", tmpDirectory.toAbsolutePath().toString());
         try {
             FileUtils.cleanDirectory(tmpDirectory);
         } catch (IOException err) {
@@ -851,7 +851,7 @@ public class FileDataStorageManager extends DataStorageManager {
             long pageId = getPageId(p);
             LOGGER.log(Level.FINER, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId);
             if (pageId > 0 && !activePagesAtBoot.contains(pageId)) {
-                LOGGER.log(Level.INFO, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted");
+                LOGGER.log(Level.FINE, "cleanupAfterBoot file " + p.toAbsolutePath() + " pageId " + pageId + ". will be deleted");
                 try {
                     Files.deleteIfExists(p);
                 } catch (IOException err) {

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -331,4 +331,9 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
         data.clear();
     }
 
+    @Override
+    public boolean containsKey(Bytes key) throws DataStorageManagerException {
+        return data.containsKey(key);
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -65,8 +65,11 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
     private final ConcurrentHashMap<Bytes, List<Bytes>> data = new ConcurrentHashMap<>();
     private final AtomicLong newPageId = new AtomicLong(1);
 
-    public MemoryHashIndexManager(Index index, AbstractTableManager tableManager, CommitLog log, DataStorageManager dataStorageManager, TableSpaceManager tableSpaceManager, String tableSpaceUUID, long transaction) {
-        super(index, tableManager, dataStorageManager, tableSpaceManager.getTableSpaceUUID(), log, transaction);
+    public MemoryHashIndexManager(Index index, AbstractTableManager tableManager, CommitLog log, DataStorageManager dataStorageManager, TableSpaceManager tableSpaceManager, String tableSpaceUUID,
+                                  long transaction,
+                                  int writeLockTimeout, int readLockTimeout) {
+        super(index, tableManager, dataStorageManager, tableSpaceManager.getTableSpaceUUID(), log, transaction,
+                writeLockTimeout, readLockTimeout);
     }
 
     LogSequenceNumber bootSequenceNumber;
@@ -339,7 +342,8 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
         } else {
             // updating a record, error if there is a mapping to another record
             List<Bytes> current = data.getOrDefault(key, Collections.emptyList());
-            return !current.contains(primaryKey);
+            return !current.isEmpty()
+                    && !current.contains(primaryKey);
         }
     }
 

--- a/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/MemoryHashIndexManager.java
@@ -332,8 +332,15 @@ public class MemoryHashIndexManager extends AbstractIndexManager {
     }
 
     @Override
-    public boolean containsKey(Bytes key) throws DataStorageManagerException {
-        return data.containsKey(key);
+    public boolean valueAlreadyMapped(Bytes key, Bytes primaryKey) throws DataStorageManagerException {
+        if (primaryKey == null) {
+            // new record, error if there is any mapping
+            return data.containsKey(key);
+        } else {
+            // updating a record, error if there is a mapping to another record
+            List<Bytes> current = data.getOrDefault(key, Collections.emptyList());
+            return !current.contains(primaryKey);
+        }
     }
 
 }

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -81,8 +81,11 @@ public class BRINIndexManager extends AbstractIndexManager {
     private final BlockRangeIndex<Bytes, Bytes> data;
     private final IndexDataStorage<Bytes, Bytes> storageLayer = new IndexDataStorageImpl();
 
-    public BRINIndexManager(Index index, MemoryManager memoryManager, AbstractTableManager tableManager, CommitLog log, DataStorageManager dataStorageManager, TableSpaceManager tableSpaceManager, String tableSpaceUUID, long transaction) {
-        super(index, tableManager, dataStorageManager, tableSpaceManager.getTableSpaceUUID(), log, transaction);
+    public BRINIndexManager(Index index, MemoryManager memoryManager, AbstractTableManager tableManager, CommitLog log,
+                            DataStorageManager dataStorageManager, TableSpaceManager tableSpaceManager, String tableSpaceUUID, long transaction,
+                            int writeLockTimeout, int readLockTimeout) {
+        super(index, tableManager, dataStorageManager, tableSpaceManager.getTableSpaceUUID(), log, transaction,
+                                             writeLockTimeout, readLockTimeout);
         this.data = new BlockRangeIndex<>(
                 memoryManager.getMaxLogicalPageSize(),
                 memoryManager.getDataPageReplacementPolicy(),

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -493,7 +493,7 @@ public class BRINIndexManager extends AbstractIndexManager {
     }
 
     @Override
-    public boolean containsKey(Bytes key) throws DataStorageManagerException {
+    public boolean valueAlreadyMapped(Bytes key, Bytes primaryKey) throws DataStorageManagerException {
         throw new DataStorageManagerException("Not implemented");
     }
 

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -497,7 +497,14 @@ public class BRINIndexManager extends AbstractIndexManager {
 
     @Override
     public boolean valueAlreadyMapped(Bytes key, Bytes primaryKey) throws DataStorageManagerException {
-        throw new DataStorageManagerException("Not implemented");
+        if (primaryKey == null) {
+            return data.containsKey(key);
+        } else {
+            // updating a record, error if there is a mapping to another record
+            List<Bytes> current = data.search(key);
+            return !current.isEmpty()
+                    && !current.contains(primaryKey);
+        }
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -493,6 +493,11 @@ public class BRINIndexManager extends AbstractIndexManager {
     }
 
     @Override
+    public boolean containsKey(Bytes key) throws DataStorageManagerException {
+        throw new DataStorageManagerException("Not implemented");
+    }
+
+    @Override
     public void close() {
         data.clear();
     }

--- a/herddb-core/src/main/java/herddb/model/Index.java
+++ b/herddb-core/src/main/java/herddb/model/Index.java
@@ -193,7 +193,7 @@ public class Index implements ColumnsList {
             this.name = name;
             return this;
         }
-        
+
         public Builder unique(boolean unique) {
             this.unique = unique;
             return this;

--- a/herddb-core/src/main/java/herddb/model/Index.java
+++ b/herddb-core/src/main/java/herddb/model/Index.java
@@ -246,9 +246,6 @@ public class Index implements ColumnsList {
             if (uuid == null || uuid.isEmpty()) {
                 uuid = UUID.randomUUID().toString();
             }
-            if (unique && (!TYPE_HASH.equals(type))) {
-                throw new IllegalArgumentException("only index type " + TYPE_HASH + " is supported for UNIQUE indexes");
-            }
             return new Index(uuid, name, table, tablespace, type, columns.toArray(new Column[columns.size()]), unique);
         }
 

--- a/herddb-core/src/main/java/herddb/model/UniqueIndexContraintViolationException.java
+++ b/herddb-core/src/main/java/herddb/model/UniqueIndexContraintViolationException.java
@@ -18,17 +18,32 @@
 
  */
 
-package herddb.core.indexes;
+package herddb.model;
+
+import herddb.utils.Bytes;
 
 /**
- * Tests on HASH UNIQUE indexes
+ * Record already exists
  *
  * @author enrico.olivelli
  */
-public class HashUniqueIndexAccessTest extends SecondaryUniqueIndexAccessSuite {
+public class UniqueIndexContraintViolationException extends StatementExecutionException {
 
-//    public HashUniqueIndexAccessTest() {
-//        super(Index.TYPE_HASH);
-//    }
+    private final Bytes key;
+    private final String indexName;
+
+    public UniqueIndexContraintViolationException(String indexName, Bytes key, String message) {
+        super(message);
+        this.key = key;
+        this.indexName = indexName;
+    }
+
+    public Bytes getKey() {
+        return key;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -421,7 +421,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                 herddb.model.Index.Builder builder = herddb.model.Index
                         .builder()
                         .onTable(table)
-                        .name("unique" + col)
+                        .name(table.name + "_unique_" + col)
                         .unique(true)
                         .type(herddb.model.Index.TYPE_BRIN)
                         .uuid(UUID.randomUUID().toString())

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -332,6 +332,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                     .name(tableName)
                     .tablespace(tableSpace);
             Set<String> primaryKey = new HashSet<>();
+            Set<String> simpleUniqueFields = new HashSet<>();
 
             if (s.getIndexes() != null) {
                 for (Index index : s.getIndexes()) {
@@ -357,7 +358,6 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                 Bytes defaultValue = decodeDefaultValue(cf, type);
 
                 if (!columnSpecs.isEmpty()) {
-
                     boolean auto_increment = decodeAutoIncrement(columnSpecs);
                     if (columnSpecs.contains("PRIMARY")) {
                         foundPk = true;
@@ -365,6 +365,10 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                     }
                     if (auto_increment && primaryKey.contains(columnName)) {
                         tablebuilder.primaryKey(columnName, auto_increment);
+                    }
+                    boolean isUnique = columnSpecs.contains("UNIQUE");
+                    if (isUnique) {
+                        simpleUniqueFields.add(columnName);
                     }
                 }
 
@@ -383,10 +387,13 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                 for (Index index : s.getIndexes()) {
                     if (index.getType().equalsIgnoreCase("PRIMARY KEY")) {
 
-                    } else if (index.getType().equalsIgnoreCase("INDEX")) {
+                    } else if (index.getType().equalsIgnoreCase("INDEX")
+                            || index.getType().equalsIgnoreCase("KEY")
+                            || index.getType().equalsIgnoreCase("UNIQUE KEY")
+                            ) {
                         String indexName = index.getName().toLowerCase();
                         String indexType = convertIndexType(null);
-                        boolean unique = isUnique(index.getType());
+                        boolean unique = index.getType().equalsIgnoreCase("UNIQUE KEY");
 
                         herddb.model.Index.Builder builder = herddb.model.Index
                                 .builder()
@@ -409,6 +416,17 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
                         otherIndexes.add(builder.build());
                     }
                 }
+            }
+            for (String col : simpleUniqueFields) {
+                herddb.model.Index.Builder builder = herddb.model.Index
+                        .builder()
+                        .onTable(table)
+                        .name("unique" + col)
+                        .unique(true)
+                        .type(herddb.model.Index.TYPE_BRIN)
+                        .uuid(UUID.randomUUID().toString())
+                        .column(col, table.getColumn(col).type);
+                otherIndexes.add(builder.build());
             }
 
             CreateTableStatement statement = new CreateTableStatement(table, otherIndexes, isNotExsists);

--- a/herddb-core/src/main/java/herddb/sql/functions/ShowCreateTableCalculator.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/ShowCreateTableCalculator.java
@@ -59,7 +59,11 @@ public class ShowCreateTableCalculator {
 
             if (!indexes.isEmpty()) {
                 indexes.forEach(idx -> {
-                    joiner.add("INDEX " + idx.name + "(" + String.join(",", idx.columnNames) + ")");
+                    if (idx.unique) {
+                        joiner.add("UNIQUE INDEX " + idx.name + " (" + String.join(",", idx.columnNames) + ")");
+                    } else {
+                        joiner.add("INDEX " + idx.name + "(" + String.join(",", idx.columnNames) + ")");
+                    }
                 });
             }
         }

--- a/herddb-core/src/main/java/herddb/sql/functions/ShowCreateTableCalculator.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/ShowCreateTableCalculator.java
@@ -60,7 +60,7 @@ public class ShowCreateTableCalculator {
             if (!indexes.isEmpty()) {
                 indexes.forEach(idx -> {
                     if (idx.unique) {
-                        joiner.add("UNIQUE INDEX " + idx.name + " (" + String.join(",", idx.columnNames) + ")");
+                        joiner.add("UNIQUE KEY " + idx.name + " (" + String.join(",", idx.columnNames) + ")");
                     } else {
                         joiner.add("INDEX " + idx.name + "(" + String.join(",", idx.columnNames) + ")");
                     }

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -2640,6 +2640,10 @@ public class RawSQLTest {
             } catch (StatementExecutionException ok) {
             }
 
+            execute(manager, "CREATE UNIQUE INDEX ixu1 ON tblspace1.tsql(n1)", Collections.emptyList());
+            Map<String, AbstractIndexManager> indexesOnTable = manager.getTableSpaceManager("tblspace1").getIndexesOnTable("tsql");
+            assertTrue(indexesOnTable.values().stream().anyMatch(s->s.getIndexName().equals("ixu1") && s.isUnique()));
+
         }
     }
 

--- a/herddb-core/src/test/java/herddb/core/indexes/BrinIndexAccessTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/BrinIndexAccessTest.java
@@ -18,8 +18,9 @@
 
  */
 
-package herddb.core;
+package herddb.core.indexes;
 
+import herddb.core.indexes.SecondaryNonUniqueIndexAccessSuite;
 import herddb.model.Index;
 
 /**
@@ -27,7 +28,7 @@ import herddb.model.Index;
  *
  * @author enrico.olivelli
  */
-public class BrinIndexAccessTest extends SecondaryIndexAccessSuite {
+public class BrinIndexAccessTest extends SecondaryNonUniqueIndexAccessSuite {
 
     public BrinIndexAccessTest() {
         super(Index.TYPE_BRIN);

--- a/herddb-core/src/test/java/herddb/core/indexes/BrinIndexAccessTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/BrinIndexAccessTest.java
@@ -20,7 +20,6 @@
 
 package herddb.core.indexes;
 
-import herddb.core.indexes.SecondaryNonUniqueIndexAccessSuite;
 import herddb.model.Index;
 
 /**

--- a/herddb-core/src/test/java/herddb/core/indexes/BrinNonUniqueIndexAccessTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/BrinNonUniqueIndexAccessTest.java
@@ -27,9 +27,9 @@ import herddb.model.Index;
  *
  * @author enrico.olivelli
  */
-public class BrinIndexAccessTest extends SecondaryNonUniqueIndexAccessSuite {
+public class BrinNonUniqueIndexAccessTest extends SecondaryNonUniqueIndexAccessSuite {
 
-    public BrinIndexAccessTest() {
+    public BrinNonUniqueIndexAccessTest() {
         super(Index.TYPE_BRIN);
     }
 

--- a/herddb-core/src/test/java/herddb/core/indexes/BrinUniqueIndexAccessTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/BrinUniqueIndexAccessTest.java
@@ -23,14 +23,14 @@ package herddb.core.indexes;
 import herddb.model.Index;
 
 /**
- * Tests on HASH UNIQUE indexes
+ * Tests on BRIN UNIQUE indexes
  *
  * @author enrico.olivelli
  */
-public class HashUniqueIndexAccessTest extends SecondaryUniqueIndexAccessSuite {
+public class BrinUniqueIndexAccessTest extends SecondaryUniqueIndexAccessSuite {
 
-    public HashUniqueIndexAccessTest() {
-        super(Index.TYPE_HASH);
+    public BrinUniqueIndexAccessTest() {
+        super(Index.TYPE_BRIN);
     }
 
 }

--- a/herddb-core/src/test/java/herddb/core/indexes/HashNonUniqueIndexAccessTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/HashNonUniqueIndexAccessTest.java
@@ -18,8 +18,9 @@
 
  */
 
-package herddb.core;
+package herddb.core.indexes;
 
+import herddb.core.indexes.SecondaryNonUniqueIndexAccessSuite;
 import herddb.model.Index;
 
 /**
@@ -27,9 +28,9 @@ import herddb.model.Index;
  *
  * @author enrico.olivelli
  */
-public class HashIndexAccessTest extends SecondaryIndexAccessSuite {
+public class HashNonUniqueIndexAccessTest extends SecondaryNonUniqueIndexAccessSuite {
 
-    public HashIndexAccessTest() {
+    public HashNonUniqueIndexAccessTest() {
         super(Index.TYPE_HASH);
     }
 

--- a/herddb-core/src/test/java/herddb/core/indexes/HashNonUniqueIndexAccessTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/HashNonUniqueIndexAccessTest.java
@@ -20,7 +20,6 @@
 
 package herddb.core.indexes;
 
-import herddb.core.indexes.SecondaryNonUniqueIndexAccessSuite;
 import herddb.model.Index;
 
 /**

--- a/herddb-core/src/test/java/herddb/core/indexes/HashUniqueIndexAccessTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/HashUniqueIndexAccessTest.java
@@ -18,33 +18,19 @@
 
  */
 
-package herddb.model.commands;
+package herddb.core.indexes;
 
-import herddb.model.DDLStatement;
 import herddb.model.Index;
 
 /**
- * Create an index
+ * Tests on HASH UNIQUE indexes
  *
  * @author enrico.olivelli
  */
-public class CreateIndexStatement extends DDLStatement {
+public class HashUniqueIndexAccessTest extends SecondaryUniqueIndexAccessSuite {
 
-    private final Index indexDefinition;
-
-    public CreateIndexStatement(Index indexDefinition) {
-        super(indexDefinition.tablespace);
-        this.indexDefinition = indexDefinition;
-    }
-
-    @Override
-    public boolean supportsTransactionAutoCreate() {
-        /* This instruction will autocreate a transaction if issued */
-        return true;
-    }
-
-    public Index getIndexDefinition() {
-        return indexDefinition;
-    }
+//    public HashUniqueIndexAccessTest() {
+//        super(Index.TYPE_HASH);
+//    }
 
 }

--- a/herddb-core/src/test/java/herddb/core/indexes/IndexCreationTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/IndexCreationTest.java
@@ -73,7 +73,7 @@ public class IndexCreationTest {
     public void hashNonUniqueRecoverTableAndIndexWithCheckpoint() throws Exception {
         recoverTableAndIndexWithCheckpoint(Index.TYPE_HASH, false);
     }
-    
+
     @Test
     public void hashUniqueRecoverTableAndIndexWithCheckpoint() throws Exception {
         recoverTableAndIndexWithCheckpoint(Index.TYPE_HASH, true);

--- a/herddb-core/src/test/java/herddb/core/indexes/IndexCreationTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/IndexCreationTest.java
@@ -18,12 +18,13 @@
 
  */
 
-package herddb.core;
+package herddb.core.indexes;
 
 import static herddb.core.TestUtils.execute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.codec.RecordSerializer;
+import herddb.core.DBManager;
 import herddb.file.FileCommitLogManager;
 import herddb.file.FileDataStorageManager;
 import herddb.file.FileMetadataStorageManager;
@@ -64,16 +65,21 @@ public class IndexCreationTest {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
-    public void brinRecoverTableAndIndexWithCheckpoint() throws Exception {
-        recoverTableAndIndexWithCheckpoint(Index.TYPE_BRIN);
+    public void brinNonUniqueRecoverTableAndIndexWithCheckpoint() throws Exception {
+        recoverTableAndIndexWithCheckpoint(Index.TYPE_BRIN, false);
     }
 
     @Test
-    public void hashRecoverTableAndIndexWithCheckpoint() throws Exception {
-        recoverTableAndIndexWithCheckpoint(Index.TYPE_HASH);
+    public void hashNonUniqueRecoverTableAndIndexWithCheckpoint() throws Exception {
+        recoverTableAndIndexWithCheckpoint(Index.TYPE_HASH, false);
+    }
+    
+    @Test
+    public void hashUniqueRecoverTableAndIndexWithCheckpoint() throws Exception {
+        recoverTableAndIndexWithCheckpoint(Index.TYPE_HASH, true);
     }
 
-    private void recoverTableAndIndexWithCheckpoint(String indexType) throws Exception {
+    private void recoverTableAndIndexWithCheckpoint(String indexType, boolean unique) throws Exception {
 
         Path dataPath = folder.newFolder("data").toPath();
         Path logsPath = folder.newFolder("logs").toPath();
@@ -125,7 +131,7 @@ public class IndexCreationTest {
 
             manager.waitForTablespace("tblspace1", 10000);
 
-            index = Index.builder().onTable(table).column("name", ColumnTypes.STRING).type(indexType).build();
+            index = Index.builder().onTable(table).column("name", ColumnTypes.STRING).type(indexType).unique(unique).build();
             manager.executeStatement(new CreateIndexStatement(index), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             /* Access through index  */

--- a/herddb-core/src/test/java/herddb/core/indexes/IndexScanRangeTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/IndexScanRangeTest.java
@@ -20,11 +20,11 @@
 
 package herddb.core.indexes;
 
-import herddb.core.DBManager;
-import herddb.core.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import herddb.index.SecondaryIndexPrefixScan;
 import herddb.index.SecondaryIndexRangeScan;
 import herddb.index.SecondaryIndexSeek;

--- a/herddb-core/src/test/java/herddb/core/indexes/IndexScanRangeTest.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/IndexScanRangeTest.java
@@ -18,8 +18,10 @@
 
  */
 
-package herddb.core;
+package herddb.core.indexes;
 
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/herddb-core/src/test/java/herddb/core/indexes/SecondaryNonUniqueIndexAccessSuite.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/SecondaryNonUniqueIndexAccessSuite.java
@@ -20,12 +20,12 @@
 
 package herddb.core.indexes;
 
-import herddb.core.DBManager;
-import herddb.core.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import herddb.index.SecondaryIndexPrefixScan;
 import herddb.index.SecondaryIndexRangeScan;
 import herddb.index.SecondaryIndexSeek;

--- a/herddb-core/src/test/java/herddb/core/indexes/SecondaryNonUniqueIndexAccessSuite.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/SecondaryNonUniqueIndexAccessSuite.java
@@ -18,8 +18,10 @@
 
  */
 
-package herddb.core;
+package herddb.core.indexes;
 
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -56,11 +58,11 @@ import org.junit.Test;
 /**
  * @author enrico.olivelli
  */
-public abstract class SecondaryIndexAccessSuite {
+public abstract class SecondaryNonUniqueIndexAccessSuite {
 
     protected String indexType;
 
-    public SecondaryIndexAccessSuite(String indexType) {
+    public SecondaryNonUniqueIndexAccessSuite(String indexType) {
         this.indexType = indexType;
     }
 

--- a/herddb-core/src/test/java/herddb/core/indexes/SecondaryUniqueIndexAccessSuite.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/SecondaryUniqueIndexAccessSuite.java
@@ -1,0 +1,132 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core.indexes;
+
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.index.SecondaryIndexPrefixScan;
+import herddb.index.SecondaryIndexSeek;
+import herddb.mem.MemoryCommitLogManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ColumnTypes;
+import herddb.model.DataScanner;
+import herddb.model.Index;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.Table;
+import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateIndexStatement;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.model.commands.CreateTableStatement;
+import herddb.model.commands.ScanStatement;
+import herddb.sql.TranslatedQuery;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * @author enrico.olivelli
+ */
+public abstract class SecondaryUniqueIndexAccessSuite {
+
+    protected String indexType;
+
+    public SecondaryUniqueIndexAccessSuite() {
+        this.indexType = Index.TYPE_HASH;
+    }
+
+    @Test
+    public void secondaryUniqueIndexPrefixScan() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            Table table = Table
+                    .builder()
+                    .tablespace("tblspace1")
+                    .name("t1")
+                    .column("id", ColumnTypes.STRING)
+                    .column("n1", ColumnTypes.INTEGER)
+                    .column("name", ColumnTypes.STRING)
+                    .primaryKey("id")
+                    .build();
+
+            CreateTableStatement st2 = new CreateTableStatement(table);
+            manager.executeStatement(st2, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            Index index = Index
+                    .builder()
+                    .onTable(table)
+                    .type(Index.TYPE_HASH)
+                    .unique(true)
+                    .column("n1", ColumnTypes.INTEGER)
+                    .column("name", ColumnTypes.STRING).
+                            build();
+
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('a',1,'n1')", Collections.emptyList());
+            herddb.utils.TestUtils.assertThrows(Exception.class, () -> {
+                TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('b',1,'n1')", Collections.emptyList());
+            });            
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('d',2,'n2')", Collections.emptyList());
+            TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('e',3,'n2')", Collections.emptyList());
+
+            // create index, it will be built using existing data
+            CreateIndexStatement st3 = new CreateIndexStatement(index);
+            manager.executeStatement(st3, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            {
+                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1=1", Collections.emptyList(), true, true, false, -1);
+                ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+                assertTrue(scan.getPredicate().getIndexOperation() instanceof SecondaryIndexPrefixScan);
+                try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                    assertEquals(3, scan1.consume().size());
+                }
+            }
+
+            {
+                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1=1 and name='n2'", Collections.emptyList(), true, true, false, -1);
+                ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+                assertTrue(scan.getPredicate().getIndexOperation() instanceof SecondaryIndexSeek);
+                try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                    assertEquals(1, scan1.consume().size());
+                }
+            }
+
+            {
+                TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1>=1", Collections.emptyList(), true, true, false, -1);
+                ScanStatement scan = translated.plan.mainStatement.unwrap(ScanStatement.class);
+                assertNull(scan.getPredicate().getIndexOperation());
+                try (DataScanner scan1 = manager.scan(scan, translated.context, TransactionContext.NO_TRANSACTION)) {
+                    assertEquals(3, scan1.consume().size());
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/core/indexes/SecondaryUniqueIndexAccessSuite.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/SecondaryUniqueIndexAccessSuite.java
@@ -21,12 +21,12 @@
 package herddb.core.indexes;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import herddb.core.DBManager;
-import herddb.core.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import herddb.index.SecondaryIndexPrefixScan;
 import herddb.index.SecondaryIndexSeek;
 import herddb.mem.MemoryCommitLogManager;
@@ -66,7 +66,7 @@ public class SecondaryUniqueIndexAccessSuite {
 
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
-    
+
     protected String indexType;
 
     public SecondaryUniqueIndexAccessSuite() {
@@ -194,7 +194,7 @@ public class SecondaryUniqueIndexAccessSuite {
             // enure another record can be stored on the same key
             TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('o',1,'n1')", Collections.emptyList());
 
-            
+
             // test transactions
             long tx = TestUtils.beginTransaction(manager, "tblspace1");
             // insert a new record, and a new index entry, but in transaction, the transacition will hold the index lock on "100-n100"
@@ -205,21 +205,21 @@ public class SecondaryUniqueIndexAccessSuite {
             TestUtils.executeUpdate(manager, "DELETE FROM  tblspace1.t1 where id='t1'", Collections.emptyList(), new TransactionContext(tx));
             // insert a new record again, with the same key in the index, we are still holding the lock on "100-n100"
             TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('t2',100,'n100')", Collections.emptyList(), new TransactionContext(tx));
-            
-            // check that we are going to timeout on lock acquisition
+
+            // check that we are going to timeout on lock acquisition from another context (for instance no transaction)
             StatementExecutionException err = herddb.utils.TestUtils.expectThrows(StatementExecutionException.class, () -> {
                 TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('t3',100,'n100')", Collections.emptyList());
             });
             assertThat(err.getCause(), instanceOf(LockAcquireTimeoutException.class));
-            
+
             TestUtils.commitTransaction(manager, "tblspace1", tx);
-            
+
             // cannot insert another record with "100-n100"
             herddb.utils.TestUtils.assertThrows(UniqueIndexContraintViolationException.class, () -> {
                 TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('t3',100,'n100')", Collections.emptyList());
             });
-            
-            
+
+
         }
 
     }

--- a/herddb-core/src/test/java/herddb/core/indexes/SecondaryUniqueIndexAccessSuite.java
+++ b/herddb-core/src/test/java/herddb/core/indexes/SecondaryUniqueIndexAccessSuite.java
@@ -99,11 +99,22 @@ public class SecondaryUniqueIndexAccessSuite {
                 TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('b',1,'n1')", Collections.emptyList());
             });
             // multiple values
+            // it is not a transaction, the first INSERT will succeed
             herddb.utils.TestUtils.assertThrows(UniqueIndexContraintViolationException.class, () -> {
                 TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('b',8,'n1'),('c',1,'n1')", Collections.emptyList());
             });
             TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('d',2,'n2')", Collections.emptyList());
             TestUtils.executeUpdate(manager, "INSERT INTO tblspace1.t1(id,n1,name) values('e',3,'n2')", Collections.emptyList());
+            
+            // single record UPDATE
+            herddb.utils.TestUtils.assertThrows(UniqueIndexContraintViolationException.class, () -> {
+                TestUtils.executeUpdate(manager, "UPDATE tblspace1.t1 set n1=1,name='n1' where id='d'", Collections.emptyList());
+            });
+            
+            // multi record UPDATE
+            herddb.utils.TestUtils.assertThrows(UniqueIndexContraintViolationException.class, () -> {
+                TestUtils.executeUpdate(manager, "UPDATE tblspace1.t1 set n1=1,name='n1' where id='d'", Collections.emptyList());
+            });
 
             {
                 TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, "SELECT * FROM tblspace1.t1 WHERE n1=8", Collections.emptyList(), true, true, false, -1);

--- a/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuite.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuite.java
@@ -49,7 +49,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -57,7 +56,7 @@ import org.junit.rules.TemporaryFolder;
  *
  * @author enrico.olivelli
  */
-public class DirectMultipleConcurrentUpdatesTest {
+public abstract class DirectMultipleConcurrentUpdatesSuite {
 
     private static final int TABLESIZE = 2000;
     private static final int MULTIPLIER = 2;
@@ -66,68 +65,8 @@ public class DirectMultipleConcurrentUpdatesTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @Test
-    public void test() throws Exception {
-        performTest(false, 0, false, false);
-    }
 
-    @Test
-    public void testWithTransactions() throws Exception {
-        performTest(true, 0, false, false);
-    }
-
-    @Test
-    public void testWithCheckpoints() throws Exception {
-        performTest(false, 2000, false, false);
-    }
-
-    @Test
-    public void testWithTransactionsWithCheckpoints() throws Exception {
-        performTest(true, 2000, false, false);
-    }
-
-    @Test
-    public void testWithIndexes() throws Exception {
-        performTest(false, 0, true, false);
-    }
-
-    @Test
-    public void testWithTransactionsAndIndexes() throws Exception {
-        performTest(true, 0, true, false);
-    }
-
-    @Test
-    public void testWithCheckpointsAndIndexes() throws Exception {
-        performTest(false, 2000, true, false);
-    }
-
-    @Test
-    public void testWithTransactionsWithCheckpointsAndIndexes() throws Exception {
-        performTest(true, 2000, true, false);
-    }
-
-
-    @Test
-    public void testWithUniqueIndexes() throws Exception {
-        performTest(false, 0, true, true);
-    }
-
-    @Test
-    public void testWithTransactionsAndUniqueIndexes() throws Exception {
-        performTest(true, 0, true, true);
-    }
-
-    @Test
-    public void testWithCheckpointsAndUniqueIndexes() throws Exception {
-        performTest(false, 2000, true, true);
-    }
-
-    @Test
-    public void testWithTransactionsWithCheckpointsAndUniqueIndexes() throws Exception {
-        performTest(true, 2000, true, true);
-    }
-
-    private void performTest(boolean useTransactions, long checkPointPeriod, boolean withIndexes, boolean uniqueIndexes) throws Exception {
+    protected void performTest(boolean useTransactions, long checkPointPeriod, boolean withIndexes, boolean uniqueIndexes) throws Exception {
         Path baseDir = folder.newFolder().toPath();
         ServerConfiguration serverConfiguration = new ServerConfiguration(baseDir);
 
@@ -147,8 +86,8 @@ public class DirectMultipleConcurrentUpdatesTest {
 
             if (withIndexes) {
                 if (uniqueIndexes) {
-                    // use n1 + key in order to not have collisions and lock timeouts
-                    execute(manager, "CREATE UNIQUE INDEX theindex ON mytable (n1, key)", Collections.emptyList());
+                    // use n1 + id in order to not have collisions and lock timeouts
+                    execute(manager, "CREATE UNIQUE INDEX theindex ON mytable (n1, id)", Collections.emptyList());
                 } else {
                     execute(manager, "CREATE INDEX theindex ON mytable (n1)", Collections.emptyList());
                 }

--- a/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuiteNoIndexesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuiteNoIndexesTest.java
@@ -1,0 +1,47 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server.hammer;
+
+import org.junit.Test;
+
+public class DirectMultipleConcurrentUpdatesSuiteNoIndexesTest extends DirectMultipleConcurrentUpdatesSuite {
+
+    @Test
+    public void test() throws Exception {
+        performTest(false, 0, false, false);
+    }
+
+    @Test
+    public void testWithTransactions() throws Exception {
+        performTest(true, 0, false, false);
+    }
+
+    @Test
+    public void testWithCheckpoints() throws Exception {
+        performTest(false, 2000, false, false);
+    }
+
+    @Test
+    public void testWithTransactionsWithCheckpoints() throws Exception {
+        performTest(true, 2000, false, false);
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest.java
@@ -1,0 +1,47 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server.hammer;
+
+import org.junit.Test;
+
+public class DirectMultipleConcurrentUpdatesSuiteWithNonUniqueIndexesTest extends DirectMultipleConcurrentUpdatesSuite {
+
+    @Test
+    public void testWithIndexes() throws Exception {
+        performTest(false, 0, true, false);
+    }
+
+    @Test
+    public void testWithTransactionsAndIndexes() throws Exception {
+        performTest(true, 0, true, false);
+    }
+
+    @Test
+    public void testWithCheckpointsAndIndexes() throws Exception {
+        performTest(false, 2000, true, false);
+    }
+
+    @Test
+    public void testWithTransactionsWithCheckpointsAndIndexes() throws Exception {
+        performTest(true, 2000, true, false);
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest.java
@@ -1,0 +1,48 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.server.hammer;
+
+import org.junit.Test;
+
+
+public class DirectMultipleConcurrentUpdatesSuiteWithUniqueIndexesTest extends DirectMultipleConcurrentUpdatesSuite {
+
+    @Test
+    public void testWithUniqueIndexes() throws Exception {
+        performTest(false, 0, true, true);
+    }
+
+    @Test
+    public void testWithTransactionsAndUniqueIndexes() throws Exception {
+        performTest(true, 0, true, true);
+    }
+
+    @Test
+    public void testWithCheckpointsAndUniqueIndexes() throws Exception {
+        performTest(false, 2000, true, true);
+    }
+
+    @Test
+    public void testWithTransactionsWithCheckpointsAndUniqueIndexes() throws Exception {
+        performTest(true, 2000, true, true);
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -594,6 +594,7 @@ public class CalcitePlannerTest {
                     + "s1 string not null, n1 int, primary key(k1,n1))", Collections.emptyList());
 
             execute(manager, "CREATE INDEX ixn1s1 on tblspace1.test23(n1,s1)", Collections.emptyList());
+            execute(manager, "CREATE UNIQUE INDEX ixn1s2 on tblspace1.test23(n1,s1,k1)", Collections.emptyList());
 
             TranslatedQuery translatedQuery = manager.getPlanner().translate("tblspace1", "SHOW CREATE TABLE tblspace1.test23 WITH INDEXES", Collections.emptyList(),
                     true, false, true, -1);
@@ -607,7 +608,7 @@ public class CalcitePlannerTest {
             TuplesList tuplesList = new TuplesList(columns, records);
             assertTrue(tuplesList.columnNames[0].equalsIgnoreCase("tabledef"));
             Tuple values = (Tuple) records.get(0);
-            assertEquals("CREATE TABLE tblspace1.test23(k1 string not null,s1 string not null,n1 integer,PRIMARY KEY(k1,n1),INDEX ixn1s1(n1,s1))", values.get("tabledef").toString());
+            assertEquals("CREATE TABLE tblspace1.test23(k1 string not null,s1 string not null,n1 integer,PRIMARY KEY(k1,n1),INDEX ixn1s1(n1,s1),UNIQUE KEY ixn1s2 (n1,s1,k1))", values.get("tabledef").toString());
 
             // Drop the table and indexes and recreate them again.
             String showCreateCommandOutput = values.get("tabledef").toString();

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBDatabaseMetadata.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBDatabaseMetadata.java
@@ -1180,7 +1180,7 @@ public class HerdDBDatabaseMetadata implements DatabaseMetaData {
     public ResultSet getIndexInfo(String catalog, String schema, String tableNamePattern, boolean onlyUnique, boolean approximate) throws SQLException {
         String query = "SELECT * FROM SYSINDEXCOLUMNS";
         if (tableNamePattern != null && !tableNamePattern.isEmpty()) {
-            query = query + " WHERE table_name LIKE '" + SQLUtils.escape(tableNamePattern) + "'";
+            query = query + " WHERE lower(table_name) LIKE '" + SQLUtils.escape(tableNamePattern.toLowerCase()) + "'";
         }
         try (Statement statement = con.createStatement();
              ResultSet rs = statement.executeQuery(query)) {

--- a/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
@@ -66,6 +66,7 @@ public class SystemTablesTest {
                      Statement statement = con.createStatement()) {
                     statement.execute("CREATE TABLE mytable (key string primary key, name string)");
                     statement.execute("CREATE INDEX mytableindex ON mytable(name)");
+                    statement.execute("CREATE UNIQUE INDEX mytableindex2 ON mytable(name, key)");
                     statement.execute("CREATE TABLE mytable2 (n2 int primary key auto_increment, name string not null, ts timestamp)");
                     statement.execute("CREATE TABLE mytable3 (n2 int primary key auto_increment, age int not null default 99, phone long not null, salary double, married bool)");
 
@@ -185,9 +186,15 @@ public class SystemTablesTest {
                                 String value = rs.getString(i + 1);
                                 record.add(value);
                             }
+                            if (rs.getString("INDEX_NAME").equals("mytableindex2")) {
+                                assertFalse(rs.getBoolean("NON_UNIQUE"));
+                            }
+                            if (rs.getString("INDEX_NAME").equals("mytableindex")) {
+                                assertTrue(rs.getBoolean("NON_UNIQUE"));
+                            }
                             records.add(record);
                         }
-                        assertEquals(2, records.size()); // pk + secondary index
+                        assertEquals(4, records.size()); // pk + secondary indexed
                     }
 
                     try (ResultSet rs = metaData.getPrimaryKeys(null, null, "mytable")) {
@@ -215,7 +222,7 @@ public class SystemTablesTest {
                             }
                             records.add(record);
                         }
-                        assertEquals(1, records.size()); // only pk
+                        assertEquals(3, records.size()); // only pk + 1 unique index with two columns
                     }
 
                     try (ResultSet rs = metaData.getIndexInfo(null, null, null, true, false)) {
@@ -229,7 +236,7 @@ public class SystemTablesTest {
                             records.add(record);
                         }
                         // this is to be incremented at every new systable
-                        assertEquals(22, records.size());
+                        assertEquals(24, records.size());
                     }
                     try (ResultSet rs = metaData.getSchemas()) {
                         List<List<String>> records = new ArrayList<>();

--- a/herddb-utils/src/main/java/herddb/utils/CompareBytesUtils.java
+++ b/herddb-utils/src/main/java/herddb/utils/CompareBytesUtils.java
@@ -22,19 +22,12 @@ package herddb.utils;
 
 import io.netty.util.internal.PlatformDependent;
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Java 8 compatibile version. In Java 8 you cannot use Arrays.compare(byte[],
  * byte[])
  */
 public final class CompareBytesUtils {
-
-    private static final Logger LOG = Logger.getLogger(CompareBytesUtils.class.getName());
-
-    static {
-        LOG.info("Not Using Arrays#compare(byte[], byte[]). Using legacy pure-Java implementation, use JDK10 in order to get best performances");
-    }
 
     private CompareBytesUtils() {
     }

--- a/herddb-utils/src/main/java/herddb/utils/LocalLockManager.java
+++ b/herddb-utils/src/main/java/herddb/utils/LocalLockManager.java
@@ -109,12 +109,12 @@ public class LocalLockManager implements ILocalLockManager {
         try {
             long tryWriteLock = lock.lock.tryWriteLock(writeLockTimeout, TimeUnit.SECONDS);
             if (tryWriteLock == 0) {
-                throw new RuntimeException("timed out acquiring lock for write");
+                throw new LockAcquireTimeoutException("timed out acquiring lock for write");
             }
             return new LockHandle(tryWriteLock, key, true, lock);
         } catch (InterruptedException err) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException(err);
+            throw new LockAcquireTimeoutException(err);
         }
     }
 
@@ -132,12 +132,12 @@ public class LocalLockManager implements ILocalLockManager {
         try {
             long tryReadLock = lock.lock.tryReadLock(readLockTimeout, TimeUnit.SECONDS);
             if (tryReadLock == 0) {
-                throw new RuntimeException("timedout trying to read lock");
+                throw new LockAcquireTimeoutException("timedout trying to read lock");
             }
             return new LockHandle(tryReadLock, key, false, lock);
         } catch (InterruptedException err) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException(err);
+            throw new LockAcquireTimeoutException(err);
         }
     }
 

--- a/herddb-utils/src/main/java/herddb/utils/LockAcquireTimeoutException.java
+++ b/herddb-utils/src/main/java/herddb/utils/LockAcquireTimeoutException.java
@@ -24,7 +24,7 @@ import herddb.core.HerdDBInternalException;
 /**
  * Timeout.
  */
-public class LockAcquireTimeoutException extends HerdDBInternalException {  
+public final class LockAcquireTimeoutException extends HerdDBInternalException {
 
     public LockAcquireTimeoutException(String message) {
         super(message);
@@ -37,5 +37,5 @@ public class LockAcquireTimeoutException extends HerdDBInternalException {
     public LockAcquireTimeoutException(Throwable cause) {
         super(cause);
     }
-    
+
 }

--- a/herddb-utils/src/main/java/herddb/utils/LockAcquireTimeoutException.java
+++ b/herddb-utils/src/main/java/herddb/utils/LockAcquireTimeoutException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.utils;
+
+import herddb.core.HerdDBInternalException;
+
+/**
+ * Timeout.
+ */
+public class LockAcquireTimeoutException extends HerdDBInternalException {  
+
+    public LockAcquireTimeoutException(String message) {
+        super(message);
+    }
+
+    public LockAcquireTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LockAcquireTimeoutException(Throwable cause) {
+        super(cause);
+    }
+    
+}

--- a/herddb-utils/src/main/java10/herddb/utils/CompareBytesUtils.java
+++ b/herddb-utils/src/main/java10/herddb/utils/CompareBytesUtils.java
@@ -21,19 +21,12 @@
 package herddb.utils;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Java 9 compatibile version. Use Arrays.compare(byte[], byte[]) which leverage
  * HotSpot intrisicts
  */
 public final class CompareBytesUtils {
-
-    private static final Logger LOG = Logger.getLogger(CompareBytesUtils.class.getName());
-
-    static {
-        LOG.info("Using Arrays#compare(byte[], byte[]), available from JDK10+");
-    }
 
     private CompareBytesUtils() {
     }


### PR DESCRIPTION
- Introduce UNIQUE indexes
- introduce Lock management (with and without transaction)
- Support HashIndexManager and BRINIndexManager (all secondary index types)
- introduce LockAcquireTimeoutException for better testing
- introduce UniqueIndexContraintViolationException (in the future the error will be propagated to the client, as DuplicatePrimaryKeyException)
- implement CREATE UNIQUE INDEX
- implement "CREATE TABLE .... column type UNIQUE" (single column inline unique constraint)
- implement "CREATE TABLE........ UNIQUE KEY name(col1,col2)" (multi column mysql syntax, unfortunately 'unique index' is not supported by jSQLParser for CREATE TABLE)
- implement SHOW CREATE TABLE WITH INDEXES
- report "unique" in sysindexes system table
- add test cases for JDBC Metadata (already working without changes! because it used SYSINDEXCOLUMNS that already reported unique/non unique columns)
- report "unique" in sysindexes system table
- add hammer tests

