### PR TITLE
Introduce REPEATABLE_READ isolation level and default to READ_COMMITTED

### DIFF
--- a/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
+++ b/herddb-collections/src/main/java/herddb/collections/TmpMapImpl.java
@@ -72,7 +72,7 @@ class TmpMapImpl<K, V> implements TmpMap<K, V> {
         private final V value;
 
         public PutStatementEvaluationContext(K key, V value) {
-            super(false);
+            super(false, false);
             this.key = key;
             this.value = value;
         }

--- a/herddb-core/src/main/java/herddb/client/HDBConnection.java
+++ b/herddb-core/src/main/java/herddb/client/HDBConnection.java
@@ -114,7 +114,8 @@ public class HDBConnection implements AutoCloseable {
                                 + "where tablespace_name=?", false,
                         Arrays.asList(tableSpace), TransactionContext.NOTRANSACTION_ID,
                         1,
-                        1)) {
+                        1,
+                        false)) {
                     boolean ok = result.hasNext();
                     if (ok) {
                         LOGGER.log(Level.INFO, "table space {0} is up now: info {1}", new Object[]{tableSpace,
@@ -334,7 +335,7 @@ public class HDBConnection implements AutoCloseable {
         throw new HDBException("client is closed");
     }
 
-    public ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize) throws ClientSideMetadataProviderException, HDBException, InterruptedException {
+    public ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize, boolean keepReadLocks) throws ClientSideMetadataProviderException, HDBException, InterruptedException {
         if (discoverTablespaceFromSql) {
             tableSpace = discoverTablespace(tableSpace, query);
         }
@@ -342,7 +343,7 @@ public class HDBConnection implements AutoCloseable {
         while (!closed) {
             try {
                 RoutedClientSideConnection route = getRouteToTableSpace(tableSpace);
-                return route.executeScan(tableSpace, query, usePreparedStatement, params, tx, maxRows, fetchSize);
+                return route.executeScan(tableSpace, query, usePreparedStatement, params, tx, maxRows, fetchSize, keepReadLocks);
             } catch (RetryRequestException retry) {
                 LOGGER.log(Level.INFO, "temporary error", retry);
                 handleRetryError(retry, trialCount++);

--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -701,7 +701,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize) throws HDBException, ClientSideMetadataProviderException {
+    ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize,
+                              boolean keepReadLocks) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         Pdu reply = null;
         try {
@@ -710,7 +711,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             long statementId = usePreparedStatement ? prepareQuery(tableSpace, query) : 0;
             query = statementId > 0 ? "" : query;
             ByteBuf message = PduCodec.OpenScanner.write(requestId, tableSpace, query, scannerId, tx, params, statementId,
-                    fetchSize, maxRows);
+                    fetchSize, maxRows, keepReadLocks);
             LOGGER.log(Level.FINEST, "open scanner {0} for query {1}, params {2}", new Object[]{scannerId, query, params});
             reply = channel.sendMessageWithPduReply(requestId, message, timeout);
 

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3589,7 +3589,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 if (record != null) {
                     // use current transaction version of the record
                     if (predicate == null || predicate.evaluate(record, context)) {
-                        keep_lock = context.isForceRetainReadLock() || lock.write;
+                        keep_lock = context.isForceRetainReadLock() || (lock != null && lock.write);
                         return record;
                     }
                     return null;
@@ -3610,7 +3610,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 Record record = fetchRecord(key, pageId, lastPageRead);
                 if (record != null && (pkFilterCompleteMatch || predicate == null || predicate.evaluate(record, context))) {
 
-                    keep_lock = context.isForceRetainReadLock() || lock.write;
+                    keep_lock = context.isForceRetainReadLock() || (lock != null && lock.write);
                     return record;
                 }
             }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3589,7 +3589,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 if (record != null) {
                     // use current transaction version of the record
                     if (predicate == null || predicate.evaluate(record, context)) {
-                        keep_lock = context.isForceRetainReadLock();
+                        keep_lock = context.isForceRetainReadLock() || lock.write;
                         return record;
                     }
                     return null;
@@ -3610,7 +3610,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 Record record = fetchRecord(key, pageId, lastPageRead);
                 if (record != null && (pkFilterCompleteMatch || predicate == null || predicate.evaluate(record, context))) {
 
-                    keep_lock = context.isForceRetainReadLock();
+                    keep_lock = context.isForceRetainReadLock() || lock.write;
                     return record;
                 }
             }

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -640,7 +640,8 @@ public class TableSpaceManager {
             TransactionContext transactionContext, boolean lockRequired, boolean forWrite
     ) throws StatementExecutionException {
         boolean rollbackOnError = false;
-        if (transactionContext.transactionId == TransactionContext.AUTOTRANSACTION_ID) {
+        if (transactionContext.transactionId == TransactionContext.AUTOTRANSACTION_ID
+                && (lockRequired || forWrite || context.isForceAcquireWriteLock() || context.isForceRetainReadLock())) {
             try {
                 // sync on beginTransaction
                 StatementExecutionResult newTransaction = Futures.result(beginTransactionAsync(context, true));

--- a/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
+++ b/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
@@ -51,6 +51,9 @@ public class StatementEvaluationContext {
     public static StatementEvaluationContext DEFAULT_EVALUATION_CONTEXT() {
         return new StatementEvaluationContext(false, false);
     }
+    public static StatementEvaluationContext DEFAULT_EVALUATION_CONTEXT_KEEP_READ_LOCKS() {
+        return new StatementEvaluationContext(false, true);
+    }
     // CHECKSTYLE.ON: MethodName
 
     protected StatementEvaluationContext(boolean forceAcquireWriteLock,  boolean forceRetainReadLock) {

--- a/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
+++ b/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
@@ -42,18 +42,21 @@ public class StatementEvaluationContext {
     private String defaultTablespace = TableSpace.DEFAULT;
     private volatile long tableSpaceLock;
     private static final ZoneId timezone = ZoneId.systemDefault();
+    // REPEATABLE READ
+    private final boolean forceRetainReadLock;
+    // SELECT ... FOR UPDATE
     private final boolean forceAcquireWriteLock;
 
     // CHECKSTYLE.OFF: MethodName
     public static StatementEvaluationContext DEFAULT_EVALUATION_CONTEXT() {
-        return new StatementEvaluationContext(false);
+        return new StatementEvaluationContext(false, false);
     }
     // CHECKSTYLE.ON: MethodName
 
-    protected StatementEvaluationContext(boolean forceAcquireWriteLock) {
+    protected StatementEvaluationContext(boolean forceAcquireWriteLock,  boolean forceRetainReadLock) {
         this.forceAcquireWriteLock = forceAcquireWriteLock;
+        this.forceRetainReadLock = forceRetainReadLock;
     }
-
 
     public String getDefaultTablespace() {
         return defaultTablespace;
@@ -115,6 +118,10 @@ public class StatementEvaluationContext {
 
     public boolean isForceAcquireWriteLock() {
         return forceAcquireWriteLock;
+    }
+
+    public boolean isForceRetainReadLock() {
+        return forceRetainReadLock;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
+++ b/herddb-core/src/main/java/herddb/model/StatementEvaluationContext.java
@@ -43,7 +43,7 @@ public class StatementEvaluationContext {
     private volatile long tableSpaceLock;
     private static final ZoneId timezone = ZoneId.systemDefault();
     // REPEATABLE READ
-    private final boolean forceRetainReadLock;
+    private boolean forceRetainReadLock;
     // SELECT ... FOR UPDATE
     private final boolean forceAcquireWriteLock;
 
@@ -122,6 +122,10 @@ public class StatementEvaluationContext {
 
     public boolean isForceRetainReadLock() {
         return forceRetainReadLock;
+    }
+
+    public void setForceRetainReadLock(boolean forceRetainReadLock) {
+        this.forceRetainReadLock = forceRetainReadLock;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -269,7 +269,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
         if (allowCache) {
             ExecutionPlan cached = cache.get(cacheKey);
             if (cached != null) {
-                return new TranslatedQuery(cached, new SQLStatementEvaluationContext(query, parameters, forceAcquireWriteLock));
+                return new TranslatedQuery(cached, new SQLStatementEvaluationContext(query, parameters, forceAcquireWriteLock, false));
             }
         }
 
@@ -323,7 +323,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
                         new SQLPlannedOperationStatement(values),
                         values
                 );
-                return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, forceAcquireWriteLock));
+                return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false, false));
             }
 
             if (query.startsWith("SHOW")) {
@@ -357,7 +357,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
                     if (allowCache) {
                         cache.put(cacheKey, executionPlan);
                     }
-                    return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, forceAcquireWriteLock));
+                    return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, forceAcquireWriteLock, false));
                 }
             }
             if (maxRows > 0) {
@@ -376,7 +376,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             if (allowCache) {
                 cache.put(cacheKey, executionPlan);
             }
-            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, forceAcquireWriteLock));
+            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, forceAcquireWriteLock, false));
         } catch (CalciteContextException ex) {
             LOG.log(Level.INFO, "Error while parsing '" + ex.getOriginalStatement() + "'", ex);
             //TODO can this be done better ?
@@ -446,7 +446,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
                     new SQLPlannedOperationStatement(values),
                     values
             );
-            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false));
+            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false, false));
         } else {
             throw new StatementExecutionException(String.format("Incorrect Syntax for SHOW CREATE TABLE tablespace.tablename"));
         }

