### PR TITLE
Allow to update the PK of a record (ReplaceOp)

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -429,7 +429,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
     }
 
-    private TableContext buildTableContext() {
+    public TableContext buildTableContext() {
         TableContext tableContext;
         if (!table.auto_increment) {
             tableContext = new TableContext() {
@@ -1118,6 +1118,8 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             value = insert.getValuesFunction().computeNewValue(new Record(key, null), context, tableContext);
         } catch (StatementExecutionException validationError) {
             return Futures.exception(validationError);
+        } catch (Throwable validationError) {
+            return Futures.exception(new StatementExecutionException(validationError));
         }
         List<UniqueIndexLockReference> uniqueIndexes = null;
         Map<String, AbstractIndexManager> indexes = tableSpaceManager.getIndexesOnTable(table.name);

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -2088,7 +2088,9 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
         List<String> updateColumnList = new ArrayList<>(projects.size());
         for (net.sf.jsqlparser.schema.Column column : update.getColumns()) {
             checkSupported(column.getTable() == null);
-            updateColumnList.add(fixMySqlBackTicks(column.getColumnName()));
+            String columnName = fixMySqlBackTicks(column.getColumnName().toLowerCase());
+            checkSupported(!tableImpl.isPrimaryKeyColumn(columnName));
+            updateColumnList.add(columnName);
             CompiledSQLExpression exp =
                     SQLParserExpressionCompiler.compileExpression(projects.get(index), tableSchema);
             expressions.add(exp);

--- a/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
+++ b/herddb-core/src/main/java/herddb/sql/SQLRecordKeyFunction.java
@@ -98,12 +98,13 @@ public class SQLRecordKeyFunction extends RecordFunction {
                 return cachedResult;
             }
         }
+        final DataAccessor prevRecord = previous == null ? DataAccessor.NULL : previous.getDataAccessor(tableContext.getTable());
 
         Map<String, Object> pk = new HashMap<>();
         for (int i = 0; i < columns.length; i++) {
             herddb.model.Column c = columns[i];
             CompiledSQLExpression expression = expressions.get(i);
-            Object value = expression.evaluate(DataAccessor.NULL, context);
+            Object value = expression.evaluate(prevRecord, context);
             if (value == null) {
                 throw new InvalidNullValueForKeyException("error while converting primary key " + pk + ", keys cannot be null");
             }


### PR DESCRIPTION
Support `UPDATE table set PK=xxx ....`
Previously that kind of statements where basically no-op

- introduce ReplaceOp that basically issues Delete and then Insert Commands
- the generated operations are not executed atomically if not inside of a Transaction
- introduce TestUtils#dump function as helper for tests
- implementation only for Calcite based planner
- simplify UpdateOp while accessing the PK
