### PR TITLE
Fix handling of Planner Cache in case of leadership change

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -235,7 +235,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                         new CalcitePlanner(this, plansCache));
                 break;
             case ServerConfiguration.PLANNER_TYPE_NONE:
-                planner = new NullSQLPlanner();
+                planner = new NullSQLPlanner(this);
                 break;
             default:
                 throw new IllegalArgumentException("invalid planner type " + plannerType);
@@ -698,7 +698,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         }
         TableSpaceManager manager = tablesSpaces.get(tableSpace);
         if (manager == null) {
-            return Futures.exception(new NotLeaderException("No such tableSpace " + tableSpace + " here. "
+            return Futures.exception(new NotLeaderException("No such tableSpace " + tableSpace + " here (at " + nodeId + "). "
                     + "Maybe the server is starting "));
         }
         if (errorIfNotLeader && !manager.isLeader()) {

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -290,6 +290,9 @@ public final class ServerConfiguration {
     public static final String PLANNER_TYPE_AUTO = "auto";
     public static final String PROPERTY_PLANNER_TYPE_DEFAULT = System.getProperty("herdddb.defaultplannertype", PLANNER_TYPE_CALCITE);
 
+    public static final String PROPERTY_PLANNER_WAITFORTABLESPACE_TIMEOUT = "server.planner.waitfortablespace.timeout";
+    public static final int PROPERTY_PLANNER_WAITFORTABLESPACE_TIMEOUT_DEFAULT = SystemProperties.getIntSystemProperty("herddb.planner.waitfortablespacetimeout", 60000);
+
     public ServerConfiguration(Properties properties) {
         this.properties = new Properties();
         this.properties.putAll(properties);

--- a/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
@@ -1,39 +1,46 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.sql;
 
 import herddb.core.DBManager;
+import herddb.core.TableSpaceManager;
 import herddb.model.NotLeaderException;
 import herddb.model.StatementExecutionException;
+import herddb.server.ServerConfiguration;
+import herddb.utils.SystemProperties;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-/**
- * @author eolivelli
- */
 public abstract class AbstractSQLPlanner {
+
+    protected final long waitForSchemaTimeout;
+    protected static final Level DUMP_QUERY_LEVEL = Level.parse(SystemProperties.getStringSystemProperty("herddb.planner.dumpqueryloglevel", Level.FINE.toString()));
+    private static final Logger LOG = Logger.getLogger(AbstractSQLPlanner.class.getName());
 
     protected final DBManager manager;
 
     public AbstractSQLPlanner(DBManager manager) {
         this.manager = manager;
+        this.waitForSchemaTimeout = manager.getServerConfiguration()
+                .getInt(ServerConfiguration.PROPERTY_PLANNER_WAITFORTABLESPACE_TIMEOUT, ServerConfiguration.PROPERTY_PLANNER_WAITFORTABLESPACE_TIMEOUT_DEFAULT);
     }
 
     public abstract void clearCache();
@@ -46,9 +53,32 @@ public abstract class AbstractSQLPlanner {
 
     public abstract TranslatedQuery translate(String defaultTableSpace, String query, List<Object> parameters, boolean scan, boolean allowCache, boolean returnValues, int maxRows) throws StatementExecutionException;
 
-    final void ensureDefaultTableSpaceBootedLocally(String defaultTableSpace) {
-        if (manager.getTableSpaceManager(defaultTableSpace) == null) {
+    protected final void ensureDefaultTableSpaceBootedLocally(String defaultTableSpace) {
+        TableSpaceManager tableSpaceManager = getTableSpaceManager(defaultTableSpace);
+        if (tableSpaceManager == null) {
             throw new NotLeaderException("tablespace " + defaultTableSpace + " not available here (at server " + manager.getNodeId() + ")");
+        }
+    }
+
+    protected final TableSpaceManager getTableSpaceManager(String tableSpace) {
+        long startTs = System.currentTimeMillis();
+        while (true) {
+            TableSpaceManager result = manager.getTableSpaceManager(tableSpace);
+            if (result != null) {
+                return result;
+            }
+            long delta = System.currentTimeMillis() - startTs;
+            LOG.log(Level.FINE, "schema {0} not available yet, after waiting {1}/{2} ms",
+                    new Object[]{tableSpace, delta, waitForSchemaTimeout});
+            if (delta >= waitForSchemaTimeout) {
+                return null;
+            }
+            clearCache();
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException err) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }

--- a/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
@@ -20,22 +20,35 @@
 
 package herddb.sql;
 
+import herddb.core.DBManager;
+import herddb.model.NotLeaderException;
 import herddb.model.StatementExecutionException;
 import java.util.List;
 
 /**
  * @author eolivelli
  */
-public interface AbstractSQLPlanner {
+public abstract class AbstractSQLPlanner {
 
-    void clearCache();
+    protected final DBManager manager;
 
-    long getCacheHits();
+    public AbstractSQLPlanner(DBManager manager) {
+        this.manager = manager;
+    }
 
-    long getCacheMisses();
+    public abstract void clearCache();
 
-    long getCacheSize();
+    public abstract long getCacheHits();
 
-    TranslatedQuery translate(String defaultTableSpace, String query, List<Object> parameters, boolean scan, boolean allowCache, boolean returnValues, int maxRows) throws StatementExecutionException;
+    public abstract long getCacheMisses();
 
+    public abstract long getCacheSize();
+
+    public abstract TranslatedQuery translate(String defaultTableSpace, String query, List<Object> parameters, boolean scan, boolean allowCache, boolean returnValues, int maxRows) throws StatementExecutionException;
+
+    final void ensureDefaultTableSpaceBootedLocally(String defaultTableSpace) {
+        if (manager.getTableSpaceManager(defaultTableSpace) == null) {
+            throw new NotLeaderException("tablespace " + defaultTableSpace + " not available here (at server " + manager.getNodeId() + ")");
+        }
+    }
 }

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -71,7 +71,6 @@ import herddb.sql.expressions.JdbcParameterExpression;
 import herddb.sql.expressions.SQLExpressionCompiler;
 import herddb.sql.expressions.TypedJdbcParameterExpression;
 import herddb.utils.SQLUtils;
-import herddb.utils.SystemProperties;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -179,8 +178,6 @@ public class CalcitePlanner extends AbstractSQLPlanner {
     /**
      * Time to wait for the requested tablespace to be up
      */
-    private static final long WAIT_FOR_SCHEMA_UP_TIMEOUT = SystemProperties.getLongSystemProperty("herddb.planner.waitfortablespacetimeout", 60000);
-    private static final Level DUMP_QUERY_LEVEL = Level.parse(SystemProperties.getStringSystemProperty("herddb.planner.dumpqueryloglevel", Level.FINE.toString()));
 
     private static final Pattern USE_DDL_PARSER = Pattern.compile("^[\\s]*(EXECUTE|CREATE|DROP|ALTER|TRUNCATE|BEGIN|COMMIT|ROLLBACK).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
@@ -394,9 +391,9 @@ public class CalcitePlanner extends AbstractSQLPlanner {
                 return result;
             }
             long delta = System.currentTimeMillis() - startTs;
-            LOG.log(Level.INFO, "schema {0} not available yet, after waiting {1}/{2} ms",
-                    new Object[]{defaultTableSpace, delta, WAIT_FOR_SCHEMA_UP_TIMEOUT});
-            if (delta >= WAIT_FOR_SCHEMA_UP_TIMEOUT) {
+            LOG.log(Level.FINE, "schema {0} not available yet, after waiting {1}/{2} ms",
+                    new Object[]{defaultTableSpace, delta, waitForSchemaTimeout});
+            if (delta >= waitForSchemaTimeout) {
                 return null;
             }
             clearCache();

--- a/herddb-core/src/main/java/herddb/sql/NullSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/NullSQLPlanner.java
@@ -20,6 +20,7 @@
 
 package herddb.sql;
 
+import herddb.core.DBManager;
 import herddb.model.StatementExecutionException;
 import java.util.List;
 
@@ -28,7 +29,11 @@ import java.util.List;
  *
  * @author enrico.olivelli
  */
-public class NullSQLPlanner implements AbstractSQLPlanner {
+public class NullSQLPlanner extends AbstractSQLPlanner {
+
+    public NullSQLPlanner(DBManager manager) {
+        super(manager);
+    }
 
     @Override
     public void clearCache() {
@@ -54,7 +59,8 @@ public class NullSQLPlanner implements AbstractSQLPlanner {
             String defaultTableSpace, String query, List<Object> parameters, boolean scan,
             boolean allowCache, boolean returnValues, int maxRows
     ) throws StatementExecutionException {
-        throw new StatementExecutionException("SQL planner is disable on this server (query was '" + query + "'");
+        ensureDefaultTableSpaceBootedLocally(defaultTableSpace);
+        throw new StatementExecutionException("SQL planner is disabled on this server (query was '" + query + "'");
     }
 
 }

--- a/herddb-core/src/test/java/herddb/data/consistency/DataConsistencyCheckTest.java
+++ b/herddb-core/src/test/java/herddb/data/consistency/DataConsistencyCheckTest.java
@@ -53,6 +53,7 @@ public class DataConsistencyCheckTest {
 
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
             execute(manager, "CREATE TABLESPACE 'consistence'", Collections.emptyList());
             manager.waitForTablespace("tblspace1", 10000);
             execute(manager, "CREATE TABLE consistence.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
@@ -94,6 +95,7 @@ public class DataConsistencyCheckTest {
         String tableName = "t1";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
             execute(manager, "CREATE TABLESPACE 'tblspace1'", Collections.emptyList());
             manager.waitForTablespace("tblspace1", 10000);
             Table table = Table
@@ -121,6 +123,7 @@ public class DataConsistencyCheckTest {
         String tableName = "t1";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
             execute(manager, "CREATE TABLESPACE 'tblspace1'", Collections.emptyList());
             manager.waitForTablespace("tblspace1", 10000);
             Table table = Table
@@ -147,6 +150,7 @@ public class DataConsistencyCheckTest {
         String tableSpaceName = "tblspace1";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
             execute(manager, "CREATE TABLESPACE 'tblspace1'", Collections.emptyList());
             manager.waitForTablespace("tblspace1", 10000);
             manager.waitForTablespace(tableSpaceName, 10000, false);
@@ -189,6 +193,7 @@ public class DataConsistencyCheckTest {
         String tableName = "nulltable";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
             execute(manager, "CREATE TABLESPACE 't1'", Collections.emptyList());
             manager.waitForTablespace(tableSpaceName, 10000);
             Table table = Table

--- a/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
@@ -225,6 +225,11 @@ public class ClientMultiServerTest {
                     } catch (ClientSideMetadataProviderException ok) {
                          assertTrue(ok.getCause() instanceof LeaderChangedException);
                     }
+
+                    // ensure that we don't use internal plans cache
+                    server_1.getManager().getPlanner().clearCache();
+                    server_2.getManager().getPlanner().clearCache();
+
                     // without prepare statement
                     try {
                         connection.executeUpdate(TableSpace.DEFAULT, "UPDATE t1 set d=2 WHERE c=1", 0, false, false, Collections.emptyList());

--- a/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
+++ b/herddb-core/src/test/java/herddb/server/ClientMultiServerTest.java
@@ -97,6 +97,7 @@ public class ClientMultiServerTest {
         serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
         serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
         serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PLANNER_WAITFORTABLESPACE_TIMEOUT, 1000);
 
         ServerConfiguration serverconfig_2 = serverconfig_1
                 .copy()

--- a/herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
+++ b/herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
@@ -22,12 +22,9 @@ package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static org.junit.Assert.assertEquals;
-<<<<<<< HEAD:herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
+import static org.junit.Assert.assertTrue;
 import herddb.core.DBManager;
 import herddb.core.TestUtils;
-=======
-import static org.junit.Assert.assertTrue;
->>>>>>> fix flaky tests:herddb-core/src/test/java/herddb/core/BetterExecuteSyntaxTest.java
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;

--- a/herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
+++ b/herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
@@ -22,8 +22,12 @@ package herddb.sql;
 
 import static herddb.core.TestUtils.execute;
 import static org.junit.Assert.assertEquals;
+<<<<<<< HEAD:herddb-core/src/test/java/herddb/sql/BetterExecuteSyntaxTest.java
 import herddb.core.DBManager;
 import herddb.core.TestUtils;
+=======
+import static org.junit.Assert.assertTrue;
+>>>>>>> fix flaky tests:herddb-core/src/test/java/herddb/core/BetterExecuteSyntaxTest.java
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;
@@ -46,6 +50,7 @@ public class BetterExecuteSyntaxTest {
 
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
             execute(manager, "CREATE TABLESPACE 'tblspace1'", Collections.emptyList());
             manager.waitForTablespace("tblspace1", 10000);
 

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -38,6 +38,7 @@ import herddb.mem.MemoryMetadataStorageManager;
 import herddb.model.Column;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
+import herddb.model.NotLeaderException;
 import herddb.model.Projection;
 import herddb.model.ScanResult;
 import herddb.model.StatementEvaluationContext;
@@ -739,7 +740,7 @@ public class CalcitePlannerTest {
         }
     }
 
-    @Test(expected = TableSpaceDoesNotExistException.class)
+    @Test(expected = NotLeaderException.class)
     public void showCreateTable_Non_Existent_TableSpace() throws Exception {
         String nodeId = "localhost";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -46,7 +46,6 @@ import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableDoesNotExistException;
 import herddb.model.TableSpace;
-import herddb.model.TableSpaceDoesNotExistException;
 import herddb.model.TransactionContext;
 import herddb.model.Tuple;
 import herddb.model.TupleComparator;

--- a/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/CalcitePlannerTest.java
@@ -38,7 +38,6 @@ import herddb.mem.MemoryMetadataStorageManager;
 import herddb.model.Column;
 import herddb.model.ColumnTypes;
 import herddb.model.DataScanner;
-import herddb.model.NotLeaderException;
 import herddb.model.Projection;
 import herddb.model.ScanResult;
 import herddb.model.StatementEvaluationContext;
@@ -46,6 +45,7 @@ import herddb.model.StatementExecutionException;
 import herddb.model.Table;
 import herddb.model.TableDoesNotExistException;
 import herddb.model.TableSpace;
+import herddb.model.TableSpaceDoesNotExistException;
 import herddb.model.TransactionContext;
 import herddb.model.Tuple;
 import herddb.model.TupleComparator;
@@ -739,7 +739,7 @@ public class CalcitePlannerTest {
         }
     }
 
-    @Test(expected = NotLeaderException.class)
+    @Test(expected = TableSpaceDoesNotExistException.class)
     public void showCreateTable_Non_Existent_TableSpace() throws Exception {
         String nodeId = "localhost";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {


### PR DESCRIPTION
While working on jSQLParser planner I noticed that Calcite Planner could be wrong in thinking about local availability of tablespaces, because it is caching "RootSchema".

With this change we are adding an additional check.
Changes:
- move AbstractSQLPlanner from interface to an abstract class
- implement the check
- fix a test case, that reproduced the issue only with jSQLParser