### PR TITLE
Implement simple SQL commands with jSQLParser (experimental)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ jobs:
   include:
   - stage: test
     jdk: openjdk11
-    script: mvn checkstyle:check verify -Pjenkins -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false jacoco:report coveralls:report spotbugs:check apache-rat:check
+    script: mvn checkstyle:check verify spotbugs:check apache-rat:check -Pjenkins -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false jacoco:report coveralls:report
   - stage: test-jsqlparser
     jdk: openjdk11
-    script: mvn checkstyle:check verify -Pjenkins -Dherdddb.defaultplannertype=jsqlparser -Dherddb.planner.allowfallbacktocalcite=false -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false jacoco:report coveralls:report spotbugs:check apache-rat:check
+    script: mvn checkstyle:check verify -Pjenkins -Dherdddb.defaultplannertype=jsqlparser -Dherddb.planner.allowfallbacktocalcite=false -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false -Dmaven.test.failure.ignore=true
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ jobs:
   - stage: test
     jdk: openjdk11
     script: mvn checkstyle:check verify -Pjenkins -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false jacoco:report coveralls:report spotbugs:check apache-rat:check
+  - stage: test-jsqlparser
+    jdk: openjdk11
+    script: mvn checkstyle:check verify -Pjenkins -Dherdddb.defaultplannertype=jsqlparser -Dherddb.planner.allowfallbacktocalcite=false -Dmaven.test.redirectTestOutputToFile=true -Dherddb.file.requirefsync=false jacoco:report coveralls:report spotbugs:check apache-rat:check
 
 branches:
   only:

--- a/herddb-core/pom.xml
+++ b/herddb-core/pom.xml
@@ -55,18 +55,18 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper-jute</artifactId>
         </dependency>
