### PR TITLE
Fix wire protocol compatibility with 0.19.0 servers

### DIFF
--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -443,7 +443,8 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             parameters.add(parametersReader.nextObject());
         }
         // with clients older than 0.20.0 keepReadLocks will be always true
-        boolean keepReadLocks = !PduCodec.OpenScanner.readDontKeepReadLocks(message);
+        byte trailer = parametersReader.readTrailer();
+        boolean keepReadLocks = (trailer & Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS) == Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS;
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.log(Level.FINER, "openScanner txId+" + txId + ", fetchSize " + fetchSize + ", maxRows " + maxRows + ", keepReadLocks " + keepReadLocks + ", " + query + " with " + parameters);
         }

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -20,6 +20,7 @@
 
 package herddb.server;
 
+import static herddb.proto.PduCodec.ObjectListReader.isDontKeepReadLocks;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_BEGIN_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_COMMIT_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_ROLLBACK_TRANSACTION;
@@ -444,7 +445,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         }
         // with clients older than 0.20.0 keepReadLocks will be always true
         byte trailer = parametersReader.readTrailer();
-        boolean keepReadLocks = (trailer & Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS) == Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS;
+        boolean keepReadLocks = !isDontKeepReadLocks(trailer);
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.log(Level.FINER, "openScanner txId+" + txId + ", fetchSize " + fetchSize + ", maxRows " + maxRows + ", keepReadLocks " + keepReadLocks + ", " + query + " with " + parameters);
         }

--- a/herddb-utils/src/main/java/herddb/proto/PduCodec.java
+++ b/herddb-utils/src/main/java/herddb/proto/PduCodec.java
@@ -1837,6 +1837,10 @@ public abstract class PduCodec {
             }
         }
 
+        public static boolean isDontKeepReadLocks(byte trailer) {
+            return ((trailer & Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS) == Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS);
+        }
+
     }
 
     private static void writeObject(ByteBuf byteBuf, Object v) {

--- a/herddb-utils/src/main/java/herddb/proto/PduCodec.java
+++ b/herddb-utils/src/main/java/herddb/proto/PduCodec.java
@@ -621,11 +621,7 @@ public abstract class PduCodec {
                                     + 1 + params.size() * 8);
 
             byteBuf.writeByte(VERSION_3);
-            int flags = Pdu.FLAGS_ISREQUEST;
-            if (!keepReadLocks) {
-                flags = flags | Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS;
-            }
-            byteBuf.writeByte(flags);
+            byteBuf.writeByte(Pdu.FLAGS_ISREQUEST);
             byteBuf.writeByte(Pdu.TYPE_OPENSCANNER);
             byteBuf.writeLong(messageId);
             byteBuf.writeLong(tx);
@@ -640,7 +636,10 @@ public abstract class PduCodec {
             for (Object p : params) {
                 writeObject(byteBuf, p);
             }
-
+            // trailer
+            if (!keepReadLocks) {
+                byteBuf.writeByte(Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS);
+            }
             return byteBuf;
 
         }
@@ -651,13 +650,6 @@ public abstract class PduCodec {
                     + FLAGS_SIZE
                     + TYPE_SIZE
                     + MSGID_SIZE);
-        }
-
-        public static boolean readDontKeepReadLocks(Pdu pdu) {
-            ByteBuf buffer = pdu.buffer;
-            byte flags =  buffer.getByte(VERSION_SIZE);
-            return (flags & Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS)
-                    == Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS;
         }
 
         public static long readStatementId(Pdu pdu) {
@@ -1834,6 +1826,15 @@ public abstract class PduCodec {
         public Object nextObject() {
             // assuming that the readerIndex is not altered but other direct accesses to the ByteBuf
             return readObject(pdu.buffer);
+        }
+
+        public byte readTrailer() {
+            // assuming that the readerIndex is not altered but other direct accesses to the ByteBuf
+            if (pdu.buffer.isReadable()) {
+                return pdu.buffer.readByte();
+            } else {
+                return 0;
+            }
         }
 
     }

--- a/herddb-utils/src/test/java/herddb/proto/PduCodecTest.java
+++ b/herddb-utils/src/test/java/herddb/proto/PduCodecTest.java
@@ -19,7 +19,9 @@
  */
 package herddb.proto;
 
+import static herddb.proto.PduCodec.ObjectListReader.isDontKeepReadLocks;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import herddb.utils.RawString;
 import io.netty.buffer.ByteBuf;
@@ -61,7 +63,7 @@ public class PduCodecTest {
             assertEquals(params.get(1), paramsReader.nextObject());
             assertEquals(params.get(2), paramsReader.nextObject());
             byte trailer = paramsReader.readTrailer();
-            assertTrue((trailer & Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS) == Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS);
+            assertTrue(isDontKeepReadLocks(trailer));
         }
 
         keepReadLocks = true; // NO TRAILER, this is what 0.19.0 clients did
@@ -83,6 +85,7 @@ public class PduCodecTest {
             assertEquals(params.get(2), paramsReader.nextObject());
             byte trailer = paramsReader.readTrailer();
             assertEquals(0, trailer);
+            assertFalse(isDontKeepReadLocks(trailer));
         }
 
     }

