### PR TITLE
JDBC: Do not depend on Netty Epool and Commons Pool2

### DIFF
--- a/herddb-jdbc/pom.xml
+++ b/herddb-jdbc/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
@@ -172,57 +172,61 @@
                                     <exclude>com.google.protobuf:*</exclude>
                                     <exclude>org.apache.bookkeeper:*</exclude>
                                     <exclude>org.apache.zookeeper:*</exclude>
-                                    <exclude>commons-configuration:*</exclude>                                                                        
-                                    <exclude>org.bouncycastle:*</exclude>                                    
-                                    <exclude>net.java.dev.jna:*</exclude>                                    
+                                    <exclude>commons-configuration:*</exclude>
+                                    <exclude>org.bouncycastle:*</exclude>
+                                    <exclude>net.java.dev.jna:*</exclude>
                                     <exclude>org.apache.httpcomponents</exclude>
                                     <exclude>org.jctools:*</exclude>
                                     <exclude>net.jpountz.lz4:*</exclude>
+                                    <exclude>io.netty:netty-transport-native-unix-common:*</exclude>
+                                    <exclude>io.netty:netty-transport-native-epoll:*</exclude>
+                                    <exclude>io.netty:netty-tcnative-boringssl-static:*</exclude>
+                                    <exclude>org.apache.commons:commons-pool2:*</exclude>
                                 </excludes>
-                            </artifactSet>                            
+                            </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache</pattern>
-                                    <shadedPattern>herddb.org.apache</shadedPattern>                                    
+                                    <shadedPattern>herddb.org.apache</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>io.netty</pattern>
-                                    <shadedPattern>herddb.io.netty</shadedPattern>                                    
+                                    <shadedPattern>herddb.io.netty</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.fasterxml</pattern>
-                                    <shadedPattern>herddb.com.fasterxml</shadedPattern>                                    
-                                </relocation>                               
+                                    <shadedPattern>herddb.com.fasterxml</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>com.google</pattern>
-                                    <shadedPattern>herddb.com.google</shadedPattern>                                    
+                                    <shadedPattern>herddb.com.google</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.slf4j</pattern>
-                                    <shadedPattern>herddb.org.slf4j</shadedPattern>                                    
+                                    <shadedPattern>herddb.org.slf4j</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>net.jcp</pattern>
-                                    <shadedPattern>herddb.net.jcp</shadedPattern>                                    
+                                    <shadedPattern>herddb.net.jcp</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>net.sf.jsqlparser</pattern>
-                                    <shadedPattern>herddb.net.sf.jsqlparser</shadedPattern>                                    
+                                    <shadedPattern>herddb.net.sf.jsqlparser</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>net.jpountz</pattern>
-                                    <shadedPattern>herddb.net.jpountz</shadedPattern>                                    
-                                </relocation>   
+                                    <shadedPattern>herddb.net.jpountz</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <!-- Calcite stuff -->
                                     <pattern>com.jayway.jsonpath</pattern>
-                                    <shadedPattern>herddb.com.jayway.jsonpath</shadedPattern>                                    
-                                </relocation>                      
-                                
+                                    <shadedPattern>herddb.com.jayway.jsonpath</shadedPattern>
+                                </relocation>
+
                                 <!-- Cannot relocate org.codehaus.commons.compiler stuff, needed by Calcite
                                     <relocation>
                                     <pattern>org.codehaus</pattern>
-                                    <shadedPattern>herddb.org.codehaus</shadedPattern>                                    
+                                    <shadedPattern>herddb.org.codehaus</shadedPattern>
                                 </relocation> -->
                             </relocations>
                             <transformers>
@@ -238,7 +242,7 @@
                                     <excludes>
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>                                        
+                                        <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/herddb-jdbc/pom.xml
+++ b/herddb-jdbc/pom.xml
@@ -63,6 +63,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/herddb-jdbc/src/main/java/herddb/jdbc/ConnectionsPoolRuntime.java
+++ b/herddb-jdbc/src/main/java/herddb/jdbc/ConnectionsPoolRuntime.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.jdbc;
+
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+/**
+ * This class holds all references to Commons Pool2, in order
+ * to not have hard links to Commons2 in the pure JDBC Driver.
+ */
+class ConnectionsPoolRuntime {
+
+    private final BasicHerdDBDataSource parent;
+    private final GenericObjectPool<HerdDBConnection> pool;
+
+    public ConnectionsPoolRuntime(BasicHerdDBDataSource parent) {
+        this.parent = parent;
+        GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+        config.setBlockWhenExhausted(true);
+        int maxActive = parent.getMaxActive();
+        config.setMaxTotal(parent.getMaxActive());
+        config.setMaxIdle(maxActive);
+        config.setMinIdle(maxActive / 2);
+        config.setJmxNamePrefix("HerdDBClient");
+        pool = new GenericObjectPool<>(new ConnectionsFactory(), config);
+    }
+
+    HerdDBConnection borrowObject() throws Exception {
+        return pool.borrowObject();
+    }
+
+    void returnObject(HerdDBConnection connection) {
+        pool.returnObject(connection);
+    }
+
+    private final class ConnectionsFactory implements PooledObjectFactory<HerdDBConnection> {
+
+        @Override
+        public PooledObject<HerdDBConnection> makeObject() throws Exception {
+            HerdDBConnection res = parent.makeConnection();
+            return new DefaultPooledObject<>(res);
+        }
+
+        @Override
+        public void destroyObject(PooledObject<HerdDBConnection> po) throws Exception {
+            po.getObject().close();
+        }
+
+        @Override
+        public boolean validateObject(PooledObject<HerdDBConnection> po) {
+            return true;
+        }
+
+        @Override
+        public void activateObject(PooledObject<HerdDBConnection> po) throws Exception {
+            po.getObject().reset(parent.getDefaultSchema());
+        }
+
+        @Override
+        public void passivateObject(PooledObject<HerdDBConnection> po) throws Exception {
+        }
+
+    }
+
+}

--- a/herddb-net/pom.xml
+++ b/herddb-net/pom.xml
@@ -49,10 +49,6 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Changes:
- Use reflection and other classloading trick in order to not depend at runtime on Netty Epool and Commons Pool2
- Remove slf4j-jdk14 dependency (it should have been marked as 'test' scope)

JDBC Driver will work even with:
- netty epoll (it does not always bring performance improvements)
- commons pool2 (no need for pure JDBC Driver, connection pool is made by third party datasources)
- netty-codec (useless)
- netty tcboring-ssl (no need for "local" development or if you do not need TLS)

Motivation:
We want to shrink the JDBC driver Jar as much as possible

