### PR TITLE
Bypass Auth in 'local' mode

### DIFF
--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -103,12 +103,17 @@ public class RoutedClientSideConnection implements ChannelEventListener {
     }
 
     private void performAuthentication(Channel channel, String serverHostname) throws Exception {
-
         SaslNettyClient saslNettyClient = new SaslNettyClient(
                 connection.getClient().getConfiguration().getString(ClientConfiguration.PROPERTY_CLIENT_USERNAME, ClientConfiguration.PROPERTY_CLIENT_USERNAME_DEFAULT),
                 connection.getClient().getConfiguration().getString(ClientConfiguration.PROPERTY_CLIENT_PASSWORD, ClientConfiguration.PROPERTY_CLIENT_PASSWORD_DEFAULT),
                 serverHostname
         );
+
+        // no need to perform auth in "local" mode
+        String mode = connection.getClient().getConfiguration().getString(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_STANDALONE);
+        if (ClientConfiguration.PROPERTY_MODE_LOCAL.equals(mode) && channel.isLocalChannel()) {
+            return;
+        }
 
         byte[] firstToken = new byte[0];
         if (saslNettyClient.hasInitialResponse()) {

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -24,6 +24,7 @@ import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_BEGIN_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_COMMIT_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_ROLLBACK_TRANSACTION;
 import herddb.backup.DumpedLogEntry;
+import herddb.client.ClientConfiguration;
 import herddb.codec.RecordSerializer;
 import herddb.core.HerdDBInternalException;
 import herddb.core.RunningStatementInfo;
@@ -116,6 +117,12 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         this.server = server;
         this.address = channel.getRemoteAddress();
         this.preparedStatements = server.getManager().getPreparedStatementsCache();
+        // no need to perform auth in "local" mode
+        boolean localMode = ServerConfiguration.PROPERTY_MODE_LOCAL.equals(server.getManager().getMode());
+        if (localMode && channel.isLocalChannel()) {
+            authenticated = true;
+            username = ClientConfiguration.PROPERTY_CLIENT_USERNAME_DEFAULT;
+        }
     }
 
     @Override


### PR DESCRIPTION
In "local" mode there is no need to perform authentication, it is only a burden.
Let's bypass it when we are using a "local" (in-JVM) channel and we are running in "local" mode