--- a/herddb-utils/src/test/java/herddb/proto/PduCodecTest.java
+++ b/herddb-utils/src/test/java/herddb/proto/PduCodecTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.proto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.utils.RawString;
+import io.netty.buffer.ByteBuf;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Tests about PduCodec
+ */
+public class PduCodecTest {
+
+    @Test
+    public void readObjectsTrailer() throws Exception {
+        long msgId = 1234;
+        String ts = "dsfs";
+        String query = "q";
+        long scannerId = 2332;
+        long tx = 353;
+        List<Object> params = Arrays.asList("1", 12L, 3d);
+        long statementId = 2342;
+        int fetchSize = 12313;
+        int maxRows = 1239;
+        boolean keepReadLocks = false; // we need a TRAILER, since 0.20.0
+        ByteBuf write = PduCodec.OpenScanner.write(msgId, ts, query, scannerId, tx, params, statementId, fetchSize, maxRows, keepReadLocks);
+        try (Pdu pdu = PduCodec.decodePdu(write);) {
+            assertEquals(msgId, pdu.messageId);
+            assertEquals(Pdu.TYPE_OPENSCANNER, pdu.type);
+            assertEquals(ts, PduCodec.OpenScanner.readTablespace(pdu));
+            assertEquals(query, PduCodec.OpenScanner.readQuery(pdu));
+            assertEquals(scannerId, PduCodec.OpenScanner.readScannerId(pdu));
+            assertEquals(tx, PduCodec.OpenScanner.readTx(pdu));
+            assertEquals(statementId, PduCodec.OpenScanner.readStatementId(pdu));
+            assertEquals(fetchSize, PduCodec.OpenScanner.readFetchSize(pdu));
+            assertEquals(maxRows, PduCodec.OpenScanner.readMaxRows(pdu));
+            PduCodec.ObjectListReader paramsReader = PduCodec.OpenScanner.startReadParameters(pdu);
+            assertEquals(params.size(), paramsReader.getNumParams());
+            assertEquals(RawString.of((String) params.get(0)), paramsReader.nextObject());
+            assertEquals(params.get(1), paramsReader.nextObject());
+            assertEquals(params.get(2), paramsReader.nextObject());
+            byte trailer = paramsReader.readTrailer();
+            assertTrue((trailer & Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS) == Pdu.FLAGS_OPENSCANNER_DONTKEEP_READ_LOCKS);
+        }
+
+        keepReadLocks = true; // NO TRAILER, this is what 0.19.0 clients did
+        write = PduCodec.OpenScanner.write(msgId, ts, query, scannerId, tx, params, statementId, fetchSize, maxRows, keepReadLocks);
+        try (Pdu pdu = PduCodec.decodePdu(write);) {
+            assertEquals(msgId, pdu.messageId);
+            assertEquals(Pdu.TYPE_OPENSCANNER, pdu.type);
+            assertEquals(ts, PduCodec.OpenScanner.readTablespace(pdu));
+            assertEquals(query, PduCodec.OpenScanner.readQuery(pdu));
+            assertEquals(scannerId, PduCodec.OpenScanner.readScannerId(pdu));
+            assertEquals(tx, PduCodec.OpenScanner.readTx(pdu));
+            assertEquals(statementId, PduCodec.OpenScanner.readStatementId(pdu));
+            assertEquals(fetchSize, PduCodec.OpenScanner.readFetchSize(pdu));
+            assertEquals(maxRows, PduCodec.OpenScanner.readMaxRows(pdu));
+            PduCodec.ObjectListReader paramsReader = PduCodec.OpenScanner.startReadParameters(pdu);
+            assertEquals(params.size(), paramsReader.getNumParams());
+            assertEquals(RawString.of((String) params.get(0)), paramsReader.nextObject());
+            assertEquals(params.get(1), paramsReader.nextObject());
+            assertEquals(params.get(2), paramsReader.nextObject());
+            byte trailer = paramsReader.readTrailer();
+            assertEquals(0, trailer);
+        }
+
+    }
+}


### PR DESCRIPTION
Use a trailer instead of the 'flags' field, that cannot be used due to a bug in the decoder

Fixes  #687 