--- a/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/DDLSQLPlanner.java
@@ -233,16 +233,16 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
         if (allowCache) {
             ExecutionPlan cached = cache.get(cacheKey);
             if (cached != null) {
-                return new TranslatedQuery(cached, new SQLStatementEvaluationContext(query, parameters, false));
+                return new TranslatedQuery(cached, new SQLStatementEvaluationContext(query, parameters, false, false));
             }
         }
         if (query.startsWith(CalcitePlanner.TABLE_CONSISTENCY_COMMAND)) {
             ExecutionPlan executionPlan = ExecutionPlan.simple(DDLSQLPlanner.this.queryConsistencyCheckStatement(defaultTableSpace, query, parameters));
-            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false));
+            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false, false));
         }
         if (query.startsWith(CalcitePlanner.TABLESPACE_CONSISTENCY_COMMAND)) {
             ExecutionPlan executionPlan = ExecutionPlan.simple(DDLSQLPlanner.this.queryConsistencyCheckStatement(query));
-            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false));
+            return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false, false));
         }
 
         net.sf.jsqlparser.statement.Statement stmt = parseStatement(query);
@@ -253,7 +253,7 @@ public class DDLSQLPlanner implements AbstractSQLPlanner {
         if (allowCache) {
             cache.put(cacheKey, executionPlan);
         }
-        return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false));
+        return new TranslatedQuery(executionPlan, new SQLStatementEvaluationContext(query, parameters, false, false));
 
     }
 

--- a/herddb-core/src/main/java/herddb/sql/SQLStatementEvaluationContext.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLStatementEvaluationContext.java
@@ -42,8 +42,8 @@ public class SQLStatementEvaluationContext extends StatementEvaluationContext {
         return jdbcParameters;
     }
 