-        <dependency>     
-            <!-- needed for ZK server -->       
+        <dependency>
+            <!-- needed for ZK server -->
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>     
-            <!-- needed for ZK server -->       
+        <dependency>
+            <!-- needed for ZK server -->
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <scope>test</scope>
-        </dependency>         
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -132,6 +132,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- we are using these features, even without using Calcite planner -->
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-linq4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -604,6 +604,7 @@ public final class RecordSerializer {
 
     private static final ZoneId UTC = ZoneId.of("UTC");
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(UTC);
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER_WITH_MILLIS = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S").withZone(UTC);
 
     public static DateTimeFormatter getUTCTimestampFormatter() {
         return TIMESTAMP_FORMATTER;
@@ -618,8 +619,13 @@ public final class RecordSerializer {
                 } else if (value instanceof RawString
                         || value instanceof String) {
                     try {
-
-                        ZonedDateTime dateTime = ZonedDateTime.parse(value.toString(), TIMESTAMP_FORMATTER);
+                        String asString = value.toString();
+                        ZonedDateTime dateTime;
+                        try {
+                            dateTime = ZonedDateTime.parse(asString, TIMESTAMP_FORMATTER);
+                        } catch (DateTimeParseException tryAgain) {
+                            dateTime = ZonedDateTime.parse(asString, TIMESTAMP_FORMATTER_WITH_MILLIS);
+                        }
                         Instant toInstant = dateTime.toInstant();
                         long millis = (toInstant.toEpochMilli());
                         Timestamp timestamp = new java.sql.Timestamp(millis);

--- a/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
+++ b/herddb-core/src/main/java/herddb/codec/RecordSerializer.java
@@ -42,6 +42,7 @@ import herddb.utils.VisibleByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -605,6 +606,7 @@ public final class RecordSerializer {
     private static final ZoneId UTC = ZoneId.of("UTC");
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(UTC);
     private static final DateTimeFormatter TIMESTAMP_FORMATTER_WITH_MILLIS = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S").withZone(UTC);
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER_ONLY_DATE = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(UTC);
 
     public static DateTimeFormatter getUTCTimestampFormatter() {
         return TIMESTAMP_FORMATTER;
@@ -624,7 +626,11 @@ public final class RecordSerializer {
                         try {
                             dateTime = ZonedDateTime.parse(asString, TIMESTAMP_FORMATTER);
                         } catch (DateTimeParseException tryAgain) {
-                            dateTime = ZonedDateTime.parse(asString, TIMESTAMP_FORMATTER_WITH_MILLIS);
+                            try {
+                                dateTime = ZonedDateTime.parse(asString, TIMESTAMP_FORMATTER_WITH_MILLIS);
+                            } catch (DateTimeParseException again) {
+                                dateTime = LocalDate.parse(asString, TIMESTAMP_FORMATTER_ONLY_DATE).atStartOfDay(UTC);
+                            }
                         }
                         Instant toInstant = dateTime.toInstant();
                         long millis = (toInstant.toEpochMilli());

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -73,7 +73,9 @@ import herddb.server.ServerConfiguration;
 import herddb.server.ServerSidePreparedStatementCache;
 import herddb.sql.AbstractSQLPlanner;
 import herddb.sql.CalcitePlanner;
+import herddb.sql.DDLSQLPlanner;
 import herddb.sql.NullSQLPlanner;
+import herddb.sql.PlansCache;
 import herddb.storage.DataStorageManager;
 import herddb.storage.DataStorageManagerException;
 import herddb.utils.DefaultJVMHalt;
@@ -221,6 +223,9 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         switch (plannerType) {
             case ServerConfiguration.PLANNER_TYPE_CALCITE:
                 planner = new CalcitePlanner(this, planCacheMem);
+                break;
+            case ServerConfiguration.PLANNER_TYPE_JSQLPARSER:
+                planner = new DDLSQLPlanner(this, new PlansCache(planCacheMem), new CalcitePlanner(this, planCacheMem));
                 break;
             case ServerConfiguration.PLANNER_TYPE_NONE:
                 planner = new NullSQLPlanner();

--- a/herddb-core/src/main/java/herddb/model/FullTableScanPredicate.java
+++ b/herddb-core/src/main/java/herddb/model/FullTableScanPredicate.java
@@ -32,4 +32,9 @@ public class FullTableScanPredicate extends Predicate {
         return true;
     }
 
+    @Override
+    public String toString() {
+        return "FullTableScan";
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
@@ -31,6 +31,7 @@ import herddb.model.TableAwareStatement;
 import herddb.model.TupleComparator;
 import herddb.model.planner.SortOp;
 import herddb.utils.ObjectSizeUtils;
+import java.util.Arrays;
 
 /**
  * Lookup a bunch record with a condition
@@ -116,10 +117,11 @@ public class ScanStatement extends TableAwareStatement {
                 comparatorString = comparator.toString();
             }
         }
+        String schema = Arrays.toString(getSchema());
         if (limits != null) {
-            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparatorString + ",limits=" + limits.toStringForScan() + '}';
+            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparatorString + ",limits=" + limits.toStringForScan() + ", schema=" + schema + '}';
         } else {
-            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparatorString + '}';
+            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparatorString + ", schema=" + schema + '}';
         }
     }
 

--- a/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/ScanStatement.java
@@ -20,6 +20,7 @@
 
 package herddb.model.commands;
 
+import herddb.model.Column;
 import herddb.model.Predicate;
 import herddb.model.Projection;
 import herddb.model.ScanLimits;
@@ -28,6 +29,7 @@ import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableAwareStatement;
 import herddb.model.TupleComparator;
+import herddb.model.planner.SortOp;
 import herddb.utils.ObjectSizeUtils;
 
 /**
@@ -106,10 +108,18 @@ public class ScanStatement extends TableAwareStatement {
 
     @Override
     public String toString() {
+        String comparatorString = "";
+        if (comparator != null) {
+            if (comparator instanceof SortOp) {
+                comparatorString = "SortOp";  // prevent recursion
+            } else {
+                comparatorString = comparator.toString();
+            }
+        }
         if (limits != null) {
-            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparator + ",limits=" + limits.toStringForScan() + '}';
+            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparatorString + ",limits=" + limits.toStringForScan() + '}';
         } else {
-            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparator + '}';
+            return "ScanStatement{table=" + table + "," + "predicate=" + predicate + ",comparator=" + comparatorString + '}';
         }
     }
 
@@ -144,5 +154,11 @@ public class ScanStatement extends TableAwareStatement {
         return res;
     }
 
+    public Column[] getSchema() {
+        if (projection != null) {
+            return projection.getColumns();
+        }
+        return tableDef.getColumns();
+    }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -200,6 +200,7 @@ public class AggregateOp implements PlannerOp {
                             values[k++] = cc.getValue();
                         }
                         Tuple tuple = new Tuple(fieldnames, values);
+                        System.out.println("OUTPUT "+tuple.toMap()+" "+Arrays.toString(tuple.getFieldNames())+" "+Arrays.toString(tuple.getValues()));
                         results.add(tuple);
                     }
                     results.writeFinished();
@@ -284,9 +285,9 @@ public class AggregateOp implements PlannerOp {
 
     @Override
     public String toString() {
-        return "AggregateOp{" + "input=" + input + ", fieldnames=" + Arrays.toString(fieldnames)
+        return "AggregateOp{" + "fieldnames=" + Arrays.toString(fieldnames)
                 + ", columns=" + Arrays.toString(columns) + ", aggtypes=" + Arrays.toString(aggtypes)
-                + ", groupedFiledsIndexes=" + groupedFiledsIndexes + ", argLists=" + argLists + '}';
+                + ", groupedFiledsIndexes=" + groupedFiledsIndexes + ", argLists=" + argLists + "\ninput=" + input + '}';
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -200,7 +200,6 @@ public class AggregateOp implements PlannerOp {
                             values[k++] = cc.getValue();
                         }
                         Tuple tuple = new Tuple(fieldnames, values);
-                        System.out.println("OUTPUT "+tuple.toMap()+" "+Arrays.toString(tuple.getFieldNames())+" "+Arrays.toString(tuple.getValues()));
                         results.add(tuple);
                     }
                     results.writeFinished();
@@ -233,13 +232,15 @@ public class AggregateOp implements PlannerOp {
 
         private Group createGroup() throws DataScannerException, StatementExecutionException {
             AggregatedColumnCalculator[] columns = new AggregatedColumnCalculator[aggtypes.length];
+            int firstIndexAggregatedColumn = fieldnames.length - aggtypes.length;
             for (int i = 0; i < aggtypes.length; i++) {
                 String aggtype = aggtypes[i];
 
                 String fieldName = fieldnames[i];
                 List<Integer> argList = argLists.get(i);
                 CompiledSQLExpression param = argList.isEmpty() ? null : new AccessCurrentRowExpression(argList.get(0)); // TODO, multi params ?
-                AggregatedColumnCalculator calculator = BuiltinFunctions.getColumnCalculator(aggtype.toLowerCase(), fieldName, param, context);
+                int type = AggregateOp.this.columns[firstIndexAggregatedColumn + i].type;
+                AggregatedColumnCalculator calculator = BuiltinFunctions.getColumnCalculator(aggtype.toLowerCase(), fieldName, type, param, context);
                 if (calculator == null) {
                     throw new StatementExecutionException("not implemented aggregation type " + aggtype);
                 }

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -66,13 +66,13 @@ public class AggregateOp implements PlannerOp {
             Column[] columns,
             String[] aggtypes,
             List<List<Integer>> argLists,
-            List<Integer> groupedFiledsIndexes
+            List<Integer> groupedFieldsIndexes
     ) {
         this.input = input;
         this.fieldnames = fieldnames;
         this.columns = columns;
         this.aggtypes = aggtypes;
-        this.groupedFiledsIndexes = groupedFiledsIndexes;
+        this.groupedFiledsIndexes = groupedFieldsIndexes;
         this.argLists = argLists;
     }
 
@@ -289,5 +289,9 @@ public class AggregateOp implements PlannerOp {
                 + ", groupedFiledsIndexes=" + groupedFiledsIndexes + ", argLists=" + argLists + '}';
     }
 
+    @Override
+    public Column[] getSchema() {
+        return columns;
+    }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -284,6 +284,10 @@ public class AggregateOp implements PlannerOp {
 
     @Override
     public String toString() {
-        return String.format("AggregateOp {GroupedFieldsIndexes = %d ArgList = %d }", groupedFiledsIndexes.size() , argLists.size());
+        return "AggregateOp{" + "input=" + input + ", fieldnames=" + Arrays.toString(fieldnames)
+                + ", columns=" + Arrays.toString(columns) + ", aggtypes=" + Arrays.toString(aggtypes)
+                + ", groupedFiledsIndexes=" + groupedFiledsIndexes + ", argLists=" + argLists + '}';
     }
+
+
 }

--- a/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/AggregateOp.java
@@ -50,7 +50,7 @@ import java.util.Map;
  *
  * @author eolivelli
  */
-@SuppressFBWarnings(value = "EI_EXPOSE_REP2")
+@SuppressFBWarnings(value = {"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
 public class AggregateOp implements PlannerOp {
 
     private final PlannerOp input;
@@ -292,7 +292,7 @@ public class AggregateOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return columns;
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/DeleteOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/DeleteOp.java
@@ -22,6 +22,7 @@ package herddb.model.planner;
 
 import herddb.codec.RecordSerializer;
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DMLStatement;
 import herddb.model.DMLStatementExecutionResult;
 import herddb.model.DataScanner;
@@ -165,5 +166,10 @@ public class DeleteOp implements PlannerOp {
     @Override
     public String toString() {
         return String.format("DeleteOp {input = %s }", input.toString());
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/DeleteOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/DeleteOp.java
@@ -169,7 +169,7 @@ public class DeleteOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.ScanResult;
@@ -169,5 +170,10 @@ public class FilterOp implements PlannerOp {
     @Override
     public String toString() {
         return String.format("FilterOp {input=[ %s ] condition=[ %s] }", input.toString(), condition.toString());
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return input.getSchema();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/FilterOp.java
@@ -173,7 +173,7 @@ public class FilterOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
-        return input.getSchema();
+    public Column[] getOutputSchema() {
+        return input.getOutputSchema();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/FilteredTableScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/FilteredTableScanOp.java
@@ -85,7 +85,7 @@ public class FilteredTableScanOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return statement.getSchema();
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/FilteredTableScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/FilteredTableScanOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.Predicate;
 import herddb.model.ScanResult;
@@ -82,4 +83,11 @@ public class FilteredTableScanOp implements PlannerOp {
     public boolean isSimpleStatementWrapper() {
         return true;
     }
+
+    @Override
+    public Column[] getSchema() {
+        return statement.getSchema();
+    }
+
+
 }

--- a/herddb-core/src/main/java/herddb/model/planner/InsertOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/InsertOp.java
@@ -208,4 +208,9 @@ public class InsertOp implements PlannerOp {
     public String toString() {
         return new StringBuilder().append("InsertOp=").append(input.toString()).toString();
     }
+
+    @Override
+    public Column[] getSchema() {
+        return new Column[0];
+    }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/InsertOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/InsertOp.java
@@ -210,7 +210,7 @@ public class InsertOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
@@ -46,7 +46,7 @@ import org.apache.calcite.linq4j.function.Predicate2;
  *
  * @author eolivelli
  */
-@SuppressFBWarnings(value = "EI_EXPOSE_REP2")
+@SuppressFBWarnings(value = {"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
 public class JoinOp implements PlannerOp {
 
     private final int[] leftKeys;
@@ -200,7 +200,7 @@ public class JoinOp implements PlannerOp {
 
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return columns;
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
@@ -198,4 +198,10 @@ public class JoinOp implements PlannerOp {
                 + "\nrightKeys=" + Arrays.toString(rightKeys) + ", right=" + right + '}';
     }
 
+
+    @Override
+    public Column[] getSchema() {
+        return columns;
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/model/planner/LimitOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/LimitOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.LimitedDataScanner;
@@ -129,4 +130,8 @@ public class LimitOp implements PlannerOp, ScanLimits {
         return String.format("LimitOp{maxRows = %s}", this.maxRows.toString());
     }
 
+    @Override
+    public Column[] getSchema() {
+        return input.getSchema();
+    }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/LimitOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/LimitOp.java
@@ -131,7 +131,7 @@ public class LimitOp implements PlannerOp, ScanLimits {
     }
 
     @Override
-    public Column[] getSchema() {
-        return input.getSchema();
+    public Column[] getOutputSchema() {
+        return input.getOutputSchema();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/LimitedSortedBindableTableScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/LimitedSortedBindableTableScanOp.java
@@ -20,55 +20,17 @@
 
 package herddb.model.planner;
 
-import herddb.core.TableSpaceManager;
-import herddb.model.DataScanner;
-import herddb.model.ScanResult;
-import herddb.model.StatementEvaluationContext;
-import herddb.model.StatementExecutionException;
-import herddb.model.StatementExecutionResult;
-import herddb.model.TransactionContext;
 import herddb.model.commands.ScanStatement;
-import herddb.utils.Wrapper;
 
 /**
  * LimitedOp + BindableTableScanOp
  *
  * @author eolivelli
  */
-public class LimitedSortedBindableTableScanOp implements PlannerOp {
-
-    final ScanStatement statement;
+public class LimitedSortedBindableTableScanOp extends SimpleScanOp {
 
     public LimitedSortedBindableTableScanOp(ScanStatement scan) {
-        this.statement = scan;
-    }
-
-    @Override
-    public String getTablespace() {
-        return statement.getTableSpace();
-    }
-
-    public ScanStatement getStatement() {
-        return statement;
-    }
-
-    @Override
-    public StatementExecutionResult execute(
-            TableSpaceManager tableSpaceManager,
-            TransactionContext transactionContext,
-            StatementEvaluationContext context, boolean lockRequired, boolean forWrite
-    ) throws StatementExecutionException {
-        DataScanner scan = tableSpaceManager.scan(statement, context, transactionContext, lockRequired, forWrite);
-        return new ScanResult(transactionContext.transactionId, scan);
-    }
-
-    @Override
-    public <T> T unwrap(Class<T> clazz) {
-        T unwrapped = statement.unwrap(clazz);
-        if (unwrapped != null) {
-            return unwrapped;
-        }
-        return Wrapper.unwrap(this, clazz);
+        super(scan);
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/planner/NestedLoopJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/NestedLoopJoinOp.java
@@ -175,4 +175,9 @@ public class NestedLoopJoinOp implements PlannerOp {
         return right;
     }
 
+    @Override
+    public Column[] getSchema() {
+        return columns;
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/model/planner/NestedLoopJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/NestedLoopJoinOp.java
@@ -49,7 +49,7 @@ import org.apache.calcite.rel.core.JoinRelType;
  *
  * @author eolivelli
  */
-@SuppressFBWarnings(value = "EI_EXPOSE_REP2")
+@SuppressFBWarnings(value = {"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
 public class NestedLoopJoinOp implements PlannerOp {
 
     private final PlannerOp left;
@@ -176,7 +176,7 @@ public class NestedLoopJoinOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return columns;
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/PlannerOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/PlannerOp.java
@@ -103,5 +103,5 @@ public interface PlannerOp extends Wrapper {
     /**
      * Return the output schema for the Op.
      */
-    Column[] getSchema();
+    Column[] getOutputSchema();
 }

--- a/herddb-core/src/main/java/herddb/model/planner/PlannerOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/PlannerOp.java
@@ -22,6 +22,7 @@ package herddb.model.planner;
 
 import herddb.core.HerdDBInternalException;
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.model.StatementExecutionResult;
@@ -98,4 +99,9 @@ public interface PlannerOp extends Wrapper {
     default boolean isSimpleStatementWrapper() {
         return false;
     }
+
+    /**
+     * Return the output schema for the Op.
+     */
+    Column[] getSchema();
 }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -174,8 +174,9 @@ public class ProjectOp implements PlannerOp {
 
     @Override
     public PlannerOp optimize() {
-        if (input instanceof TableScanOp) {
-            return new ProjectedTableScanOp(this, (TableScanOp) input);
+        if (input instanceof TableScanOp
+                || input instanceof BindableTableScanOp) {
+            return new ProjectedTableScanOp(this, (SimpleScanOp) input);
         }
         return this;
     }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -225,6 +225,12 @@ public class ProjectOp implements PlannerOp {
         public DataAccessor map(DataAccessor tuple, StatementEvaluationContext context) throws StatementExecutionException {
             return tuple;
         }
+
+        @Override
+        public String toString() {
+            return "IdentityProjection{" + "columns=" + columns + ", fieldNames=" + fieldNames + '}';
+        }
+
     }
 
     @SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -229,7 +229,7 @@ public class ProjectOp implements PlannerOp {
 
         @Override
         public String toString() {
-            return "IdentityProjection{" + "columns=" + columns + ", fieldNames=" + fieldNames + '}';
+            return "IdentityProjection{" + "columns=" + Arrays.toString(columns) + ", fieldNames=" + Arrays.toString(fieldNames) + '}';
         }
 
     }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -383,7 +383,7 @@ public class ProjectOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return projection.getColumns();
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -82,8 +82,8 @@ public class ProjectOp implements PlannerOp {
 
         @Override
         public String toString() {
-            return "BasicProjection{" + "columns=" + Arrays.toString(columns)
-                    + ", fieldNames=" + Arrays.toString(fieldNames) + ", fields=" + fields + '}';
+            return "BasicProjection{fieldNames=" + Arrays.toString(fieldNames) + ", columns=" + Arrays.toString(columns)
+                    + ", fields=" + fields + '}';
         }
 
         @Override
@@ -325,7 +325,7 @@ public class ProjectOp implements PlannerOp {
 
         @Override
         public String toString() {
-            return "ZeroCopyProjection{" + "fieldNames=" + Arrays.toString(fieldNames)
+            return "ZeroCopyProjection{" + "fieldNames=" + Arrays.toString(fieldNames) + ", schema=" + Arrays.toString(columns)
                     + ", zeroCopyProjections=" + Arrays.toString(zeroCopyProjections) + '}';
         }
 

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -174,9 +174,12 @@ public class ProjectOp implements PlannerOp {
 
     @Override
     public PlannerOp optimize() {
-        if (input instanceof TableScanOp
-                || input instanceof BindableTableScanOp) {
-            return new ProjectedTableScanOp(this, (SimpleScanOp) input);
+        if (input instanceof TableScanOp) {
+            // this simplification works only with TableScanOp
+            // and not with for instance BindableTableScanOp
+            // because we are going to push the projection into the
+            // ScanStatement
+            return new ProjectedTableScanOp(this, (TableScanOp) input);
         }
         return this;
     }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectOp.java
@@ -379,4 +379,9 @@ public class ProjectOp implements PlannerOp {
                 + "input=" + input + '}';
     }
 
+    @Override
+    public Column[] getSchema() {
+        return projection.getColumns();
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
@@ -83,7 +83,7 @@ public class ProjectedTableScanOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return statement.getSchema();
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
@@ -40,7 +40,7 @@ public class ProjectedTableScanOp implements PlannerOp {
 
     final ScanStatement statement;
 
-    ProjectedTableScanOp(ProjectOp op, TableScanOp tableScan) {
+    ProjectedTableScanOp(ProjectOp op, SimpleScanOp tableScan) {
         this.statement = tableScan.unwrap(ScanStatement.class);
         Projection proj = op.getProjection();
         // we can alter the statement, the TableScan will be dropped from the plan

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
@@ -41,7 +41,7 @@ public class ProjectedTableScanOp implements PlannerOp {
 
     final ScanStatement statement;
 
-    ProjectedTableScanOp(ProjectOp op, SimpleScanOp tableScan) {
+    ProjectedTableScanOp(ProjectOp op, TableScanOp tableScan) {
         this.statement = tableScan.unwrap(ScanStatement.class);
         Projection proj = op.getProjection();
         // we can alter the statement, the TableScan will be dropped from the plan
@@ -79,7 +79,7 @@ public class ProjectedTableScanOp implements PlannerOp {
 
     @Override
     public String toString() {
-        return "ProjectedTableScanOp{" + "statement=" + statement + '}';
+        return "ProjectedTableScanOp{projection = " + statement.getProjection() + "\ninput=" + statement + '}';
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ProjectedTableScanOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.Projection;
 import herddb.model.ScanResult;
@@ -79,6 +80,11 @@ public class ProjectedTableScanOp implements PlannerOp {
     @Override
     public String toString() {
         return "ProjectedTableScanOp{" + "statement=" + statement + '}';
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return statement.getSchema();
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
@@ -33,6 +33,7 @@ import herddb.model.StatementExecutionException;
 import herddb.model.StatementExecutionResult;
 import herddb.model.TransactionContext;
 import herddb.utils.DataAccessor;
+import java.util.Arrays;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.EnumerableDefaults;
 
@@ -124,8 +125,8 @@ public class SemiJoinOp implements PlannerOp {
 
     @Override
     public String toString() {
-        return String.format("SemiJoinOp {leftKeySize = %d rightKeySize = %d  left = {%s} right = {%s}}",
-                leftKeys.length , rightKeys.length, left.toString(), right.toString());
+        return String.format("SemiJoinOp {leftKey = %s rightKey = %s\n  left = {%s}\n  right = {%s}}",
+                Arrays.toString(leftKeys) , Arrays.toString(rightKeys), left.toString(), right.toString());
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
@@ -127,4 +127,9 @@ public class SemiJoinOp implements PlannerOp {
         return String.format("SemiJoinOp {leftKeySize = %d rightKeySize = %d  left = {%s} right = {%s}}",
                 leftKeys.length , rightKeys.length, left.toString(), right.toString());
     }
+
+    @Override
+    public Column[] getSchema() {
+        return columns;
+    }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SemiJoinOp.java
@@ -42,7 +42,7 @@ import org.apache.calcite.linq4j.EnumerableDefaults;
  *
  * @author eolivelli
  */
-@SuppressFBWarnings(value = "EI_EXPOSE_REP2")
+@SuppressFBWarnings(value = {"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
 public class SemiJoinOp implements PlannerOp {
 
     private final int[] leftKeys;
@@ -125,12 +125,11 @@ public class SemiJoinOp implements PlannerOp {
 
     @Override
     public String toString() {
-        return String.format("SemiJoinOp {leftKey = %s rightKey = %s\n  left = {%s}\n  right = {%s}}",
-                Arrays.toString(leftKeys) , Arrays.toString(rightKeys), left.toString(), right.toString());
+        return "SemiJoinOp {leftKey = " + Arrays.toString(leftKeys) + " rightKey = " + Arrays.toString(rightKeys) + "\n  left = " + left + "\n  right = " + right + '}';
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return columns;
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleDeleteOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleDeleteOp.java
@@ -78,7 +78,7 @@ public class SimpleDeleteOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return new Column[0];
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleDeleteOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleDeleteOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DMLStatement;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
@@ -74,6 +75,11 @@ public class SimpleDeleteOp implements PlannerOp {
     @Override
     public String toString() {
         return "SimpleDeleteOp{" + "statement=" + statement + '}';
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return new Column[0];
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleInsertOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleInsertOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DMLStatement;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionResult;
@@ -69,5 +70,10 @@ public class SimpleInsertOp implements PlannerOp {
     @Override
     public String toString() {
         return String.format("SimpleInsert= statement %s ", statement.toString());
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleInsertOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleInsertOp.java
@@ -73,7 +73,7 @@ public class SimpleInsertOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleScanOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.ScanResult;
 import herddb.model.StatementEvaluationContext;
@@ -74,6 +75,11 @@ public abstract class SimpleScanOp implements PlannerOp {
     ) throws StatementExecutionException {
         DataScanner scan = tableSpaceManager.scan(statement, context, transactionContext, lockRequired, forWrite);
         return new ScanResult(scan.getTransactionId(), scan);
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return statement.getSchema();
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleScanOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleScanOp.java
@@ -78,7 +78,7 @@ public abstract class SimpleScanOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return statement.getSchema();
     }
 

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleUpdateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleUpdateOp.java
@@ -78,7 +78,7 @@ public class SimpleUpdateOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SimpleUpdateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SimpleUpdateOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DMLStatement;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionResult;
@@ -76,4 +77,8 @@ public class SimpleUpdateOp implements PlannerOp {
         return "SimpleUpdateOp{" + "statement=" + statement + '}';
     }
 
+    @Override
+    public Column[] getSchema() {
+        return new Column[0];
+    }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -233,7 +233,7 @@ public class SortOp implements PlannerOp, TupleComparator {
     }
 
     @Override
-    public Column[] getSchema() {
-        return input.getSchema();
+    public Column[] getOutputSchema() {
+        return input.getOutputSchema();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -228,8 +228,8 @@ public class SortOp implements PlannerOp, TupleComparator {
 
     @Override
     public String toString() {
-        return "SortOp{fields=" + Arrays.toString(fields) + ",\ndirs=" + Arrays.toString(directions) + ",\nnullDirs=" + Arrays.toString(nullLastDirections) + ",\nonlyPrimaryKeyAndAscending=" + onlyPrimaryKeyAndAscending
-                + "\n input=" + input + '}';
+        return "SortOp{fields=" + Arrays.toString(fields) + ",dirs=" + Arrays.toString(directions) + ",nullDirs=" + Arrays.toString(nullLastDirections) + ",onlyPrimaryKeyAndAscending=" + onlyPrimaryKeyAndAscending
+                + "\ninput=" + input + '}';
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -228,7 +228,12 @@ public class SortOp implements PlannerOp, TupleComparator {
 
     @Override
     public String toString() {
-        return "SortOp{fields=" + Arrays.toString(fields) + ", dirs=" + Arrays.toString(directions) + ",nullDirs=" + Arrays.toString(nullLastDirections) + ", onlyPrimaryKeyAndAscending=" + onlyPrimaryKeyAndAscending + '}';
+        return "SortOp{fields=" + Arrays.toString(fields) + ",\ndirs=" + Arrays.toString(directions) + ",\nnullDirs=" + Arrays.toString(nullLastDirections) + ",\nonlyPrimaryKeyAndAscending=" + onlyPrimaryKeyAndAscending
+                + "\n input=" + input + '}';
     }
 
+    @Override
+    public Column[] getSchema() {
+        return input.getSchema();
+    }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
@@ -146,7 +146,7 @@ public class UnionAllOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
-        return inputs.get(0).getSchema();
+    public Column[] getOutputSchema() {
+        return inputs.get(0).getOutputSchema();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UnionAllOp.java
@@ -21,6 +21,7 @@
 package herddb.model.planner;
 
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DataScanner;
 import herddb.model.DataScannerException;
 import herddb.model.ScanResult;
@@ -142,5 +143,10 @@ public class UnionAllOp implements PlannerOp {
             sb.append(Arrays.toString(inputs.toArray()));
         }
         return sb.toString();
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return inputs.get(0).getSchema();
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/UpdateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UpdateOp.java
@@ -181,7 +181,7 @@ public class UpdateOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/UpdateOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/UpdateOp.java
@@ -22,6 +22,7 @@ package herddb.model.planner;
 
 import herddb.codec.RecordSerializer;
 import herddb.core.TableSpaceManager;
+import herddb.model.Column;
 import herddb.model.DMLStatement;
 import herddb.model.DMLStatementExecutionResult;
 import herddb.model.DataScanner;
@@ -177,5 +178,10 @@ public class UpdateOp implements PlannerOp {
     @Override
     public String toString() {
         return String.format("UpdateOp=[ input=%s recordFunction= %s", input, recordFunction.toString());
+    }
+
+    @Override
+    public Column[] getSchema() {
+        return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/ValuesOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ValuesOp.java
@@ -98,7 +98,7 @@ public class ValuesOp implements PlannerOp {
     }
 
     @Override
-    public Column[] getSchema() {
+    public Column[] getOutputSchema() {
         return new Column[0];
     }
 }

--- a/herddb-core/src/main/java/herddb/model/planner/ValuesOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/ValuesOp.java
@@ -96,4 +96,9 @@ public class ValuesOp implements PlannerOp {
     public String toString() {
         return new StringBuilder().append("ValuesOp(tuples=" + this.tuples + ")").append(": count = ").append(this.tuples.size()).toString();
     }
+
+    @Override
+    public Column[] getSchema() {
+        return new Column[0];
+    }
 }

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -287,7 +287,7 @@ public final class ServerConfiguration {
     public static final String PLANNER_TYPE_NONE = "none";
     public static final String PLANNER_TYPE_CALCITE = "calcite";
     public static final String PLANNER_TYPE_JSQLPARSER = "jsqlparser";
-    public static final String PROPERTY_PLANNER_TYPE_DEFAULT = PLANNER_TYPE_JSQLPARSER;
+    public static final String PROPERTY_PLANNER_TYPE_DEFAULT = System.getProperty("herdddb.defaultplannertype", PLANNER_TYPE_CALCITE);
 
     public ServerConfiguration(Properties properties) {
         this.properties = new Properties();

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -287,6 +287,7 @@ public final class ServerConfiguration {
     public static final String PLANNER_TYPE_NONE = "none";
     public static final String PLANNER_TYPE_CALCITE = "calcite";
     public static final String PLANNER_TYPE_JSQLPARSER = "jsqlparser";
+    public static final String PLANNER_TYPE_AUTO = "auto";
     public static final String PROPERTY_PLANNER_TYPE_DEFAULT = System.getProperty("herdddb.defaultplannertype", PLANNER_TYPE_CALCITE);
 
     public ServerConfiguration(Properties properties) {

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -286,7 +286,8 @@ public final class ServerConfiguration {
     public static final String PROPERTY_PLANNER_TYPE = "server.planner.type";
     public static final String PLANNER_TYPE_NONE = "none";
     public static final String PLANNER_TYPE_CALCITE = "calcite";
-    public static final String PROPERTY_PLANNER_TYPE_DEFAULT = PLANNER_TYPE_CALCITE;
+    public static final String PLANNER_TYPE_JSQLPARSER = "jsqlparser";
+    public static final String PROPERTY_PLANNER_TYPE_DEFAULT = PLANNER_TYPE_JSQLPARSER;
 
     public ServerConfiguration(Properties properties) {
         this.properties = new Properties();

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -496,7 +496,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 ByteBuf error = PduCodec.ErrorResponse.write(message.messageId, "unsupported query type for scan " + query + ": PLAN is " + translatedQuery.plan);
                 channel.sendReplyMessage(message.messageId, error);
             }
-        } catch (DataScannerException | StatementExecutionException err) {
+        } catch (DataScannerException | HerdDBInternalException err) {
             if (err.getCause() != null && err.getCause() instanceof ValidationException) {
                 // no stacktraces for bad queries
                 LOGGER.log(Level.FINE, "SQL error on scanner " + scannerId + ": " + err);

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -207,9 +207,9 @@ public class CalcitePlanner implements AbstractSQLPlanner {
     private static final SqlTypeFactoryImpl SQL_TYPE_FACTORY_IMPL = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     private static final RexBuilder REX_BUILDER  = new RexBuilder(SQL_TYPE_FACTORY_IMPL);
 
-    public CalcitePlanner(DBManager manager, long maxPlanCacheSize) {
+    public CalcitePlanner(DBManager manager, PlansCache plansCache) {
         this.manager = manager;
-        this.cache = new PlansCache(maxPlanCacheSize);
+        this.cache = plansCache;
         //used only for DDL
         this.fallback = new DDLSQLPlanner(manager, cache, null);
     }

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -211,7 +211,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
         this.manager = manager;
         this.cache = new PlansCache(maxPlanCacheSize);
         //used only for DDL
-        this.fallback = new DDLSQLPlanner(manager, cache);
+        this.fallback = new DDLSQLPlanner(manager, cache, null);
     }
 
     private final PlansCache cache;

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -22,22 +22,13 @@ package herddb.sql;
 
 import static herddb.model.Column.column;
 import com.google.common.collect.ImmutableList;
-import herddb.core.AbstractIndexManager;
 import herddb.core.AbstractTableManager;
 import herddb.core.DBManager;
 import herddb.core.TableSpaceManager;
-import herddb.index.IndexOperation;
-import herddb.index.PrimaryIndexPrefixScan;
-import herddb.index.PrimaryIndexRangeScan;
-import herddb.index.PrimaryIndexSeek;
-import herddb.index.SecondaryIndexPrefixScan;
-import herddb.index.SecondaryIndexRangeScan;
-import herddb.index.SecondaryIndexSeek;
 import herddb.metadata.MetadataStorageManagerException;
 import herddb.model.AutoIncrementPrimaryKeyRecordFunction;
 import herddb.model.Column;
 import herddb.model.ColumnTypes;
-import herddb.model.ColumnsList;
 import herddb.model.DMLStatement;
 import herddb.model.ExecutionPlan;
 import herddb.model.Predicate;
@@ -74,7 +65,6 @@ import herddb.model.planner.UnionAllOp;
 import herddb.model.planner.UpdateOp;
 import herddb.model.planner.ValuesOp;
 import herddb.sql.expressions.AccessCurrentRowExpression;
-import herddb.sql.expressions.BindableTableScanColumnNameResolver;
 import herddb.sql.expressions.CompiledMultiAndExpression;
 import herddb.sql.expressions.CompiledSQLExpression;
 import herddb.sql.expressions.ConstantExpression;
@@ -91,7 +81,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.function.BiFunction;
@@ -345,7 +334,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
                 if (scanStatement != null) {
                     Table tableDef = scanStatement.getTableDef();
                     CompiledSQLExpression where = scanStatement.getPredicate().unwrap(CompiledSQLExpression.class);
-                    SQLRecordKeyFunction keyFunction = findIndexAccess(where, tableDef.getPrimaryKey(),
+                    SQLRecordKeyFunction keyFunction = IndexUtils.findIndexAccess(where, tableDef.getPrimaryKey(),
                             tableDef, "=", tableDef);
                     if (keyFunction == null || !keyFunction.isFullPrimaryKey()) {
                         throw new StatementExecutionException("unsupported GET not on PK, bad where clause: " + query);
@@ -483,33 +472,6 @@ public class CalcitePlanner implements AbstractSQLPlanner {
                     .setQuoting(Quoting.BACK_TICK)
                     .build();
 
-    /**
-     * the function {@link Predicate#matchesRawPrimaryKey(herddb.utils.Bytes, herddb.model.StatementEvaluationContext)
-     * }
-     * works on a projection of the table wich contains only the pk fields of
-     * the table for instance if the predicate wants to access first element of
-     * the pk, and this field is the 3rd in the column list then you will find
-     * {@link AccessCurrentRowExpression} with index=2. To this expression you
-     * have to apply the projection and map 2 (3rd element of the table) to 0
-     * (1st element of the pk)
-     *
-     * @param filterPk
-     * @param table
-     */
-    private static CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(CompiledSQLExpression filterPk, Table table, Object debug) {
-        try {
-            int[] projectionToKey = table.getPrimaryKeyProjection();
-            return filterPk.remapPositionalAccessToToPrimaryKeyAccessor(projectionToKey);
-        } catch (IllegalStateException notImplemented) {
-            if (debug instanceof RelNode) {
-                LOG.log(Level.INFO, "Not implemented best access for PK on "
-                    + RelOptUtil.dumpPlan("", (RelNode) debug, SqlExplainFormat.TEXT, SqlExplainLevel.ALL_ATTRIBUTES), notImplemented);
-            } else {
-                LOG.log(Level.INFO, "Not implemented best access for PK on {0}", debug);
-            }
-            return null;
-        }
-    }
 
     private static final Logger LOG = Logger.getLogger(CalcitePlanner.class
             .getName());
@@ -926,7 +888,7 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             }
             predicate = new SQLRecordPredicate(table, null, where);
             TableSpaceManager tableSpaceManager = manager.getTableSpaceManager(tableSpace);
-            discoverIndexOperations(tableSpace, where, table, predicate, scan, tableSpaceManager);
+            IndexUtils.discoverIndexOperations(tableSpace, where, table, predicate, scan, tableSpaceManager);
         }
         List<RexNode> projections = new ArrayList<>(scan.projects.size());
 
@@ -941,43 +903,6 @@ public class CalcitePlanner implements AbstractSQLPlanner {
         ScanStatement scanStatement = new ScanStatement(tableSpace, table.name, projection, predicate, null, null);
         scanStatement.setTableDef(table);
         return new BindableTableScanOp(scanStatement);
-    }
-
-    static void discoverIndexOperations(final String tableSpace,
-                                         CompiledSQLExpression where,
-                                         Table table,
-                                         SQLRecordPredicate predicate,
-                                         Object debug,
-                                         TableSpaceManager tableSpaceManager) throws StatementExecutionException {
-        IndexOperation op = scanForIndexAccess(where, table, tableSpaceManager);
-        predicate.setIndexOperation(op);
-        CompiledSQLExpression filterPk = findFiltersOnPrimaryKey(table, where);
-
-        if (filterPk != null) {
-            filterPk = remapPositionalAccessToToPrimaryKeyAccessor(filterPk, table, debug);
-        }
-        predicate.setPrimaryKeyFilter(filterPk);
-    }
-
-    private static CompiledSQLExpression findFiltersOnPrimaryKey(Table table, CompiledSQLExpression where) throws StatementExecutionException {
-        List<CompiledSQLExpression> expressions = new ArrayList<>();
-
-        for (String pk : table.primaryKey) {
-            List<CompiledSQLExpression> conditions =
-                    where.scanForConstraintsOnColumn(pk, table);
-            if (conditions.isEmpty()) {
-                break;
-            }
-            expressions.addAll(conditions);
-        }
-        if (expressions.isEmpty()) {
-            // no match at all, there is no direct constraint on PK
-            return null;
-        } else if (expressions.size() == 1) {
-            return expressions.get(0);
-        } else {
-            return new CompiledMultiAndExpression(expressions.toArray(new CompiledSQLExpression[expressions.size()]));
-        }
     }
 
     private PlannerOp planProject(EnumerableProject op, RelDataType rowType) {
@@ -1294,138 +1219,6 @@ public class CalcitePlanner implements AbstractSQLPlanner {
             default:
                 throw new StatementExecutionException("unsupported expression type " + type.getSqlTypeName());
         }
-    }
-
-    public static SQLRecordKeyFunction findIndexAccess(
-            CompiledSQLExpression where,
-            String[] columnsToMatch, ColumnsList table,
-            String operator, BindableTableScanColumnNameResolver res
-    ) throws StatementExecutionException {
-        List<CompiledSQLExpression> expressions = new ArrayList<>();
-        List<String> columns = new ArrayList<>();
-
-        for (String pk : columnsToMatch) {
-            List<CompiledSQLExpression> conditions = where.scanForConstraintedValueOnColumnWithOperator(pk, operator, res);
-            if (conditions.isEmpty()) {
-                break;
-            }
-            columns.add(pk);
-            expressions.add(conditions.get(0));
-        }
-        if (expressions.isEmpty()) {
-            // no match at all, there is no direct constraint on PK
-            return null;
-        }
-        return new SQLRecordKeyFunction(columns, expressions, table);
-    }
-
-    private static IndexOperation scanForIndexAccess(CompiledSQLExpression expressionWhere, Table table, TableSpaceManager tableSpaceManager) {
-        SQLRecordKeyFunction keyFunction = findIndexAccess(expressionWhere, table.primaryKey, table,
-                "=", table);
-        IndexOperation result = null;
-        if (keyFunction != null) {
-            if (keyFunction.isFullPrimaryKey()) {
-                result = new PrimaryIndexSeek(keyFunction);
-            } else {
-                result = new PrimaryIndexPrefixScan(keyFunction);
-            }
-        } else {
-            SQLRecordKeyFunction rangeMin = findIndexAccess(expressionWhere, table.primaryKey,
-                    table, ">=", table
-            );
-            if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
-                rangeMin = null;
-            }
-            if (rangeMin == null) {
-                rangeMin = findIndexAccess(expressionWhere, table.primaryKey, table,
-                        ">", table);
-                if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
-                    rangeMin = null;
-                }
-            }
-
-            SQLRecordKeyFunction rangeMax = findIndexAccess(expressionWhere, table.primaryKey,
-                    table, "<=", table);
-            if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
-                rangeMax = null;
-            }
-            if (rangeMax == null) {
-                rangeMax = findIndexAccess(expressionWhere, table.primaryKey, table, "<", table);
-                if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
-                    rangeMax = null;
-                }
-            }
-            if (rangeMin != null || rangeMax != null) {
-                result = new PrimaryIndexRangeScan(table.primaryKey, rangeMin, rangeMax);
-            }
-        }
-
-        if (result == null && tableSpaceManager != null) {
-            Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
-            if (indexes != null) {
-                // TODO: use some kind of statistics, maybe using an index is more expensive than a full table scan
-                for (AbstractIndexManager index : indexes.values()) {
-                    if (!index.isAvailable()) {
-                        continue;
-                    }
-                    IndexOperation secondaryIndexOperation = findSecondaryIndexOperation(index, expressionWhere, table);
-                    if (secondaryIndexOperation != null) {
-                        result = secondaryIndexOperation;
-                        break;
-                    }
-                }
-            }
-        }
-        return result;
-    }
-
-    private static IndexOperation findSecondaryIndexOperation(
-            AbstractIndexManager index,
-            CompiledSQLExpression where, Table table
-    ) throws StatementExecutionException {
-        IndexOperation secondaryIndexOperation = null;
-        String[] columnsToMatch = index.getColumnNames();
-        SQLRecordKeyFunction indexSeekFunction = findIndexAccess(where, columnsToMatch,
-                index.getIndex(), "=", table);
-        if (indexSeekFunction != null) {
-            if (indexSeekFunction.isFullPrimaryKey()) {
-                secondaryIndexOperation = new SecondaryIndexSeek(index.getIndexName(), columnsToMatch, indexSeekFunction);
-            } else {
-                secondaryIndexOperation = new SecondaryIndexPrefixScan(index.getIndexName(), columnsToMatch, indexSeekFunction);
-            }
-        } else {
-            SQLRecordKeyFunction rangeMin = findIndexAccess(where, columnsToMatch,
-                    index.getIndex(), ">=", table);
-            if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
-                rangeMin = null;
-
-            }
-            if (rangeMin == null) {
-                rangeMin = findIndexAccess(where, columnsToMatch,
-                        index.getIndex(), ">", table);
-                if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
-                    rangeMin = null;
-                }
-            }
-
-            SQLRecordKeyFunction rangeMax = findIndexAccess(where, columnsToMatch,
-                    index.getIndex(), "<=", table);
-            if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
-                rangeMax = null;
-            }
-            if (rangeMax == null) {
-                rangeMax = findIndexAccess(where, columnsToMatch,
-                        index.getIndex(), "<", table);
-                if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
-                    rangeMax = null;
-                }
-            }
-            if (rangeMin != null || rangeMax != null) {
-                secondaryIndexOperation = new SecondaryIndexRangeScan(index.getIndexName(), columnsToMatch, rangeMin, rangeMax);
-            }
-
-        }
-        return secondaryIndexOperation;
     }
 
     private static boolean isCachable(String query) {

--- a/herddb-core/src/main/java/herddb/sql/IndexUtils.java
+++ b/herddb-core/src/main/java/herddb/sql/IndexUtils.java
@@ -1,0 +1,246 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
+package herddb.sql;
+
+import herddb.core.AbstractIndexManager;
+import herddb.core.TableSpaceManager;
+import herddb.index.IndexOperation;
+import herddb.index.PrimaryIndexPrefixScan;
+import herddb.index.PrimaryIndexRangeScan;
+import herddb.index.PrimaryIndexSeek;
+import herddb.index.SecondaryIndexPrefixScan;
+import herddb.index.SecondaryIndexRangeScan;
+import herddb.index.SecondaryIndexSeek;
+import herddb.model.ColumnsList;
+import herddb.model.StatementExecutionException;
+import herddb.model.Table;
+import herddb.sql.expressions.BindableTableScanColumnNameResolver;
+import herddb.sql.expressions.CompiledMultiAndExpression;
+import herddb.sql.expressions.CompiledSQLExpression;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.SqlExplainFormat;
+import org.apache.calcite.sql.SqlExplainLevel;
+
+/**
+ * Utilities for searching for possible Index usages
+ */
+public class IndexUtils {
+
+    private static final Logger LOG = Logger.getLogger(IndexUtils.class
+            .getName());
+
+    static void discoverIndexOperations(final String tableSpace,
+                                        CompiledSQLExpression where,
+                                        Table table,
+                                        SQLRecordPredicate predicate,
+                                        Object debug,
+                                        TableSpaceManager tableSpaceManager) throws StatementExecutionException {
+        IndexOperation op = scanForIndexAccess(where, table, tableSpaceManager);
+        predicate.setIndexOperation(op);
+        CompiledSQLExpression filterPk = findFiltersOnPrimaryKey(table, where);
+
+        if (filterPk != null) {
+            filterPk = remapPositionalAccessToToPrimaryKeyAccessor(filterPk, table, debug);
+        }
+        predicate.setPrimaryKeyFilter(filterPk);
+    }
+
+    private static IndexOperation scanForIndexAccess(CompiledSQLExpression expressionWhere, Table table, TableSpaceManager tableSpaceManager) {
+        SQLRecordKeyFunction keyFunction = findIndexAccess(expressionWhere, table.primaryKey, table,
+                "=", table);
+        IndexOperation result = null;
+        if (keyFunction != null) {
+            if (keyFunction.isFullPrimaryKey()) {
+                result = new PrimaryIndexSeek(keyFunction);
+            } else {
+                result = new PrimaryIndexPrefixScan(keyFunction);
+            }
+        } else {
+            SQLRecordKeyFunction rangeMin = findIndexAccess(expressionWhere, table.primaryKey,
+                    table, ">=", table
+            );
+            if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
+                rangeMin = null;
+            }
+            if (rangeMin == null) {
+                rangeMin = findIndexAccess(expressionWhere, table.primaryKey, table,
+                        ">", table);
+                if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
+                    rangeMin = null;
+                }
+            }
+
+            SQLRecordKeyFunction rangeMax = findIndexAccess(expressionWhere, table.primaryKey,
+                    table, "<=", table);
+            if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
+                rangeMax = null;
+            }
+            if (rangeMax == null) {
+                rangeMax = findIndexAccess(expressionWhere, table.primaryKey, table, "<", table);
+                if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
+                    rangeMax = null;
+                }
+            }
+            if (rangeMin != null || rangeMax != null) {
+                result = new PrimaryIndexRangeScan(table.primaryKey, rangeMin, rangeMax);
+            }
+        }
+
+        if (result == null && tableSpaceManager != null) {
+            Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);
+            if (indexes != null) {
+                // TODO: use some kind of statistics, maybe using an index is more expensive than a full table scan
+                for (AbstractIndexManager index : indexes.values()) {
+                    if (!index.isAvailable()) {
+                        continue;
+                    }
+                    IndexOperation secondaryIndexOperation = findSecondaryIndexOperation(index, expressionWhere, table);
+                    if (secondaryIndexOperation != null) {
+                        result = secondaryIndexOperation;
+                        break;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private static IndexOperation findSecondaryIndexOperation(
+            AbstractIndexManager index,
+            CompiledSQLExpression where, Table table
+    ) throws StatementExecutionException {
+        IndexOperation secondaryIndexOperation = null;
+        String[] columnsToMatch = index.getColumnNames();
+        SQLRecordKeyFunction indexSeekFunction = findIndexAccess(where, columnsToMatch,
+                index.getIndex(), "=", table);
+        if (indexSeekFunction != null) {
+            if (indexSeekFunction.isFullPrimaryKey()) {
+                secondaryIndexOperation = new SecondaryIndexSeek(index.getIndexName(), columnsToMatch, indexSeekFunction);
+            } else {
+                secondaryIndexOperation = new SecondaryIndexPrefixScan(index.getIndexName(), columnsToMatch, indexSeekFunction);
+            }
+        } else {
+            SQLRecordKeyFunction rangeMin = findIndexAccess(where, columnsToMatch,
+                    index.getIndex(), ">=", table);
+            if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
+                rangeMin = null;
+
+            }
+            if (rangeMin == null) {
+                rangeMin = findIndexAccess(where, columnsToMatch,
+                        index.getIndex(), ">", table);
+                if (rangeMin != null && !rangeMin.isFullPrimaryKey()) {
+                    rangeMin = null;
+                }
+            }
+
+            SQLRecordKeyFunction rangeMax = findIndexAccess(where, columnsToMatch,
+                    index.getIndex(), "<=", table);
+            if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
+                rangeMax = null;
+            }
+            if (rangeMax == null) {
+                rangeMax = findIndexAccess(where, columnsToMatch,
+                        index.getIndex(), "<", table);
+                if (rangeMax != null && !rangeMax.isFullPrimaryKey()) {
+                    rangeMax = null;
+                }
+            }
+            if (rangeMin != null || rangeMax != null) {
+                secondaryIndexOperation = new SecondaryIndexRangeScan(index.getIndexName(), columnsToMatch, rangeMin, rangeMax);
+            }
+
+        }
+        return secondaryIndexOperation;
+    }
+
+    /**
+     * the function {@link Predicate#matchesRawPrimaryKey(herddb.utils.Bytes, herddb.model.StatementEvaluationContext)
+     * }
+     * works on a projection of the table wich contains only the pk fields of the table for instance if the predicate wants to access first element of the pk, and this field is the 3rd in the column
+     * list then you will find {@link AccessCurrentRowExpression} with index=2. To this expression you have to apply the projection and map 2 (3rd element of the table) to 0 (1st element of the pk)
+     *
+     * @param filterPk
+     * @param table
+     */
+    private static CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(CompiledSQLExpression filterPk, Table table, Object debug) {
+        try {
+            int[] projectionToKey = table.getPrimaryKeyProjection();
+            return filterPk.remapPositionalAccessToToPrimaryKeyAccessor(projectionToKey);
+        } catch (IllegalStateException notImplemented) {
+            if (debug instanceof RelNode) {
+                LOG.log(Level.INFO, "Not implemented best access for PK on "
+                        + RelOptUtil.dumpPlan("", (RelNode) debug, SqlExplainFormat.TEXT, SqlExplainLevel.ALL_ATTRIBUTES), notImplemented);
+            } else {
+                LOG.log(Level.INFO, "Not implemented best access for PK on {0}", debug);
+            }
+            return null;
+        }
+    }
+
+    public static SQLRecordKeyFunction findIndexAccess(
+            CompiledSQLExpression where,
+            String[] columnsToMatch, ColumnsList table,
+            String operator, BindableTableScanColumnNameResolver res
+    ) throws StatementExecutionException {
+        List<CompiledSQLExpression> expressions = new ArrayList<>();
+        List<String> columns = new ArrayList<>();
+
+        for (String pk : columnsToMatch) {
+            List<CompiledSQLExpression> conditions = where.scanForConstraintedValueOnColumnWithOperator(pk, operator, res);
+            if (conditions.isEmpty()) {
+                break;
+            }
+            columns.add(pk);
+            expressions.add(conditions.get(0));
+        }
+        if (expressions.isEmpty()) {
+            // no match at all, there is no direct constraint on PK
+            return null;
+        }
+        return new SQLRecordKeyFunction(columns, expressions, table);
+    }
+
+    private static CompiledSQLExpression findFiltersOnPrimaryKey(Table table, CompiledSQLExpression where) throws StatementExecutionException {
+        List<CompiledSQLExpression> expressions = new ArrayList<>();
+
+        for (String pk : table.primaryKey) {
+            List<CompiledSQLExpression> conditions =
+                    where.scanForConstraintsOnColumn(pk, table);
+            if (conditions.isEmpty()) {
+                break;
+            }
+            expressions.addAll(conditions);
+        }
+        if (expressions.isEmpty()) {
+            // no match at all, there is no direct constraint on PK
+            return null;
+        } else if (expressions.size() == 1) {
+            return expressions.get(0);
+        } else {
+            return new CompiledMultiAndExpression(expressions.toArray(new CompiledSQLExpression[expressions.size()]));
+        }
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledAndExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledAndExpression.java
@@ -23,6 +23,8 @@ package herddb.sql.expressions;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.SQLRecordPredicateFunctions;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CompiledAndExpression extends CompiledBinarySQLExpression {
 
@@ -49,6 +51,14 @@ public class CompiledAndExpression extends CompiledBinarySQLExpression {
     @Override
     public String toString() {
         return "CompiledAndExpression{" + "left=" + left + ", right=" + right + '}';
+    }
+
+    @Override
+    public List<CompiledSQLExpression> scanForConstraintedValueOnColumnWithOperator(String column, String operator, BindableTableScanColumnNameResolver columnNameResolver) {
+        List<CompiledSQLExpression> res = new ArrayList<>();
+        res.addAll(left.scanForConstraintedValueOnColumnWithOperator(column, operator, columnNameResolver));
+        res.addAll(right.scanForConstraintedValueOnColumnWithOperator(column, operator, columnNameResolver));
+        return res;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledAndExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledAndExpression.java
@@ -1,23 +1,22 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.sql.expressions;
 
 import herddb.model.StatementEvaluationContext;
@@ -27,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CompiledAndExpression extends CompiledBinarySQLExpression {
-
 
     public CompiledAndExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
         super(left, right);
@@ -54,11 +52,26 @@ public class CompiledAndExpression extends CompiledBinarySQLExpression {
     }
 
     @Override
+    public List<CompiledSQLExpression> scanForConstraintsOnColumn(String column, BindableTableScanColumnNameResolver columnNameResolver) {
+        List<CompiledSQLExpression> res = new ArrayList<>();
+        res.addAll(left.scanForConstraintsOnColumn(column, columnNameResolver));
+        res.addAll(right.scanForConstraintsOnColumn(column, columnNameResolver));
+        return res;
+    }
+
+    @Override
     public List<CompiledSQLExpression> scanForConstraintedValueOnColumnWithOperator(String column, String operator, BindableTableScanColumnNameResolver columnNameResolver) {
         List<CompiledSQLExpression> res = new ArrayList<>();
         res.addAll(left.scanForConstraintedValueOnColumnWithOperator(column, operator, columnNameResolver));
         res.addAll(right.scanForConstraintedValueOnColumnWithOperator(column, operator, columnNameResolver));
         return res;
+    }
+
+    @Override
+    public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
+        CompiledSQLExpression remappedLeft = left.remapPositionalAccessToToPrimaryKeyAccessor(projection);
+        CompiledSQLExpression remappedRight = right.remapPositionalAccessToToPrimaryKeyAccessor(projection);
+        return new CompiledAndExpression(remappedLeft, remappedRight);
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledBinarySQLExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledBinarySQLExpression.java
@@ -94,4 +94,17 @@ public abstract class CompiledBinarySQLExpression implements CompiledSQLExpressi
         return ObjectSizeUtils.DEFAULT_OBJECT_SIZE_OVERHEAD + right.estimateObjectSizeForCache() + left.estimateObjectSizeForCache();
     }
 
+    @Override
+    public String toString() {
+        return "BINARY-EXP{op=" + getOperator() + ", left=" + left + ", right=" + right + '}';
+    }
+
+    public boolean isNegateSupported() {
+        return false;
+    }
+
+    public CompiledBinarySQLExpression negate() {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledFunction.java
@@ -73,6 +73,7 @@ public class CompiledFunction implements CompiledSQLExpression {
             case BuiltinFunctions.COUNT:
             case BuiltinFunctions.SUM:
             case BuiltinFunctions.MIN:
+            case BuiltinFunctions.AVG:
             case BuiltinFunctions.MAX:
                 // AGGREGATED FUNCTION
                 return null;

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanEqualsExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanEqualsExpression.java
@@ -23,28 +23,35 @@ package herddb.sql.expressions;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.SQLRecordPredicateFunctions;
+import herddb.utils.SQLRecordPredicateFunctions.CompareResult;
 
-public class CompiledMinorThenExpression extends CompiledBinarySQLExpression {
+public class CompiledGreaterThanEqualsExpression extends CompiledBinarySQLExpression {
 
-    public CompiledMinorThenExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
+    public CompiledGreaterThanEqualsExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
         super(left, right);
     }
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
         SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
-        return res == SQLRecordPredicateFunctions.CompareResult.MINOR;
+        return res == CompareResult.GREATER || res == CompareResult.EQUALS;
     }
 
     @Override
     public String getOperator() {
-        return "<";
+        return ">=";
+    }
+
+    @Override
+    public String toString() {
+        return "CompiledGreaterThenEqualsExpression{left=" + left + ", right=" + right + "}";
     }
 
     @Override
     public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
-        return new CompiledMinorThenExpression(
+        return new CompiledGreaterThanEqualsExpression(
                 left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
                 right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanEqualsExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanEqualsExpression.java
@@ -43,15 +43,21 @@ public class CompiledGreaterThanEqualsExpression extends CompiledBinarySQLExpres
     }
 
     @Override
-    public String toString() {
-        return "CompiledGreaterThenEqualsExpression{left=" + left + ", right=" + right + "}";
-    }
-
-    @Override
     public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
         return new CompiledGreaterThanEqualsExpression(
                 left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
                 right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
+    }
+
+
+    @Override
+    public CompiledBinarySQLExpression negate() {
+        return new CompiledMinorThanExpression(left, right);
+    }
+
+    @Override
+    public boolean isNegateSupported() {
+        return true;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanExpression.java
@@ -24,9 +24,9 @@ import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.SQLRecordPredicateFunctions;
 
-public class CompiledGreaterThenExpression extends CompiledBinarySQLExpression {
+public class CompiledGreaterThanExpression extends CompiledBinarySQLExpression {
 
-    public CompiledGreaterThenExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
+    public CompiledGreaterThanExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
         super(left, right);
     }
 
@@ -43,7 +43,7 @@ public class CompiledGreaterThenExpression extends CompiledBinarySQLExpression {
 
     @Override
     public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
-        return new CompiledGreaterThenExpression(
+        return new CompiledGreaterThanExpression(
                 left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
                 right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledGreaterThanExpression.java
@@ -49,7 +49,12 @@ public class CompiledGreaterThanExpression extends CompiledBinarySQLExpression {
     }
 
     @Override
-    public String toString() {
-        return "CompiledGreaterThenExpression{left=" + left + ", right=" + right + "}";
+    public CompiledBinarySQLExpression negate() {
+        return new CompiledMinorThanEqualsExpression(left, right);
+    }
+
+    @Override
+    public boolean isNegateSupported() {
+        return true;
     }
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanEqualsExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanEqualsExpression.java
@@ -24,31 +24,27 @@ import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.SQLRecordPredicateFunctions;
 
-public class CompiledAndExpression extends CompiledBinarySQLExpression {
+public class CompiledMinorThanEqualsExpression extends CompiledBinarySQLExpression {
 
-
-    public CompiledAndExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
+    public CompiledMinorThanEqualsExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
         super(left, right);
     }
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
-        boolean ok = SQLRecordPredicateFunctions.toBoolean(left.evaluate(bean, context));
-        if (!ok) {
-            return false;
-        }
-        return SQLRecordPredicateFunctions.toBoolean(right.evaluate(bean, context));
+        SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
+        return res == SQLRecordPredicateFunctions.CompareResult.MINOR || res == SQLRecordPredicateFunctions.CompareResult.EQUALS;
     }
 
     @Override
-    public void validate(StatementEvaluationContext context) throws StatementExecutionException {
-        left.validate(context);
-        right.validate(context);
+    public String getOperator() {
+        return "<=";
     }
 
     @Override
-    public String toString() {
-        return "CompiledAndExpression{" + "left=" + left + ", right=" + right + '}';
+    public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
+        return new CompiledMinorThanEqualsExpression(
+                left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
+                right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }
-
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanEqualsExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanEqualsExpression.java
@@ -47,4 +47,16 @@ public class CompiledMinorThanEqualsExpression extends CompiledBinarySQLExpressi
                 left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
                 right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }
+
+    @Override
+    public CompiledBinarySQLExpression negate() {
+        return new CompiledGreaterThanExpression(left, right);
+    }
+
+    @Override
+    public boolean isNegateSupported() {
+        return true;
+    }
+
+
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanExpression.java
@@ -47,4 +47,15 @@ public class CompiledMinorThanExpression extends CompiledBinarySQLExpression {
                 left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
                 right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }
+
+
+    @Override
+    public CompiledBinarySQLExpression negate() {
+        return new CompiledGreaterThanEqualsExpression(left, right);
+    }
+
+    @Override
+    public boolean isNegateSupported() {
+        return true;
+    }
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledMinorThanExpression.java
@@ -24,31 +24,27 @@ import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.SQLRecordPredicateFunctions;
 
-public class CompiledAndExpression extends CompiledBinarySQLExpression {
+public class CompiledMinorThanExpression extends CompiledBinarySQLExpression {
 
-
-    public CompiledAndExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
+    public CompiledMinorThanExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
         super(left, right);
     }
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
-        boolean ok = SQLRecordPredicateFunctions.toBoolean(left.evaluate(bean, context));
-        if (!ok) {
-            return false;
-        }
-        return SQLRecordPredicateFunctions.toBoolean(right.evaluate(bean, context));
+        SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
+        return res == SQLRecordPredicateFunctions.CompareResult.MINOR;
     }
 
     @Override
-    public void validate(StatementEvaluationContext context) throws StatementExecutionException {
-        left.validate(context);
-        right.validate(context);
+    public String getOperator() {
+        return "<";
     }
 
     @Override
-    public String toString() {
-        return "CompiledAndExpression{" + "left=" + left + ", right=" + right + '}';
+    public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
+        return new CompiledMinorThanExpression(
+                left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
+                right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
     }
-
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledOrExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledOrExpression.java
@@ -23,35 +23,31 @@ package herddb.sql.expressions;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.StatementExecutionException;
 import herddb.utils.SQLRecordPredicateFunctions;
-import herddb.utils.SQLRecordPredicateFunctions.CompareResult;
 
-public class CompiledGreaterThenEqualsExpression extends CompiledBinarySQLExpression {
+public class CompiledOrExpression extends CompiledBinarySQLExpression {
 
-    public CompiledGreaterThenEqualsExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
+    public CompiledOrExpression(CompiledSQLExpression left, CompiledSQLExpression right) {
         super(left, right);
     }
 
     @Override
     public Object evaluate(herddb.utils.DataAccessor bean, StatementEvaluationContext context) throws StatementExecutionException {
-        SQLRecordPredicateFunctions.CompareResult res = left.opCompareTo(bean, context, right);
-        return res == CompareResult.GREATER || res == CompareResult.EQUALS;
+        boolean ok = SQLRecordPredicateFunctions.toBoolean(left.evaluate(bean, context));
+        if (ok) {
+            return true;
+        }
+        return SQLRecordPredicateFunctions.toBoolean(right.evaluate(bean, context));
     }
 
     @Override
-    public String getOperator() {
-        return ">=";
+    public void validate(StatementEvaluationContext context) throws StatementExecutionException {
+        left.validate(context);
+        right.validate(context);
     }
 
     @Override
     public String toString() {
-        return "CompiledGreaterThenEqualsExpression{left=" + left + ", right=" + right + "}";
-    }
-
-    @Override
-    public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
-        return new CompiledGreaterThenEqualsExpression(
-                left.remapPositionalAccessToToPrimaryKeyAccessor(projection),
-                right.remapPositionalAccessToToPrimaryKeyAccessor(projection));
+        return "CompiledAndExpression{" + "left=" + left + ", right=" + right + '}';
     }
 
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/CompiledOrExpression.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/CompiledOrExpression.java
@@ -50,4 +50,11 @@ public class CompiledOrExpression extends CompiledBinarySQLExpression {
         return "CompiledAndExpression{" + "left=" + left + ", right=" + right + '}';
     }
 
+    @Override
+    public CompiledSQLExpression remapPositionalAccessToToPrimaryKeyAccessor(int[] projection) {
+        CompiledSQLExpression remappedLeft = left.remapPositionalAccessToToPrimaryKeyAccessor(projection);
+        CompiledSQLExpression remappedRight = right.remapPositionalAccessToToPrimaryKeyAccessor(projection);
+        return new CompiledAndExpression(remappedLeft, remappedRight);
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
@@ -81,13 +81,13 @@ public class SQLExpressionCompiler {
                 case "<>":
                     return new CompiledNotEqualsExpression(operands[0], operands[1]);
                 case ">":
-                    return new CompiledGreaterThenExpression(operands[0], operands[1]);
+                    return new CompiledGreaterThanExpression(operands[0], operands[1]);
                 case ">=":
-                    return new CompiledGreaterThenEqualsExpression(operands[0], operands[1]);
+                    return new CompiledGreaterThanEqualsExpression(operands[0], operands[1]);
                 case "<":
-                    return new CompiledMinorThenExpression(operands[0], operands[1]);
+                    return new CompiledMinorThanExpression(operands[0], operands[1]);
                 case "<=":
-                    return new CompiledMinorThenEqualsExpression(operands[0], operands[1]);
+                    return new CompiledMinorThanEqualsExpression(operands[0], operands[1]);
                 case "+":
                     return new CompiledAddExpression(operands[0], operands[1]);
                 case "MOD":

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLParserExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLParserExpressionCompiler.java
@@ -1,0 +1,163 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql.expressions;
+
+import herddb.model.StatementExecutionException;
+import herddb.sql.DDLSQLPlanner;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.JdbcParameter;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.expression.TimestampValue;
+
+/**
+ * Created a pure Java implementation of the expression which represents the given jSQLParser Expression
+ *
+ * @author enrico.olivelli
+ */
+public class SQLParserExpressionCompiler {
+
+    public static CompiledSQLExpression compileExpression(Expression expression) {
+        if (expression == null) {
+            return null;
+        }
+        if (expression instanceof JdbcParameter) {
+            JdbcParameter p = (JdbcParameter) expression;
+            return new JdbcParameterExpression(p.getIndex() - 1);
+        } else if (expression instanceof StringValue
+                || expression instanceof LongValue
+                || expression instanceof TimestampValue) {
+            return new ConstantExpression(DDLSQLPlanner.resolveValue(expression, false));
+        }
+//        else if (expression instanceof RexLiteral) {
+//            RexLiteral p = (RexLiteral) expression;
+//            if (p.isNull()) {
+//                return new ConstantExpression(null);
+//            } else {
+//                return new ConstantExpression(safeValue(p.getValue3(), p.getType(), p.getTypeName()));
+//            }
+//        } else if (expression instanceof RexInputRef) {
+//            RexInputRef p = (RexInputRef) expression;
+//            return new AccessCurrentRowExpression(p.getIndex());
+//        } else if (expression instanceof RexCall) {
+//            RexCall p = (RexCall) expression;
+//            SqlOperator op = p.op;
+//            String name = op.getName();
+//            CompiledSQLExpression[] operands = new CompiledSQLExpression[p.operands.size()];
+//            int i = 0;
+//            for (RexNode operand : p.operands) {
+//                operands[i++] = compileExpression(operand);
+//            }
+//            switch (name) {
+//                case "=":
+//                    return new CompiledEqualsExpression(operands[0], operands[1]);
+//                case "<>":
+//                    return new CompiledNotEqualsExpression(operands[0], operands[1]);
+//                case ">":
+//                    return new CompiledGreaterThenExpression(operands[0], operands[1]);
+//                case ">=":
+//                    return new CompiledGreaterThenEqualsExpression(operands[0], operands[1]);
+//                case "<":
+//                    return new CompiledMinorThenExpression(operands[0], operands[1]);
+//                case "<=":
+//                    return new CompiledMinorThenEqualsExpression(operands[0], operands[1]);
+//                case "+":
+//                    return new CompiledAddExpression(operands[0], operands[1]);
+//                case "MOD":
+//                    return new CompiledModuloExpression(operands[0], operands[1]);
+//                case "-":
+//                    if (operands.length == 1) {
+//                        return new CompiledSignedExpression('-', operands[0]);
+//                    } else if (operands.length == 2) {
+//                        return new CompiledSubtractExpression(operands[0], operands[1]);
+//                    }
+//                    break;
+//                case "*":
+//                    return new CompiledMultiplyExpression(operands[0], operands[1]);
+//                case "/":
+//                    return new CompiledDivideExpression(operands[0], operands[1]);
+//                case "/INT":
+//                    return new CompiledDivideIntExpression(operands[0], operands[1]);
+//                case "LIKE":
+//                    if (operands.length == 2) {
+//                        return new CompiledLikeExpression(operands[0], operands[1]);
+//                    } else {
+//                        // ESCAPE
+//                        return new CompiledLikeExpression(operands[0], operands[1], operands[2]);
+//                    }
+//                case "AND":
+//                    return new CompiledMultiAndExpression(operands);
+//                case "OR":
+//                    return new CompiledMultiOrExpression(operands);
+//                case "NOT":
+//                    return new CompiledParenthesisExpression(true, operands[0]);
+//                case "IS NOT NULL":
+//                    return new CompiledIsNullExpression(true, operands[0]);
+//                case "IS NOT TRUE":
+//                    return new CompiledIsNotTrueExpression(false, operands[0]);
+//                case "IS NULL":
+//                    return new CompiledIsNullExpression(false, operands[0]);
+//                case "CAST":
+//                    return operands[0].cast(CalcitePlanner.convertToHerdType(p.type));
+//                case "CASE":
+//                    List<Map.Entry<CompiledSQLExpression, CompiledSQLExpression>> cases = new ArrayList<>(operands.length / 2);
+//                    boolean hasElse = operands.length % 2 == 1;
+//                    int numcases = hasElse ? ((operands.length - 1) / 2) : (operands.length / 2);
+//                    for (int j = 0; j < numcases; j++) {
+//                        cases.add(new AbstractMap.SimpleImmutableEntry<>(operands[j * 2], operands[j * 2 + 1]));
+//                    }
+//                    CompiledSQLExpression elseExp = hasElse ? operands[operands.length - 1] : null;
+//                    return new CompiledCaseExpression(cases, elseExp);
+//                case BuiltinFunctions.NAME_CURRENT_TIMESTAMP:
+//                    return new CompiledFunction(BuiltinFunctions.CURRENT_TIMESTAMP, Collections.emptyList());
+//                case BuiltinFunctions.NAME_LOWERCASE:
+//                    return new CompiledFunction(BuiltinFunctions.LOWER, Arrays.asList(operands));
+//                case BuiltinFunctions.NAME_UPPER:
+//                    return new CompiledFunction(BuiltinFunctions.UPPER, Arrays.asList(operands));
+//                case BuiltinFunctions.NAME_ABS:
+//                    return new CompiledFunction(BuiltinFunctions.ABS, Arrays.asList(operands));
+//                case BuiltinFunctions.NAME_ROUND:
+//                    return new CompiledFunction(BuiltinFunctions.ROUND, Arrays.asList(operands));
+//                case BuiltinFunctions.NAME_EXTRACT:
+//                    return new CompiledFunction(BuiltinFunctions.EXTRACT, Arrays.asList(operands));
+//                case BuiltinFunctions.NAME_FLOOR:
+//                    return new CompiledFunction(BuiltinFunctions.FLOOR, Arrays.asList(operands));
+//                case BuiltinFunctions.NAME_RAND:
+//                    return new CompiledFunction(BuiltinFunctions.RAND, Arrays.asList(operands));
+//                case BuiltinFunctions.NAME_REINTERPRET:
+//                    if (operands.length != 1) {
+//                        throw new StatementExecutionException("unsupported use of Reinterpret with " + Arrays.toString(operands));
+//                    }
+//                    return (CompiledSQLExpression) operands[0];
+//                default:
+//                    throw new StatementExecutionException("unsupported operator '" + name + "'");
+//            }
+//        } else if (expression instanceof RexFieldAccess) {
+//            RexFieldAccess p = (RexFieldAccess) expression;
+//            CompiledSQLExpression object = compileExpression(p.getReferenceExpr());
+//            return new AccessFieldExpression(object, p.getField().getName());
+//        } else if (expression instanceof RexCorrelVariable) {
+//            RexCorrelVariable p = (RexCorrelVariable) expression;
+//            return new AccessCorrelVariableExpression(p.id.getId(), p.id.getName());
+//        }
+        throw new StatementExecutionException("not implemented expression type " + expression.getClass() + ": " + expression);
+    }
+}

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLParserExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLParserExpressionCompiler.java
@@ -105,7 +105,7 @@ public class SQLParserExpressionCompiler {
             IntHolder indexInSchema = new IntHolder(-1);
             Column found = findColumnInSchema(columnName, tableSchema, indexInSchema);
             if (indexInSchema.value == -1 || found == null) {
-                throw new StatementExecutionException("Column " + columnName + " not found in target table " + Arrays.toString(tableSchema));
+                checkSupported(false, "Column " + columnName + " not found in target table " + Arrays.toString(tableSchema));
             }
             return new AccessCurrentRowExpression(indexInSchema.value);
         } else if (expression instanceof BinaryExpression) {

--- a/herddb-core/src/main/java/herddb/sql/functions/AvgColumnCalculator.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/AvgColumnCalculator.java
@@ -1,0 +1,64 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql.functions;
+
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.sql.SQLRecordPredicate;
+import herddb.sql.expressions.CompiledSQLExpression;
+
+/**
+ * SQL AVG
+ *
+ * @author enrico.olivelli
+ */
+public class AvgColumnCalculator extends AbstractSingleExpressionArgumentColumnCalculator {
+
+    public AvgColumnCalculator(String fieldName, int type, CompiledSQLExpression expression, StatementEvaluationContext context) throws StatementExecutionException {
+        super(fieldName, expression, context);
+        this.type = type;
+    }
+    private final int type;
+    private long result;
+    private long count;
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public void consume(herddb.utils.DataAccessor tuple) throws StatementExecutionException {
+        Comparable value = valueExtractor.apply(tuple);
+        if (value != null) {
+            result += ((Number) value).longValue();
+        }
+        count++;
+    }
+
+    @Override
+    public Object getValue() {
+        if (count == 0) {
+            throw new StatementExecutionException("Division by zero in AVG function");
+        }
+        return SQLRecordPredicate.cast(result / count, type);
+    }
+}

--- a/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
@@ -100,4 +100,17 @@ public class BuiltinFunctions {
         }
     }
 
+    public static boolean isAggregatedFunction(String functionNameLowercase) {
+        switch (functionNameLowercase) {
+            case COUNT:
+            case SUM:
+            case SUM0:
+            case MIN:
+            case MAX:
+                return true;
+            default:
+                return false;
+        }
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/functions/FloatingPointAvgColumnCalculator.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/FloatingPointAvgColumnCalculator.java
@@ -1,0 +1,62 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql.functions;
+
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.sql.expressions.CompiledSQLExpression;
+
+/**
+ * SQL AVG
+ *
+ * @author enrico.olivelli
+ */
+public class FloatingPointAvgColumnCalculator extends AbstractSingleExpressionArgumentColumnCalculator {
+
+    public FloatingPointAvgColumnCalculator(String fieldName, CompiledSQLExpression expression, StatementEvaluationContext context) throws StatementExecutionException {
+        super(fieldName, expression, context);
+    }
+
+    double result;
+    long count;
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public void consume(herddb.utils.DataAccessor tuple) throws StatementExecutionException {
+        Comparable value = valueExtractor.apply(tuple);
+        if (value != null) {
+            result += ((Number) value).doubleValue();
+        }
+        count++;
+    }
+
+    @Override
+    public Object getValue() {
+        if (count == 0) {
+            throw new StatementExecutionException("Division by zero in AVG function");
+        }
+        return result / count;
+    }
+}

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -1662,13 +1662,6 @@ public class RawSQLTest {
 
             }
 
-            try (DataScanner scan1 = scan(manager, "SELECT SUM(1) as cc FROM tblspace1.tsql", Collections.emptyList())) {
-                List<DataAccessor> result = scan1.consume();
-                assertEquals(1, result.size());
-                assertEquals(Long.valueOf(4), result.get(0).get(0));
-                assertEquals(Long.valueOf(4), result.get(0).get("cc"));
-            }
-
             // test "modulo" operator
             try (DataScanner scan1 = scan(manager, "SELECT n1 % 4 as cc FROM tblspace1.tsql where n1 % 4 = 1 and k1='mykey3'", Collections.emptyList())) {
                 List<DataAccessor> result = scan1.consume();
@@ -1677,6 +1670,12 @@ public class RawSQLTest {
                 assertEquals(Long.valueOf(1), result.get(0).get("cc"));
             }
 
+            try (DataScanner scan1 = scan(manager, "SELECT SUM(1) as cc FROM tblspace1.tsql", Collections.emptyList())) {
+                List<DataAccessor> result = scan1.consume();
+                assertEquals(1, result.size());
+                assertEquals(Long.valueOf(4), result.get(0).get(0));
+                assertEquals(Long.valueOf(4), result.get(0).get("cc"));
+            }
 
         }
     }

--- a/herddb-core/src/test/java/herddb/core/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/core/RawSQLTest.java
@@ -67,7 +67,6 @@ import herddb.model.commands.RollbackTransactionStatement;
 import herddb.model.commands.ScanStatement;
 import herddb.model.planner.PlannerOp;
 import herddb.model.planner.ProjectOp.ZeroCopyProjection.RuntimeProjectedDataAccessor;
-import herddb.sql.CalcitePlanner;
 import herddb.sql.DDLSQLPlanner;
 import herddb.sql.TranslatedQuery;
 import herddb.utils.Bytes;
@@ -1084,11 +1083,10 @@ public class RawSQLTest {
                 List<DataAccessor> result = scan1.consume();
                 assertEquals(2, result.size());
             }
-            if (manager.getPlanner() instanceof CalcitePlanner) {
-                try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql LIMIT ?,?", Arrays.asList(1, 2), TransactionContext.NO_TRANSACTION)) {
-                    List<DataAccessor> result = scan1.consume();
-                    assertEquals(2, result.size());
-                }
+
+            try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql LIMIT ?,?", Arrays.asList(1, 2), TransactionContext.NO_TRANSACTION)) {
+                List<DataAccessor> result = scan1.consume();
+                assertEquals(2, result.size());
             }
 
             try (DataScanner scan1 = scan(manager, "SELECT * FROM tblspace1.tsql "

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -100,7 +100,17 @@ public class CalcitePlannerTest {
 
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
             execute(manager, "INSERT INTO tblspace1.tsql (k1,n1) values(?,?)", Arrays.asList("mykey", 1234), TransactionContext.NO_TRANSACTION);
-            execute(manager, "INSERT INTO tblspace1.tsql (k1,n1) values('mykey2',1235)", Arrays.asList("mykey", 1234), TransactionContext.NO_TRANSACTION);
+
+            try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql", Collections.emptyList())) {
+                assertEquals(1, scan.consume().size());
+            }
+
+            try (DataScanner scan = scan(manager, "SELECT n1,k1 FROM tblspace1.tsql", Collections.emptyList())) {
+                assertEquals(1, scan.consume().size());
+            }
+            try (DataScanner scan = scan(manager, "SELECT k1,n1 FROM tblspace1.tsql", Collections.emptyList())) {
+                assertEquals(1, scan.consume().size());
+            }
 
             try (DataScanner scan = scan(manager, "SELECT n1,k1 FROM tblspace1.tsql where k1='mykey'", Collections.emptyList())) {
                 assertEquals(1, scan.consume().size());

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -92,7 +92,6 @@ public class CalcitePlannerTest {
     public void simplePlansTests() throws Exception {
         String nodeId = "localhost";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
-            assumeThat(manager.getPlanner(), instanceOf(CalcitePlanner.class));
 
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
@@ -101,6 +100,7 @@ public class CalcitePlannerTest {
 
             execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
             execute(manager, "INSERT INTO tblspace1.tsql (k1,n1) values(?,?)", Arrays.asList("mykey", 1234), TransactionContext.NO_TRANSACTION);
+            execute(manager, "INSERT INTO tblspace1.tsql (k1,n1) values('mykey2',1235)", Arrays.asList("mykey", 1234), TransactionContext.NO_TRANSACTION);
 
             try (DataScanner scan = scan(manager, "SELECT n1,k1 FROM tblspace1.tsql where k1='mykey'", Collections.emptyList())) {
                 assertEquals(1, scan.consume().size());

--- a/herddb-core/src/test/java/herddb/sql/DDLSQLPlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/DDLSQLPlannerTest.java
@@ -21,9 +21,7 @@ package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.scan;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeThat;
 import herddb.core.DBManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
@@ -46,7 +44,6 @@ public class DDLSQLPlannerTest {
     public void testColumnWithNameSize() throws Exception {
         String nodeId = "localhost";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
-            assumeThat(manager.getPlanner(), instanceOf(CalcitePlanner.class));
 
             manager.start();
             CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);

--- a/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
@@ -211,6 +211,9 @@ public class SimplerPlannerTest {
                             + " ORDER BY k1",
                     Collections.emptyList())) {
                 List<DataAccessor> results = scan.consume();
+                for (DataAccessor res : results) {
+                    System.out.println("RES: "+res.toMap()+" "+Arrays.toString(res.getFieldNames())+" "+Arrays.toString(res.getValues()));
+                }
                 assertEquals(2, results.size());
                 assertEquals(3, results.get(0).getFieldNames().length);
                 assertEquals(1L, results.get(0).get(0));

--- a/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
@@ -211,9 +211,6 @@ public class SimplerPlannerTest {
                             + " ORDER BY k1",
                     Collections.emptyList())) {
                 List<DataAccessor> results = scan.consume();
-                for (DataAccessor res : results) {
-                    System.out.println("RES: "+res.toMap()+" "+Arrays.toString(res.getFieldNames())+" "+Arrays.toString(res.getValues()));
-                }
                 assertEquals(2, results.size());
                 assertEquals(3, results.get(0).getFieldNames().length);
                 assertEquals(1L, results.get(0).get(0));

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
                 <artifactId>netty-transport-native-epoll</artifactId>
                 <version>${libs.netty4}</version>
                 <classifier>linux-x86_64</classifier>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
@@ -190,6 +190,11 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${libs.netty4ssl}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.calcite</groupId>
+                <artifactId>calcite-linq4j</artifactId>
+                <version>${libs.calcite}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.calcite</groupId>
@@ -205,11 +210,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.calcite</groupId>
-                <artifactId>calcite-linq4j</artifactId>
-                <version>${libs.calcite}</version>                
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -240,7 +240,7 @@
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
                 <version>1.1.7</version>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
@@ -384,7 +384,7 @@
                     <exclusion>
                         <groupId>com.beust</groupId>
                         <artifactId>jcommander</artifactId>
-                    </exclusion>                    
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
This is a prototype about using jSQLParser for planning basic SQL commands:
- INSERT .... VALUES(x,x,x,x)
- SELECT col,col... FROM TABLE WHERE ... ORDER BY.....
- UPDATE TABLE set col=...... WHERE xxxxx
- DELETE FROM TABLE where .....

We are going to reuse all of the PlannerOp framework, this way:
- we are maintaining only one "implementation" of the data access system
- we can leverage all of the zero-copy optimizations that we introduced with Calcite

For "unsupported" operations we will fall back to Calcite.

Changes:
- add new configuration options: server.planner.type=calcite|jsqlparser|auto|none
- add systemproperty herddb.defaultplanner=calcilte (useful for CI)
- add Travis build with herddb.defaultplanner=jsqlparser
- Introduce fallback mechanism in case of server.planner.type=auto (try with jsqlparser, then fallback to Calcite)
- in case of server.planner.type=jsqlparser we want to be able to drop Calcite dependencies at runtime (@rmannibucau will be very happy!)
- implement INSERT/UPSERT/SELECT/UPDATE/DELETE statements
- implement GROUP BY (without Having)
- implement basic aggregations (COUNT,SUM....)
- implement GetStatement
- implement Indexes

Notable missing features:
- HAVING
- JOIN
- Handle automatic type inference (needed for some test case about string -> timestamp conversions)

Differences between the two Planners:

Calcite:
- slow, especially at boot time
- powerfull: it takes into account implicit Collactions (physical sort) of columsn, Nullable constranits, Table size, it simplifies expressions, it is able to elide aggregation and in generale to make the plan as efficient as possible
- handles mostly all SQL syntax
- bigger runtime (brings lots of third party dependencies)

jSQLParser:
- faster
- very short minded: very minimal similfications, not smart assumptions on dataset
- cannot handle all SQL syntax, especially JOINS, EXISTS...
- single jar runtime
