### PR TITLE
Implement correctly alias handling in sort with jSQLParser

### DIFF
--- a/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/JoinOp.java
@@ -204,4 +204,12 @@ public class JoinOp implements PlannerOp {
         return columns;
     }
 
+    public PlannerOp getLeft() {
+        return left;
+    }
+
+    public PlannerOp getRight() {
+        return right;
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/model/planner/SortOp.java
+++ b/herddb-core/src/main/java/herddb/model/planner/SortOp.java
@@ -236,4 +236,9 @@ public class SortOp implements PlannerOp, TupleComparator {
     public Column[] getOutputSchema() {
         return input.getOutputSchema();
     }
+
+    public PlannerOp getInput() {
+        return input;
+    }
+
 }

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -1576,24 +1576,19 @@ public class JSQLParserPlanner implements AbstractSQLPlanner {
         // add aggregations
         if (containsAggregatedFunctions) {
             checkSupported(scanJoinedTables.length == 0);
-            OpSchema opSchema = new OpSchema(
+            op = planAggregate(selectedFields, currentSchema, op, currentSchema, plainSelect.getGroupBy());
+            currentSchema = new OpSchema(
                     currentSchema.tableSpace,
                     currentSchema.name,
                     currentSchema.alias,
                     ColumnRef.toColumnsRefsArray(currentSchema.name, op.getOutputSchema()));
-            op = planAggregate(selectedFields, opSchema, op, currentSchema, plainSelect.getGroupBy());
         }
 
         // TODO: add having
 
         // add order by
         if (plainSelect.getOrderByElements() != null) {
-            OpSchema opSchema = new OpSchema(
-                    currentSchema.tableSpace,
-                    currentSchema.name,
-                    currentSchema.alias,
-                    ColumnRef.toColumnsRefsArray(currentSchema.name, op.getOutputSchema()));
-            op = planSort(op, opSchema, plainSelect.getOrderByElements());
+            op = planSort(op, currentSchema, plainSelect.getOrderByElements());
         }
 
         // add limit

--- a/herddb-core/src/test/java/herddb/sql/AlterTableSQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/AlterTableSQLTest.java
@@ -18,7 +18,7 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.scan;
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/AlterTablespaceSQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/AlterTablespaceSQLTest.java
@@ -18,7 +18,7 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.scan;
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import herddb.core.DBManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
+++ b/herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
@@ -18,10 +18,12 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static org.junit.Assert.assertEquals;
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/ColumnTimestampTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ColumnTimestampTest.java
@@ -18,11 +18,12 @@
 
 */
 
-package herddb.core;
+package herddb.sql;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.codec.RecordSerializer;
+import herddb.core.BaseTestcase;
 import herddb.model.ColumnTypes;
 import herddb.model.GetResult;
 import herddb.model.Record;

--- a/herddb-core/src/test/java/herddb/sql/SimpleOperatorsTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SimpleOperatorsTest.java
@@ -18,13 +18,14 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.executeUpdate;
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/SimpleScanZeroCopyTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SimpleScanZeroCopyTest.java
@@ -18,12 +18,14 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.codec.DataAccessorForFullRecord;
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/SimpleSubqueryTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SimpleSubqueryTest.java
@@ -18,7 +18,7 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.executeUpdate;
@@ -26,6 +26,7 @@ import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import herddb.core.DBManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/SystemTablesTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SystemTablesTest.java
@@ -18,13 +18,15 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
+import herddb.core.RunningStatementInfo;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/TruncateTableSQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/TruncateTableSQLTest.java
@@ -18,12 +18,14 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import herddb.core.DBManager;
+import herddb.core.TestUtils;
 import herddb.file.FileDataStorageManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/UpdateTest.java
+++ b/herddb-core/src/test/java/herddb/sql/UpdateTest.java
@@ -18,7 +18,7 @@
 
  */
 
-package herddb.core;
+package herddb.sql;
 
 import static herddb.core.TestUtils.beginTransaction;
 import static herddb.core.TestUtils.commitTransaction;
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import herddb.core.DBManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;


### PR DESCRIPTION
Fix a bug in handling aliased column names in ORDER BY with simple jsqlparser based planner.

I have also moved most of SQL planning related tests to herddb.sql package in order to ease finding for those tests