### PR TITLE
Do not start callback threads for client in local mode

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -207,7 +207,7 @@ public class ClientConfiguration {
                     set(PROPERTY_SERVER_PORT, 0);
                 }
             }
-            set(PROPERTY_CLIENT_CALLBACKS, 4);
+            set(PROPERTY_CLIENT_CALLBACKS, 0);
             set(PROPERTY_MAX_CONNECTIONS_PER_SERVER, 1);
             set(PROPERTY_CLIENT_CONNECT_REMOTE_SERVER, false);
         }

--- a/herddb-core/src/test/java/herddb/client/SimpleLocalModeTest.java
+++ b/herddb-core/src/test/java/herddb/client/SimpleLocalModeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.client;
+
+import static org.junit.Assert.assertTrue;
+import herddb.model.TableSpace;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.server.StaticClientSideMetadataProvider;
+import herddb.utils.RawString;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Basic server/client local mode boot test
+ *
+ * @author enrico.olivelli
+ */
+public class SimpleLocalModeTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+        Path baseDir = folder.newFolder().toPath();
+        try (Server server = new Server(new ServerConfiguration(baseDir)
+                .set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_LOCAL))) {
+            server.start();
+            server.waitForStandaloneBoot();
+            ClientConfiguration clientConfiguration = new ClientConfiguration(folder.newFolder().toPath())
+                    .set(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_LOCAL);
+            try (HDBClient client = new HDBClient(clientConfiguration);
+                    HDBConnection connection = client.openConnection()) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+
+                assertTrue(connection.waitForTableSpace(TableSpace.DEFAULT, Integer.MAX_VALUE));
+
+                long resultCreateTable = connection.executeUpdate(TableSpace.DEFAULT,
+                        "CREATE TABLE mytable (id string primary key, n1 long, n2 integer)", 0, false, true,
+                        Collections.emptyList()).updateCount;
+                Assert.assertEquals(1, resultCreateTable);
+
+                long tx = connection.beginTransaction(TableSpace.DEFAULT);
+                long countInsert = connection.executeUpdate(TableSpace.DEFAULT,
+                        "INSERT INTO mytable (id,n1,n2) values(?,?,?),(?,?,?)", tx, false, true, Arrays.asList("test", 1, 2, "test2", 2, 3)).updateCount;
+                Assert.assertEquals(2, countInsert);
+
+                GetResult res = connection.executeGet(TableSpace.DEFAULT,
+                        "SELECT * FROM mytable WHERE id='test'", tx, true, Collections.emptyList());
+                Map<RawString, Object> record = res.data;
+                Assert.assertNotNull(record);
+
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The client callback threads are pretty useless in "local" mode, let's drop them by default