### PR TITLE
Cache ZooKeeper handle and invalidate cache in case of server network  address change

### DIFF
--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -341,7 +341,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
             }
         } catch (java.net.ConnectException err) {
             // this error will be retryed by the client
-            throw new UnreachableServerException(err);
+            throw new UnreachableServerException("Cannot connect to " + nodeId, err, nodeId);
         } catch (HDBException err) {
             throw err;
         } catch (Exception err) {

--- a/herddb-core/src/main/java/herddb/client/ZookeeperClientSideMetadataProvider.java
+++ b/herddb-core/src/main/java/herddb/client/ZookeeperClientSideMetadataProvider.java
@@ -88,20 +88,19 @@ public final class ZookeeperClientSideMetadataProvider implements ClientSideMeta
         }
 
         private ZooKeeper get() throws InterruptedException {
-            ZooKeeper current = zk.get();
-            if (current != null
-                    && current.getState() != ZooKeeper.States.CLOSED) {
-                return current;
-            }
-
             makeLock.lockInterruptibly(); // we don't want to race creating ZK handles
             try {
+                ZooKeeper current = zk.get();
+                if (current != null
+                        && current.getState() != ZooKeeper.States.CLOSED) {
+                    return current;
+                }
+
                 ZooKeeper newHandle = makeZooKeeper();
                 boolean ok = zk.compareAndSet(current, newHandle);
                 if (ok) {
                     return newHandle;
                 } else {
-                    // we failed setting the reference ? this should not be possible
                     newHandle.close();
                     return current;
                 }

--- a/herddb-core/src/main/java/herddb/client/impl/UnreachableServerException.java
+++ b/herddb-core/src/main/java/herddb/client/impl/UnreachableServerException.java
@@ -27,21 +27,20 @@ package herddb.client.impl;
  */
 public class UnreachableServerException extends RetryRequestException {
 
-    public UnreachableServerException(String message) {
-        super(message);
-    }
+    private final String nodeId;
 
-    public UnreachableServerException(Throwable cause) {
-        super(cause);
-    }
-
-    public UnreachableServerException(String message, Throwable cause) {
+    public UnreachableServerException(String message, Throwable cause, String nodeId) {
         super(message, cause);
+        this.nodeId = nodeId;
     }
 
     @Override
     public boolean isRequireMetadataRefresh() {
         return true;
+    }
+
+    public String getNodeId() {
+        return nodeId;
     }
 
 }

--- a/herddb-core/src/test/java/herddb/client/ZookeeperClientSideMetadataProviderTest.java
+++ b/herddb-core/src/test/java/herddb/client/ZookeeperClientSideMetadataProviderTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.client.impl.UnreachableServerException;
+import herddb.cluster.ZookeeperMetadataStorageManager;
+import herddb.model.NodeMetadata;
+import herddb.model.TableSpace;
+import herddb.network.ServerHostData;
+import herddb.utils.TestUtils;
+import herddb.utils.ZKTestEnv;
+import java.io.IOException;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ZookeeperClientSideMetadataProviderTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        try (ZookeeperMetadataStorageManager server = new ZookeeperMetadataStorageManager(testEnv.getAddress(), testEnv.getTimeout(), testEnv.getPath());
+                ZookeeperClientSideMetadataProvider prov = new ZookeeperClientSideMetadataProvider(testEnv.getAddress(), testEnv.getTimeout(), testEnv.getPath());) {
+            server.start();
+            assertTrue(server.ensureDefaultTableSpace("node1", "node1", 5000, 1));
+            server.registerNode(NodeMetadata
+                    .builder()
+                    .host("test-node")
+                    .port(1234)
+                    .ssl(true)
+                    .nodeId("node1")
+                    .build());
+
+            ServerHostData currentData = prov.getServerHostData("node1");
+            assertEquals("test-node", currentData.getHost());
+            assertEquals(1234, currentData.getPort());
+            assertTrue(currentData.isSsl());
+
+            assertEquals("node1", prov.getTableSpaceLeader(TableSpace.DEFAULT));
+
+            server.registerNode(NodeMetadata
+                    .builder()
+                    .host("test-node-newhost")
+                    .port(1234)
+                    .ssl(true)
+                    .nodeId("node1")
+                    .build());
+
+            prov.requestMetadataRefresh(new UnreachableServerException("error", new IOException(), "node1"));
+            assertEquals("node1", prov.getTableSpaceLeader(TableSpace.DEFAULT));
+
+            currentData = prov.getServerHostData("node1");
+            assertEquals("test-node-newhost", currentData.getHost());
+            assertEquals(1234, currentData.getPort());
+            assertTrue(currentData.isSsl());
+
+            prov.requestMetadataRefresh(new Exception());
+
+            currentData = prov.getServerHostData("node1");
+            assertEquals("test-node-newhost", currentData.getHost());
+            assertEquals(1234, currentData.getPort());
+            assertTrue(currentData.isSsl());
+            assertEquals("node1", prov.getTableSpaceLeader(TableSpace.DEFAULT));
+
+            final ZooKeeper currentZooKeeper = prov.getZooKeeper();
+
+            // expire session
+            currentZooKeeper.getTestable().injectSessionExpiration();
+
+            // wait for a new handle to be created
+            TestUtils.waitForCondition(() -> {
+                ZooKeeper zk = prov.getZooKeeper();
+                return zk != currentZooKeeper;
+            }, TestUtils.NOOP, 100);
+
+            // clean cache
+            prov.requestMetadataRefresh(new UnreachableServerException("error", new IOException(), "node1"));
+
+            assertEquals("node1", prov.getTableSpaceLeader(TableSpace.DEFAULT));
+            prov.getServerHostData("node1");
+            assertEquals("test-node-newhost", currentData.getHost());
+            assertEquals(1234, currentData.getPort());
+            assertTrue(currentData.isSsl());
+            assertEquals("node1", prov.getTableSpaceLeader(TableSpace.DEFAULT));
+
+
+        }
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/cluster/ServerWithDynamicPortTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/ServerWithDynamicPortTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.cluster;
+
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.client.HDBConnection;
+import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.utils.ZKTestEnv;
+import java.util.Collections;
+import java.util.logging.Logger;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.test.TestStatsProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests about retrying queries in case of network address change.
+ *
+ * @author enrico.olivelli
+ */
+public class ServerWithDynamicPortTest {
+
+    private static final Logger LOG = Logger.getLogger(ServerWithDynamicPortTest.class.getName());
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        testEnv.startBookieAndInitCluster();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+
+        TestStatsProvider statsProvider = new TestStatsProvider();
+
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        clientConfiguration.set(ClientConfiguration.PROPERTY_MODE, ClientConfiguration.PROPERTY_MODE_CLUSTER);
+        clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        clientConfiguration.set(ClientConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+
+        StatsLogger logger = statsProvider.getStatsLogger("ds");
+        try (HDBClient client1 = new HDBClient(clientConfiguration, logger)) {
+            try (HDBConnection connection = client1.openConnection()) {
+
+                try (Server server_1 = new Server(serverconfig_1)) {
+                    server_1.start();
+                    server_1.waitForStandaloneBoot();
+
+                    // create table and insert data
+                    connection.executeUpdate(TableSpace.DEFAULT, "CREATE TABLE t1(k1 int primary key, n1 int)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                    connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO t1(k1,n1) values(1,1)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                }
+
+                // change port
+                serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7868);
+                try (Server server_1 = new Server(serverconfig_1)) {
+                    server_1.start();
+                    server_1.waitForStandaloneBoot();
+
+                    connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO t1(k1,n1) values(2,1)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                    connection.executeUpdate(TableSpace.DEFAULT, "INSERT INTO t1(k1,n1) values(3,1)",
+                            TransactionContext.NOTRANSACTION_ID, false, false, Collections.emptyList());
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
I noticed that on the client we are not caching the ZooKeeper client ! This is a huge problem.
Also, in case of network address change of a node, the client is not invalidating propertly the routes maps and it also invalidate the caches too eagerly, requiring a great amount of work.

Changes:
- cache ZK client
- invalidate properly the caches