### PR TITLE
Wait for BookKeeper Cluster to start

### DIFF
--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
@@ -62,10 +62,13 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
     private long ledgersRetentionPeriod = 1000 * 60 * 60 * 24;
     private long maxLedgerSizeBytes = 100 * 1024 * 1024 * 1024;
     private long maxIdleTime = 0;
+    private long bookkeeperClusterReadyWaitTime = 60_000;
+
     private ConcurrentHashMap<String, BookkeeperCommitLog> activeLogs = new ConcurrentHashMap<>();
 
     public BookkeeperCommitLogManager(ZookeeperMetadataStorageManager metadataStorageManager, ServerConfiguration serverConfiguration, StatsLogger statsLogger) {
         this.statsLogger = statsLogger;
+        this.bookkeeperClusterReadyWaitTime = serverConfiguration.getInt(ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT, ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT_DEFAULT);
         config = new ClientConfiguration();
 
         config.setThrottleValue(0);
@@ -202,6 +205,14 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
 
     public void setMaxIdleTime(long maxIdleTime) {
         this.maxIdleTime = maxIdleTime;
+    }
+
+    public long getBookkeeperClusterReadyWaitTime() {
+        return bookkeeperClusterReadyWaitTime;
+    }
+
+    public void setBookkeeperClusterReadyWaitTime(long bookkeeperClusterReadyWaitTime) {
+        this.bookkeeperClusterReadyWaitTime = bookkeeperClusterReadyWaitTime;
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
+++ b/herddb-core/src/main/java/herddb/cluster/BookkeeperCommitLogManager.java
@@ -68,7 +68,7 @@ public class BookkeeperCommitLogManager extends CommitLogManager {
 
     public BookkeeperCommitLogManager(ZookeeperMetadataStorageManager metadataStorageManager, ServerConfiguration serverConfiguration, StatsLogger statsLogger) {
         this.statsLogger = statsLogger;
-        this.bookkeeperClusterReadyWaitTime = serverConfiguration.getInt(ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT, ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT_DEFAULT);
+        this.bookkeeperClusterReadyWaitTime = serverConfiguration.getLong(ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT, ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT_DEFAULT);
         config = new ClientConfiguration();
 
         config.setThrottleValue(0);

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -465,7 +465,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         // that if you lose the node with the server you will have at most 1 minute of unavailability (no leader)
         if (ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER.equals(mode)) {
             initialDefaultTableSpaceReplicaNode = TableSpace.ANY_NODE;
-            initialDefaultTableSpaceMaxLeaderInactivityTime = 60_000; // 1 minute            
+            initialDefaultTableSpaceMaxLeaderInactivityTime = 60_000; // 1 minute
             expectedreplicacount = serverConfiguration.getInt(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT);
         } else if (ServerConfiguration.PROPERTY_MODE_CLUSTER.equals(mode)) {
             expectedreplicacount = serverConfiguration.getInt(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT);

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -465,7 +465,9 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         // that if you lose the node with the server you will have at most 1 minute of unavailability (no leader)
         if (ServerConfiguration.PROPERTY_MODE_DISKLESSCLUSTER.equals(mode)) {
             initialDefaultTableSpaceReplicaNode = TableSpace.ANY_NODE;
-            initialDefaultTableSpaceMaxLeaderInactivityTime = 60_000; // 1 minute
+            initialDefaultTableSpaceMaxLeaderInactivityTime = 60_000; // 1 minute            
+            expectedreplicacount = serverConfiguration.getInt(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT);
+        } else if (ServerConfiguration.PROPERTY_MODE_CLUSTER.equals(mode)) {
             expectedreplicacount = serverConfiguration.getInt(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT_DEFAULT);
         }
         boolean created = metadataStorageManager.ensureDefaultTableSpace(initialDefaultTableSpaceLeader, initialDefaultTableSpaceReplicaNode,

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -148,6 +148,9 @@ public final class ServerConfiguration {
     public static final String PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD = "server.bookkeeper.ledgers.retention.period";
     public static final long PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD_DEFAULT = 1000L * 60 * 60 * 24 * 2;
 
+    public static final String PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT = "server.bookkeeper.wait.cluser.ready.timeout";
+    public static final int PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT_DEFAULT = 6000 * 2; // 2 minutes
+
     public static final String PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE = "server.bookkeeper.ledgers.max.size";
     public static final long PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE_DEFAULT = 1024L * 1024 * 1024;
 

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -149,7 +149,7 @@ public final class ServerConfiguration {
     public static final long PROPERTY_BOOKKEEPER_LEDGERS_RETENTION_PERIOD_DEFAULT = 1000L * 60 * 60 * 24 * 2;
 
     public static final String PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT = "server.bookkeeper.wait.cluser.ready.timeout";
-    public static final int PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT_DEFAULT = 6000 * 2; // 2 minutes
+    public static final int PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT_DEFAULT = 60_000 * 2; // 2 minutes
 
     public static final String PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE = "server.bookkeeper.ledgers.max.size";
     public static final long PROPERTY_BOOKKEEPER_LEDGERS_MAX_SIZE_DEFAULT = 1024L * 1024 * 1024;

--- a/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
@@ -106,7 +106,7 @@ public class WaitForBookiesTest {
                     .build();
             server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
-            try ( DataScanner scan = scan(server_1.getManager(), "SELECT * FROM systablespacereplicastate", Collections.emptyList())) {
+            try (DataScanner scan = scan(server_1.getManager(), "SELECT * FROM systablespacereplicastate", Collections.emptyList())) {
                 List<DataAccessor> results = scan.consume();
                 assertEquals(1, results.size());
             }

--- a/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
@@ -92,13 +92,13 @@ public class WaitForBookiesTest {
         }
 
         serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT, 10000);
-        try (Server server_1 = new Server(serverconfig_1)) {                         
+        try (Server server_1 = new Server(serverconfig_1)) {
             server_1.start();
             // add a second bookie after starting the server
             testEnv.startNewBookie();
             server_1.waitForTableSpaceBoot(TableSpace.DEFAULT, 5000, true);
-                       
-            // verify server is working at it is able to write to the WAL           
+
+            // verify server is working at it is able to write to the WAL
             Table table = Table.builder()
                     .name("t1")
                     .column("c", ColumnTypes.INTEGER)

--- a/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/WaitForBookiesTest.java
@@ -1,0 +1,118 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.cluster;
+
+import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertEquals;
+import herddb.model.ColumnTypes;
+import herddb.model.DataScanner;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.Table;
+import herddb.model.TableSpace;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableStatement;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.utils.DataAccessor;
+import herddb.utils.TestUtils;
+import herddb.utils.ZKTestEnv;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Booting two servers, one table space, bookies are not available at cluster bootstrap.
+ *
+ * @author enrico.olivelli
+ */
+public class WaitForBookiesTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ZKTestEnv testEnv;
+
+    @Before
+    public void beforeSetup() throws Exception {
+        testEnv = new ZKTestEnv(folder.newFolder().toPath());
+        // start only one bookie
+        testEnv.startBookieAndInitCluster();
+    }
+
+    @After
+    public void afterTeardown() throws Exception {
+        if (testEnv != null) {
+            testEnv.close();
+        }
+    }
+
+    @Test
+    public void testBootstrapClusterWaitForBookies() throws Exception {
+        ServerConfiguration serverconfig_1 = new ServerConfiguration(folder.newFolder().toPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
+        serverconfig_1.set(ServerConfiguration.PROPERTY_PORT, 7867);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
+        serverconfig_1.set(ServerConfiguration.PROPERTY_DEFAULT_REPLICA_COUNT, 2);
+
+        serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT, 0);
+
+        try (Server server_1 = new Server(serverconfig_1)) {
+            // boot should fail, as we need two bookies
+            server_1.start();
+            server_1.getManager().setActivatorPauseStatus(true);
+            Exception err = TestUtils.expectThrows(Exception.class, () -> {
+                server_1.waitForTableSpaceBoot(TableSpace.DEFAULT, 5000, true);
+            });
+            assertEquals("TableSpace " + TableSpace.DEFAULT + " not started within 5000 ms", err.getMessage());
+        }
+
+        serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_WAIT_CLUSTER_READY_TIMEOUT, 10000);
+        try (Server server_1 = new Server(serverconfig_1)) {                         
+            server_1.start();
+            // add a second bookie after starting the server
+            testEnv.startNewBookie();
+            server_1.waitForTableSpaceBoot(TableSpace.DEFAULT, 5000, true);
+                       
+            // verify server is working at it is able to write to the WAL           
+            Table table = Table.builder()
+                    .name("t1")
+                    .column("c", ColumnTypes.INTEGER)
+                    .primaryKey("c")
+                    .build();
+            server_1.getManager().executeStatement(new CreateTableStatement(table), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+
+            try ( DataScanner scan = scan(server_1.getManager(), "SELECT * FROM systablespacereplicastate", Collections.emptyList())) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals(1, results.size());
+            }
+
+        }
+
+    }
+
+}

--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -106,6 +106,9 @@ server.bookkeeper.ack.quorum.size=1
 # retention period, in milliseconds, of bookkeeper ledgers
 server.bookkeeper.ledgers.retention.period=34560000
 
+# wait for BookKeeper cluster to be ready while bootstrapping a tablespace
+#server.bookkeeper.wait.cluser.ready.timeout=120000
+
 # maximum size of a single ledger
 # if you have huge ledgers than you cannot recover Bookie disk space during checkpoints
 # so it is better to roll a new ledger after a given amount of written bytes
@@ -197,3 +200,8 @@ server.network.thread.callback.workers=64
 
 # threads for handling executions of activity which happen after writing to the log (mostly DML)
 server.async.thread.workers=64
+
+# additional Bookie properties
+# every entry that starts with 'bookie.' will be passed to the embedded Bookie, after stripping out the prefix
+# set bookie.allowLoopback=true for local testing, this flag will allow the bookie to bind on 127.0.0.1/localhost
+#bookie.allowLoopback=false

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <libs.calcite>1.24.0</libs.calcite>
         <libs.commonslang>2.6</libs.commonslang>
         <libs.jackson.mapper>2.10.3</libs.jackson.mapper>
-        <libs.zookeeper>3.6.1</libs.zookeeper>
+        <libs.zookeeper>3.6.2</libs.zookeeper>
         <libs.jsqlparser>3.2</libs.jsqlparser>
         <libs.curator>2.12.0</libs.curator>
         <libs.guava>21.0</libs.guava>


### PR DESCRIPTION
- Wait for bookie to be up and running while boostrapping a Tablespace (server.bookkeeper.wait.cluser.ready.timeout)
- Upgrade to ZooKeeper 3.6.2
- Clean up log level
- Use default expectedreplicacount even for "herd" tablespace

With this change is will be easy to start an HerdDB cluster with default expectedreplicacount greater than one, because the first server will have time to wait for the other servers to start the internal bookie

set server.bookkeeper.wait.cluser.ready.timeout=0 in order to rollback to previous behaviour