-    public SQLStatementEvaluationContext(String query, List<Object> jdbcParameters, boolean forceAcquireWriteLock) {
-        super(forceAcquireWriteLock);
+    public SQLStatementEvaluationContext(String query, List<Object> jdbcParameters, boolean forceAcquireWriteLock, boolean forceRetainReadLock) {
+        super(forceAcquireWriteLock, forceRetainReadLock);
         this.query = query;
         this.jdbcParameters = jdbcParameters;
         final int len = jdbcParameters.size();

--- a/herddb-core/src/test/java/herddb/cluster/BackupRestoreTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/BackupRestoreTest.java
@@ -128,7 +128,7 @@ public class BackupRestoreTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     ByteArrayOutputStream oo = new ByteArrayOutputStream();
                     BackupUtils.dumpTableSpace(TableSpace.DEFAULT, 64 * 1024, connection, oo, new ProgressListener() {
@@ -137,12 +137,12 @@ public class BackupRestoreTest {
 
                     connection.executeUpdate(TableSpace.DEFAULT, "DELETE FROM t1", 0, false, true, Collections.emptyList());
 
-                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     BackupUtils.restoreTableSpace("newts", server_2.getNodeId(), connection, new ByteArrayInputStream(backupData), new ProgressListener() {
                     });
 
-                    assertEquals(4, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(4, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     assertEquals(1, server_2.getManager().getTableSpaceManager("newts").getIndexesOnTable("t1").size());
                 }
@@ -221,7 +221,7 @@ public class BackupRestoreTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     ByteArrayOutputStream oo = new ByteArrayOutputStream();
                     BackupUtils.dumpTableSpace(TableSpace.DEFAULT, 64 * 1024, connection, oo, new ProgressListener() {
@@ -230,13 +230,13 @@ public class BackupRestoreTest {
 
                     connection.executeUpdate(TableSpace.DEFAULT, "DELETE FROM t1", 0, false, true, Collections.emptyList());
 
-                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     BackupUtils.restoreTableSpace("newts", server_2.getNodeId(), connection, new ByteArrayInputStream(backupData), new ProgressListener() {
                     });
 
                     /* No new insert AND no delete... if 5 it did see the new insert but missed the delete! */
-                    assertEquals(4, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(4, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
                 }
 
             }
@@ -315,7 +315,7 @@ public class BackupRestoreTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    assertEquals(5, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(5, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     ByteArrayOutputStream oo = new ByteArrayOutputStream();
                     BackupUtils.dumpTableSpace(TableSpace.DEFAULT, 64 * 1024, connection, oo, new ProgressListener() {
@@ -324,13 +324,13 @@ public class BackupRestoreTest {
 
                     connection.executeUpdate(TableSpace.DEFAULT, "DELETE FROM t1", 0, false, true, Collections.emptyList());
 
-                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     BackupUtils.restoreTableSpace("newts", server_2.getNodeId(), connection, new ByteArrayInputStream(backupData), new ProgressListener() {
                     });
 
                     /* No new insert AND no delete... if 5 it did see the new insert but missed the delete! */
-                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
                 }
 
             }
@@ -393,7 +393,7 @@ public class BackupRestoreTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     ByteArrayOutputStream oo = new ByteArrayOutputStream();
                     BackupUtils.dumpTableSpace(TableSpace.DEFAULT, 64 * 1024, connection, oo, new ProgressListener() {
@@ -416,12 +416,12 @@ public class BackupRestoreTest {
 
                     connection.executeUpdate(TableSpace.DEFAULT, "DELETE FROM t1", 0, false, true, Collections.emptyList());
 
-                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     BackupUtils.restoreTableSpace("newts", server_2.getNodeId(), connection, new ByteArrayInputStream(backupData), new ProgressListener() {
                     });
 
-                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     assertEquals(1, server_2.getManager().getTableSpaceManager("newts").getIndexesOnTable("t1").size());
 
@@ -489,7 +489,7 @@ public class BackupRestoreTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     ByteArrayOutputStream oo = new ByteArrayOutputStream();
                     BackupUtils.dumpTableSpace(TableSpace.DEFAULT, 64 * 1024, connection, oo, new ProgressListener() {
@@ -513,12 +513,12 @@ public class BackupRestoreTest {
 
                     connection.executeUpdate(TableSpace.DEFAULT, "DELETE FROM t1", 0, false, true, Collections.emptyList());
 
-                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     BackupUtils.restoreTableSpace("newts", server_2.getNodeId(), connection, new ByteArrayInputStream(backupData), new ProgressListener() {
                     });
 
-                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     assertEquals(1, server_2.getManager().getTableSpaceManager("newts").getIndexesOnTable("t1").size());
 
@@ -584,7 +584,7 @@ public class BackupRestoreTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(4, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     ByteArrayOutputStream oo = new ByteArrayOutputStream();
                     BackupUtils.dumpTableSpace(TableSpace.DEFAULT, 64 * 1024, connection, oo, new ProgressListener() {
@@ -609,12 +609,12 @@ public class BackupRestoreTest {
 
                     connection.executeUpdate(TableSpace.DEFAULT, "DELETE FROM t1", 0, false, true, Collections.emptyList());
 
-                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     BackupUtils.restoreTableSpace("newts", server_2.getNodeId(), connection, new ByteArrayInputStream(backupData), new ProgressListener() {
                     });
 
-                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                    assertEquals(5, connection.executeScan("newts", "SELECT * FROM newts.t1", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                     assertEquals(1, server_2.getManager().getTableSpaceManager("newts").getIndexesOnTable("t1").size());
 

--- a/herddb-core/src/test/java/herddb/cluster/ExpectedReplicaCountTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ExpectedReplicaCountTest.java
@@ -144,6 +144,9 @@ public class ExpectedReplicaCountTest {
 
                     // the TableSpaceManager will roll a new ledger
                     herddb.utils.TestUtils.waitForCondition(() -> {
+                        if (log.getWriter() == null) {
+                            return false;
+                        }
                         long newLedgerId = log.getWriter().getLedgerId();
                         return newLedgerId != currentLedgerId;
                     }, herddb.utils.TestUtils.NOOP, 100);

--- a/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
@@ -158,7 +158,7 @@ public class RetryOnLeaderChangedTest {
 
                         // use client2, so that it opens a connection to current leader
                         try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1",
-                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0)) {
+                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0, true)) {
                             assertEquals(3, scan.consume().size());
                         }
 
@@ -167,7 +167,7 @@ public class RetryOnLeaderChangedTest {
 
                         // perform operation
                         try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1",
-                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0)) {
+                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0, true)) {
                             assertEquals(3, scan.consume().size());
                         }
                         // check the client handled "not leader error"
@@ -245,7 +245,7 @@ public class RetryOnLeaderChangedTest {
         testKillLeader((connection) -> {
             try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT,
                     "SELECT * FROM ttt.t1", false, Collections.emptyList(),
-                    TransactionContext.NOTRANSACTION_ID, 0, 0)) {
+                    TransactionContext.NOTRANSACTION_ID, 0, 0, true)) {
                 assertEquals(3, scan.consume().size());
             } catch (Exception err) {
                 throw new RuntimeException(err);
@@ -373,7 +373,7 @@ public class RetryOnLeaderChangedTest {
 
                         // use client2, so that it opens a connection to current leader
                         try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM ttt.t1",
-                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0)) {
+                                false, Collections.emptyList(), TransactionContext.NOTRANSACTION_ID, 0, 0, true)) {
                             assertEquals(3, scan.consume().size());
                         }
 

--- a/herddb-core/src/test/java/herddb/core/AutoTransactionTest.java
+++ b/herddb-core/src/test/java/herddb/core/AutoTransactionTest.java
@@ -160,10 +160,15 @@ public class AutoTransactionTest extends BaseTestcase {
         try (DataScanner scan = manager.scan(new ScanStatement(tableSpace, tableName, Projection.IDENTITY(table.columnNames, table.getColumns()), null, null, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.AUTOTRANSACTION_TRANSACTION)) {
             tx = scan.getTransactionId();
             assertEquals(1, scan.consume().size());
+            assertEquals(0, tx);
+        }
+
+        try (DataScanner scan = manager.scan(new ScanStatement(tableSpace, tableName, Projection.IDENTITY(table.columnNames, table.getColumns()), null, null, null), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT_KEEP_READ_LOCKS(), TransactionContext.AUTOTRANSACTION_TRANSACTION)) {
+            tx = scan.getTransactionId();
+            assertEquals(1, scan.consume().size());
         }
 
         TestUtils.commitTransaction(manager, tableSpace, tx);
-
     }
 
     @Test

--- a/herddb-core/src/test/java/herddb/core/CheckpointTest.java
+++ b/herddb-core/src/test/java/herddb/core/CheckpointTest.java
@@ -22,7 +22,7 @@ package herddb.core;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.executeUpdate;
-import static herddb.core.TestUtils.scan;
+import static herddb.core.TestUtils.scanKeepReadLocks;
 import static herddb.model.TransactionContext.NO_TRANSACTION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -805,7 +805,7 @@ public class CheckpointTest {
 
             err = herddb.utils.TestUtils.expectThrows(herddb.model.StatementExecutionException.class, () -> {
                 // this select in a transaction will timeout, write lock is already held by the transaction
-                scan(manager, "SELECT * FROM tblspace1.tsql where k1=?",
+                scanKeepReadLocks(manager, "SELECT * FROM tblspace1.tsql",
                         Arrays.asList("mykey"), TransactionContext.AUTOTRANSACTION_TRANSACTION);
             });
             assertEquals("timedout trying to read lock", err.getCause().getMessage());

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -285,8 +285,8 @@ public class RawSQLTest {
 
              // GET .. -> NO READ LOCK BY DEFAULT
             {
-                long tx;
-                try (DataScanner scan = scan(manager, "SELECT k1,n1 FROM tblspace1.tsql where k1='a'", Collections.emptyList(), TransactionContext.AUTOTRANSACTION_TRANSACTION)) {
+                long tx = TestUtils.beginTransaction(manager, "tblspace1");
+                try (DataScanner scan = scan(manager, "SELECT k1,n1 FROM tblspace1.tsql where k1='a'", Collections.emptyList(), new TransactionContext(tx))) {
                     assertEquals(1, scan.consume().size());
                     tx = scan.getTransactionId();
                 }
@@ -332,8 +332,8 @@ public class RawSQLTest {
 
             // SCAN .. -> NO READ LOCK by default
             {
-                long tx;
-                try (DataScanner scan = scan(manager, "SELECT k1,n1 FROM tblspace1.tsql ", Collections.emptyList(), TransactionContext.AUTOTRANSACTION_TRANSACTION)) {
+                long tx = TestUtils.beginTransaction(manager, "tblspace1");
+                try (DataScanner scan = scan(manager, "SELECT k1,n1 FROM tblspace1.tsql ", Collections.emptyList(), new TransactionContext(tx))) {
                     assertEquals(1, scan.consume().size());
                     tx = scan.getTransactionId();
                 }

--- a/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
+++ b/herddb-core/src/test/java/herddb/core/SimpleJoinTest.java
@@ -84,6 +84,7 @@ public class SimpleJoinTest {
                     + " JOIN tblspace1.table2 t2"
                     + " ON t1.n1 > 0"
                     + "   and t2.n2 >= 1", Collections.emptyList(), true, true, false, -1);
+                translated.context.setForceRetainReadLock(true);
                 assertThat(translated.plan.originalRoot, instanceOf(NestedLoopJoinOp.class));
                 NestedLoopJoinOp join = (NestedLoopJoinOp) translated.plan.originalRoot;
                 assertThat(join.getLeft(), instanceOf(SimpleScanOp.class));

--- a/herddb-core/src/test/java/herddb/core/TestUtils.java
+++ b/herddb-core/src/test/java/herddb/core/TestUtils.java
@@ -80,6 +80,12 @@ public class TestUtils {
         return ((ScanResult) manager.executePlan(translated.plan, translated.context, transactionContext)).dataScanner;
     }
 
+    public static DataScanner scanKeepReadLocks(DBManager manager, String query, List<Object> parameters, TransactionContext transactionContext) throws StatementExecutionException {
+        TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, query, parameters, true, true, false, -1);
+        translated.context.setForceRetainReadLock(true);
+        return ((ScanResult) manager.executePlan(translated.plan, translated.context, transactionContext)).dataScanner;
+    }
+
     public static DataScanner scan(DBManager manager, String query, List<Object> parameters, int maxRows, TransactionContext transactionContext) throws StatementExecutionException {
         TranslatedQuery translated = manager.getPlanner().translate(TableSpace.DEFAULT, query, parameters, true, true, false, maxRows);
         return ((ScanResult) manager.executePlan(translated.plan, translated.context, transactionContext)).dataScanner;

--- a/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
@@ -149,7 +149,7 @@ public class ClientMultiServerTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
 
@@ -189,7 +189,7 @@ public class ClientMultiServerTest {
                     }
 
                     // the client MUST automatically look for the new leader
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
 
@@ -207,13 +207,13 @@ public class ClientMultiServerTest {
 
                     });
                     // with prepare statement
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         fail("server_1 MUST not accept queries");
                     } catch (ClientSideMetadataProviderException ok) {
                          assertTrue(ok.getCause() instanceof LeaderChangedException);
                     }
                     // without prepare statement
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", false, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", false, Collections.emptyList(), 0, 0, 10, true)) {
                         fail("server_1 MUST not accept queries");
                     } catch (ClientSideMetadataProviderException ok) {
                          assertTrue(ok.getCause() instanceof LeaderChangedException);
@@ -239,7 +239,7 @@ public class ClientMultiServerTest {
                 try (HDBClient client_to_2 = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
                      HDBConnection connection = client_to_2.openConnection()) {
                     client_to_2.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server_2));
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
                 }
@@ -309,7 +309,7 @@ public class ClientMultiServerTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
                     // switch leader to server2
@@ -328,7 +328,7 @@ public class ClientMultiServerTest {
                     assertTrue(tManager != null && !tManager.isLeader());
 
                     // the client MUST automatically look for the new leader
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
 
@@ -345,7 +345,7 @@ public class ClientMultiServerTest {
                         }
 
                     });
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         fail("server_1 MUST not accept queries");
                     } catch (ClientSideMetadataProviderException ok) {
                          assertTrue(ok.getCause() instanceof LeaderChangedException);
@@ -356,7 +356,7 @@ public class ClientMultiServerTest {
                 try (HDBClient client_to_2 = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
                      HDBConnection connection = client_to_2.openConnection()) {
                     client_to_2.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server_2));
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
                 }

--- a/herddb-core/src/test/java/herddb/server/EmbeddedBookieTest.java
+++ b/herddb-core/src/test/java/herddb/server/EmbeddedBookieTest.java
@@ -139,7 +139,7 @@ public class EmbeddedBookieTest {
                 try (HDBClient client = new HDBClient(client_configuration);
                      HDBConnection connection = client.openConnection()) {
 
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
                     // switch leader to server2
@@ -158,7 +158,7 @@ public class EmbeddedBookieTest {
                     assertTrue(tManager != null && !tManager.isLeader());
 
                     // the client MUST automatically look for the new leader
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
 
@@ -175,7 +175,7 @@ public class EmbeddedBookieTest {
                         }
 
                     });
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         fail("server_1 MUST not accept queries");
                     } catch (ClientSideMetadataProviderException ok) {
                         assertTrue(ok.getCause() instanceof LeaderChangedException);
@@ -186,7 +186,7 @@ public class EmbeddedBookieTest {
                 try (HDBClient client_to_2 = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()));
                      HDBConnection connection = client_to_2.openConnection()) {
                     client_to_2.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server_2));
-                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10)) {
+                    try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM t1 WHERE c=1", true, Collections.emptyList(), 0, 0, 10, true)) {
                         assertEquals(1, scan.consume().size());
                     }
                 }

--- a/herddb-core/src/test/java/herddb/server/HistoryChangelogTest.java
+++ b/herddb-core/src/test/java/herddb/server/HistoryChangelogTest.java
@@ -198,7 +198,7 @@ public class HistoryChangelogTest {
                         if (doneElements.contains(entry.getKey())) {
                             ScanResultSet res = connection.executeScan(TableSpace.DEFAULT, "SELECT id, status, hid, (SELECT MAX(hid) as mm  from history where history.id=mytable.id) as maxhid "
                                             + "FROM mytable where id=?", true, Arrays.asList(entry.getKey()),
-                                    TransactionContext.NOTRANSACTION_ID, -1, 10000);
+                                    TransactionContext.NOTRANSACTION_ID, -1, 10000, true);
                             List<Map<String, Object>> consume = res.consume();
                             assertEquals(1, consume.size());
                             Map<String, Object> data = consume.get(0);
@@ -236,7 +236,7 @@ public class HistoryChangelogTest {
                     if (doneElements.contains(entry.getKey())) {
                         ScanResultSet res = connection.executeScan(TableSpace.DEFAULT, "SELECT id, status, hid, (SELECT MAX(hid) as mm  from history where history.id=mytable.id) as maxhid "
                                         + "FROM mytable where id=?", true, Arrays.asList(entry.getKey()),
-                                TransactionContext.NOTRANSACTION_ID, -1, 10000);
+                                TransactionContext.NOTRANSACTION_ID, -1, 10000, true);
                         List<Map<String, Object>> consume = res.consume();
                         assertEquals(1, consume.size());
                         Map<String, Object> data = consume.get(0);

--- a/herddb-core/src/test/java/herddb/server/SimpleClientScanDiscoverTableSpaceTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientScanDiscoverTableSpaceTest.java
@@ -61,19 +61,19 @@ public class SimpleClientScanDiscoverTableSpaceTest {
                     Assert.assertEquals(1, connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO foo.mytable (id,n1,n2) values(?,?,?)", 0, false, true, Arrays.asList("test_" + i, 1, 2)).updateCount);
                 }
 
-                assertEquals(99, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(99, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                 // maxRows
-                assertEquals(17, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable", true, Collections.emptyList(), 0, 17, 10).consume().size());
+                assertEquals(17, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable", true, Collections.emptyList(), 0, 17, 10, true).consume().size());
 
                 // empty result set
-                assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable WHERE id='none'", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable WHERE id='none'", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                 // single fetch result test
-                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable WHERE id='test_1'", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM foo.mytable WHERE id='test_1'", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                 // single fetch result test
-                assertEquals(1, connection.executeScan("foo", "SELECT * FROM mytable WHERE id='test_1'", true, Collections.emptyList(), 0, 0, 10).consume().size());
+                assertEquals(1, connection.executeScan("foo", "SELECT * FROM mytable WHERE id='test_1'", true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
             }
         }

--- a/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientScanTest.java
@@ -69,30 +69,30 @@ public class SimpleClientScanTest {
                 }
 
                 assertEquals(99, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
-                        emptyList(), 0, 0, 10).consume().size());
+                        emptyList(), 0, 0, 10, true).consume().size());
 
                 // maxRows
                 assertEquals(17, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
-                        emptyList(), 0, 17, 10).consume().size());
+                        emptyList(), 0, 17, 10, true).consume().size());
 
                 // empty result set
                 assertEquals(0, connection.
                         executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='none'", true, Collections.
-                                emptyList(), 0, 0, 10).consume().size());
+                                emptyList(), 0, 0, 10, true).consume().size());
 
                 // single fetch result test
                 assertEquals(1, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id='test_1'",
-                        true, Collections.emptyList(), 0, 0, 10).consume().size());
+                        true, Collections.emptyList(), 0, 0, 10, true).consume().size());
 
                 // agregation in transaction, this is trickier than what you can think
                 long tx = connection.beginTransaction(TableSpace.DEFAULT);
                 assertEquals(1, connection.executeScan(TableSpace.DEFAULT,
-                        "SELECT count(*) FROM mytable WHERE id='test_1'", true, Collections.emptyList(), tx, 0, 10).
+                        "SELECT count(*) FROM mytable WHERE id='test_1'", true, Collections.emptyList(), tx, 0, 10, true).
                         consume().size());
                 connection.rollbackTransaction(TableSpace.DEFAULT, tx);
 
                 assertEquals(0, connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable WHERE id=?", true,
-                        Arrays.<Object>asList((Object) null), 0, 0, 10).consume().size());
+                        Arrays.<Object>asList((Object) null), 0, 0, 10, true).consume().size());
 
             }
         }
@@ -176,7 +176,7 @@ public class SimpleClientScanTest {
                 ServerSideConnectionPeer peerWithScanner = null;
                 long tx = withTransaction ? primary.beginTransaction(TableSpace.DEFAULT) : 0;
                 try (ScanResultSet scan = connection2.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true,
-                        Collections.emptyList(), tx, 0, 1)) {
+                        Collections.emptyList(), tx, 0, 1, true)) {
                     assertTrue(scan.hasNext());
                     System.out.println("next:" + scan.next());
 
@@ -214,7 +214,7 @@ public class SimpleClientScanTest {
         // scan with fetchSize = 1, we will have 100 chunks
         ServerSideConnectionPeer peerWithScanner = null;
         try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
-                emptyList(), 0, 0, 1)) {
+                emptyList(), 0, 0, 1, true)) {
             while (scan.hasNext()) {
                 System.out.println("next:" + scan.next());
 
@@ -243,7 +243,7 @@ public class SimpleClientScanTest {
         ServerSideConnectionPeer peerWithScanner = null;
         int chunks = 0;
         try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT, "SELECT * FROM mytable", true, Collections.
-                emptyList(), tx, 0, 1)) {
+                emptyList(), tx, 0, 1, true)) {
 
             while (scan.hasNext()) {
                 System.out.println("next:" + scan.next());
@@ -284,7 +284,7 @@ public class SimpleClientScanTest {
                 "SELECT count(*) FROM mytable "
                 + "UNION ALL "
                 + "SELECT count(*) FROM mytable", true, Collections.emptyList(), tx,
-                0, 1)) {
+                0, 1, true)) {
 
             assertTrue(scan.hasNext());
             System.out.println("next:" + scan.next());

--- a/herddb-core/src/test/java/herddb/server/SimpleClientServerAutoTransactionTest.java
+++ b/herddb-core/src/test/java/herddb/server/SimpleClientServerAutoTransactionTest.java
@@ -84,7 +84,7 @@ public class SimpleClientServerAutoTransactionTest {
 
                 connection.commitTransaction(TableSpace.DEFAULT, tx);
 
-                try (ScanResultSet scan = connection.executeScan(server.getManager().getVirtualTableSpaceId(), "SELECT * FROM sysconfig", true, Collections.emptyList(), 0, 0, 10)) {
+                try (ScanResultSet scan = connection.executeScan(server.getManager().getVirtualTableSpaceId(), "SELECT * FROM sysconfig", true, Collections.emptyList(), 0, 0, 10, true)) {
                     List<Map<String, Object>> all = scan.consume();
                     for (Map<String, Object> aa : all) {
                         RawString name = (RawString) aa.get("name");
@@ -94,7 +94,7 @@ public class SimpleClientServerAutoTransactionTest {
                     }
                 }
 
-                try (ScanResultSet scan = connection.executeScan(null, "SELECT * FROM " + server.getManager().getVirtualTableSpaceId() + ".sysclients", true, Collections.emptyList(), 0, 0, 10)) {
+                try (ScanResultSet scan = connection.executeScan(null, "SELECT * FROM " + server.getManager().getVirtualTableSpaceId() + ".sysclients", true, Collections.emptyList(), 0, 0, 10, true)) {
                     List<Map<String, Object>> all = scan.consume();
                     for (Map<String, Object> aa : all) {
                         assertEquals(RawString.of("jvm-local"), aa.get("address"));

--- a/herddb-core/src/test/java/herddb/server/UseVirtualTableSpaceIdWithZookKeeperTest.java
+++ b/herddb-core/src/test/java/herddb/server/UseVirtualTableSpaceIdWithZookKeeperTest.java
@@ -133,17 +133,17 @@ public class UseVirtualTableSpaceIdWithZookKeeperTest {
                     client.setClientSideMetadataProvider(new ZookeeperClientSideMetadataProvider(testEnv.getAddress(),
                             testEnv.getTimeout(), testEnv.getPath()));
                     try (ScanResultSet scan = connection.executeScan(null,
-                            "SELECT * FROM " + server_1.getManager().getVirtualTableSpaceId() + ".sysnodes", true, Collections.emptyList(), 0, 0, 10)) {
+                            "SELECT * FROM " + server_1.getManager().getVirtualTableSpaceId() + ".sysnodes", true, Collections.emptyList(), 0, 0, 10, true)) {
                         List<Map<String, Object>> all = scan.consume();
                         assertEquals(2, all.size());
                     }
                     try (ScanResultSet scan = connection.executeScan(null,
-                            "SELECT * FROM " + server_2.getManager().getVirtualTableSpaceId() + ".sysnodes", true, Collections.emptyList(), 0, 0, 10)) {
+                            "SELECT * FROM " + server_2.getManager().getVirtualTableSpaceId() + ".sysnodes", true, Collections.emptyList(), 0, 0, 10, true)) {
                         List<Map<String, Object>> all = scan.consume();
                         assertEquals(2, all.size());
                     }
                     try (ScanResultSet scan = connection.executeScan(TableSpace.DEFAULT,
-                            "SELECT * FROM sysnodes", true, Collections.emptyList(), 0, 0, 10)) {
+                            "SELECT * FROM sysnodes", true, Collections.emptyList(), 0, 0, 10, true)) {
                         List<Map<String, Object>> all = scan.consume();
                         assertEquals(2, all.size());
                     }

--- a/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuite.java
+++ b/herddb-core/src/test/java/herddb/server/hammer/DirectMultipleConcurrentUpdatesSuite.java
@@ -137,7 +137,7 @@ public abstract class DirectMultipleConcurrentUpdatesSuite {
                                                                   }
                                                               } else {
                                                                   gets.incrementAndGet();
-                                                                  DataScanner res = TestUtils.scan(manager,
+                                                                  DataScanner res = TestUtils.scanKeepReadLocks(manager,
                                                                           "SELECT * FROM mytable where id=?", Arrays.asList("test_" + k),
                                                                           new TransactionContext(useTransactions ? TransactionContext.AUTOTRANSACTION_ID : TransactionContext.NOTRANSACTION_ID));
                                                                   if (!res.hasNext()) {

--- a/herddb-core/src/test/java/herddb/sql/SQLRecordPredicateTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SQLRecordPredicateTest.java
@@ -76,7 +76,7 @@ public class SQLRecordPredicateTest {
 
                 assertTrue(pred.getWhere() != null && (pred.getWhere() instanceof CompiledSQLExpression));
 
-                StatementEvaluationContext ctx = new SQLStatementEvaluationContext("the-query", Arrays.asList("my-string"), false);
+                StatementEvaluationContext ctx = new SQLStatementEvaluationContext("the-query", Arrays.asList("my-string"), false, false);
 
                 Record record = RecordSerializer.makeRecord(table, "pk", "test", "name", "myname");
                 assertEquals(Boolean.TRUE, pred.evaluate(record, ctx));

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBConnection.java
@@ -472,4 +472,9 @@ public class HerdDBConnection implements java.sql.Connection {
     boolean isKeepReadLocks() {
         return transactionIsolation == Connection.TRANSACTION_REPEATABLE_READ;
     }
+
+    long getTransactionId() {
+        return transactionId;
+    }
+
 }

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBPreparedStatement.java
@@ -79,7 +79,7 @@ public class HerdDBPreparedStatement extends HerdDBStatement implements Prepared
             parent.discoverTableSpace(sql);
             ScanResultSet scanResult = this.parent.getConnection()
                     .executeScan(parent.getTableSpace(), sql, true, parameters, parent.ensureTransaction(), maxRows,
-                            fetchSize);
+                            fetchSize, parent.isKeepReadLocks());
             this.parent.bindToTransaction(scanResult.transactionId);
             return lastResultSet = new HerdDBResultSet(scanResult, this);
         } catch (ClientSideMetadataProviderException | HDBException | InterruptedException ex) {

--- a/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBStatement.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/HerdDBStatement.java
@@ -74,7 +74,7 @@ public class HerdDBStatement implements java.sql.Statement {
             parent.discoverTableSpace(sql);
             ScanResultSet scanResult = this.parent.getConnection()
                     .executeScan(parent.getTableSpace(), sql, false, Collections.emptyList(), parent.ensureTransaction(),
-                            maxRows, fetchSize);
+                            maxRows, fetchSize, parent.isKeepReadLocks());
             parent.bindToTransaction(scanResult.transactionId);
             return lastResultSet = new HerdDBResultSet(scanResult, this);
         } catch (ClientSideMetadataProviderException | HDBException | InterruptedException ex) {

--- a/herddb-jdbc/src/test/java/herddb/jdbc/SimpleScanTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/SimpleScanTest.java
@@ -259,7 +259,11 @@ public class SimpleScanTest {
                     try (Connection con = dataSource.getConnection()) {
                         con.setAutoCommit(false);
                         Transaction tx;
-                        try (PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable ")) {
+                        try (Statement s = con.createStatement()) {
+                            // force the creation of the transaction, by issuing a DML command
+                            s.executeUpdate("UPDATE mytable set n1=1 where k1 ='aaa'");
+                        }
+                        try (PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable")) {
                             statement.setFetchSize(1);
                             ResultSet rs = statement.executeQuery();
                             assertTrue(rs.next());
@@ -278,7 +282,11 @@ public class SimpleScanTest {
                     Transaction tx;
                     try (Connection con = dataSource.getConnection()) {
                         con.setAutoCommit(false);
-                        PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable ");
+                        try (Statement s = con.createStatement()) {
+                            // force the creation of the transaction, by issuing a DML command
+                            s.executeUpdate("UPDATE mytable set n1=1 where k1 ='aaa'");
+                        }
+                        PreparedStatement statement = con.prepareStatement("SELECT n1, k1 FROM mytable");
                         statement.setFetchSize(1);
                         ResultSet rs = statement.executeQuery();
                         assertTrue(rs.next());

--- a/herddb-jdbc/src/test/java/herddb/jdbc/TransactionIsolationTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/TransactionIsolationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import herddb.client.ClientConfiguration;
+import herddb.model.TableSpace;
+import herddb.model.Transaction;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.utils.Bytes;
+import herddb.utils.LockHandle;
+import java.sql.Connection;
+import java.sql.Statement;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Basic client testing about setTransactionIsolation
+ *
+ * @author enrico.olivelli
+ */
+public class TransactionIsolationTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+
+        try (HerdDBEmbeddedDataSource dataSource = new HerdDBEmbeddedDataSource()) {
+
+            dataSource.getProperties().setProperty(ServerConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
+            dataSource.getProperties().setProperty(ClientConfiguration.PROPERTY_BASEDIR, folder.newFolder().getAbsolutePath());
+            try (Connection con = dataSource.getConnection();
+                    Statement statement = con.createStatement()) {
+                statement.execute("CREATE TABLE mytable (key string primary key, name string)");
+
+            }
+            Server server = dataSource.getServer();
+            try (Connection con = dataSource.getConnection();
+                    Statement statement = con.createStatement()) {
+                assertEquals(1, statement.executeUpdate("INSERT INTO mytable (key,name) values('k1','name1')"));
+
+                assertEquals(Connection.TRANSACTION_READ_COMMITTED, con.getTransactionIsolation());
+                assertEquals(TableSpace.DEFAULT, con.getSchema());
+                assertTrue(con.getAutoCommit());
+
+                con.setAutoCommit(false);
+
+                {
+                    HerdDBConnection hCon = (HerdDBConnection) con;
+                    assertEquals(0, hCon.getTransactionId());
+
+                    statement.executeQuery("SELECT * FROM mytable").close();
+                    long tx = hCon.getTransactionId();
+
+                    Transaction transaction = server.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTransaction(tx);
+
+                    // in TRANSACTION_READ_COMMITTED no lock is to be retained
+                    assertTrue(transaction.locks.get("mytable").isEmpty());
+
+                    con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+                    statement.executeQuery("SELECT * FROM mytable").close();
+
+                    LockHandle lock = transaction.lookupLock("mytable", Bytes.from_string("k1"));
+                    assertFalse(lock.write);
+
+                    statement.executeQuery("SELECT * FROM mytable FOR UPDATE").close();
+                    lock = transaction.lookupLock("mytable", Bytes.from_string("k1"));
+                    assertTrue(lock.write);
+
+                    con.rollback();
+                    assertNull(server.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTransaction(tx));
+                }
+
+                // test SELECT ... FOR UPDATE
+                {
+                    HerdDBConnection hCon = (HerdDBConnection) con;
+                    assertEquals(0, hCon.getTransactionId());
+                    con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+
+                    statement.executeQuery("SELECT * FROM mytable FOR UPDATE").close();
+                    long tx = hCon.getTransactionId();
+                    Transaction transaction = server.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTransaction(tx);
+                    LockHandle lock = transaction.lookupLock("mytable", Bytes.from_string("k1"));
+                    assertTrue(lock.write);
+
+                    con.rollback();
+                    assertNull(server.getManager().getTableSpaceManager(TableSpace.DEFAULT).getTransaction(tx));
+                }
+
+            }
+
+        }
+    }
+
+}

--- a/herddb-services/src/test/java/herddb/server/SimpleClusterTest.java
+++ b/herddb-services/src/test/java/herddb/server/SimpleClusterTest.java
@@ -79,7 +79,7 @@ public class SimpleClusterTest {
                         new ZookeeperClientSideMetadataProvider(zookeeperServer.getConnectString(), 40000, "/herddb")
                 );
                 try (HDBConnection con = client.openConnection()) {
-                    try (ScanResultSet scan = con.executeScan(TableSpace.DEFAULT, "SELECT * FROM SYSTABLES", false, Collections.emptyList(), 0, 10, 10);) {
+                    try (ScanResultSet scan = con.executeScan(TableSpace.DEFAULT, "SELECT * FROM SYSTABLES", false, Collections.emptyList(), 0, 10, 10, false);) {
                         scan.consume();
                     }
                 }

--- a/herddb-services/src/test/java/herddb/server/SimpleServerTest.java
+++ b/herddb-services/src/test/java/herddb/server/SimpleServerTest.java
@@ -77,7 +77,7 @@ public class SimpleServerTest {
                         new StaticClientSideMetadataProvider(ServerMain.getRunningInstance().getServer()
                         ));
                 try (HDBConnection con = client.openConnection()) {
-                    try (ScanResultSet scan = con.executeScan(TableSpace.DEFAULT, "SELECT * FROM SYSTABLES", false, Collections.emptyList(), 0, 10, 10);) {
+                    try (ScanResultSet scan = con.executeScan(TableSpace.DEFAULT, "SELECT * FROM SYSTABLES", false, Collections.emptyList(), 0, 10, 10, false);) {
                         scan.consume();
                     }
                 }

--- a/herddb-utils/src/main/java/herddb/proto/Pdu.java
+++ b/herddb-utils/src/main/java/herddb/proto/Pdu.java
@@ -62,6 +62,8 @@ public class Pdu implements AutoCloseable {
 
     public static final byte FLAGS_ISREQUEST = 1;
     public static final byte FLAGS_ISRESPONSE = 2;
+    public static final byte FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS = 4;
+
 
     private static final Recycler<Pdu> RECYCLER = new Recycler<Pdu>() {
         @Override
@@ -90,11 +92,11 @@ public class Pdu implements AutoCloseable {
     public long messageId;
 
     public boolean isRequest() {
-        return (flags | FLAGS_ISREQUEST) == FLAGS_ISREQUEST;
+        return (flags & FLAGS_ISREQUEST) == FLAGS_ISREQUEST;
     }
 
     public boolean isResponse() {
-        return (flags | FLAGS_ISRESPONSE) == FLAGS_ISRESPONSE;
+        return (flags & FLAGS_ISRESPONSE) == FLAGS_ISRESPONSE;
     }
 
     @Override


### PR DESCRIPTION
Since the beginning we always held 'read' lock in Transaction, in order to prevent modifications to a record 'SELECTED' within the context of a transaction.
This is far too restrictive than standard READ_COMMITTED isolation level.

This patch introduces the support for REPEATABLE_READ transaction isolation.
With REPEATABLE_READ the behavior is the same same as in 0.19.0 with READ_COMMITTED
With READ_COMMITTED (the default) each transaction won't keep the 'read' lock for each record

Results:
- "SELECT * FROM table" won't hold a lock for each record, saving lots of resources
- we will be nearer the expected behavior for SQL/JDBC

Motivation:
MagNews, that works with H2,SQLServer,Oracle and PostGRE assumes standard behavior and it is not able to work properly with the current behavior of HerdDB.

The patch also introduces an optimization regarding auto creation of transactions: if you do not have to keep read locks than it is useless to begin a transaction with a SELECT .... query, so we are going to postpone the creation of the transaction only at the first statemement that needs locks.

Notice:
This patch introduces a modification in the wire protocol, that in theory should be 100% compatible, but there is a bug in the server side processing of "Pdu#flags" field that actually makes it impossible to implement such 100% compatible change.
We will have to decide what to do before accepting this patch