### PR TITLE
Implement Oracle-LIKE DUAL table

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -35,6 +35,7 @@ import herddb.core.stats.TableSpaceManagerStats;
 import herddb.core.system.SysclientsTableManager;
 import herddb.core.system.SyscolumnsTableManager;
 import herddb.core.system.SysconfigTableManager;
+import herddb.core.system.SysdualTableManager;
 import herddb.core.system.SysindexcolumnsTableManager;
 import herddb.core.system.SysindexesTableManager;
 import herddb.core.system.SyslogstatusManager;
@@ -226,6 +227,7 @@ public class TableSpaceManager {
             registerSystemTableManager(new SyscolumnsTableManager(this));
             registerSystemTableManager(new SystransactionsTableManager(this));
             registerSystemTableManager(new SyslogstatusManager(this));
+            registerSystemTableManager(new SysdualTableManager(this));
         }
         registerSystemTableManager(new SystablespacesTableManager(this));
         registerSystemTableManager(new SystablespacereplicastateTableManager(this));

--- a/herddb-core/src/main/java/herddb/core/system/SysdualTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysdualTableManager.java
@@ -47,7 +47,7 @@ public class SysdualTableManager extends AbstractSystemTableManager {
             .primaryKey("dummy")
             .build();
     private final List<Record> result;
-        
+
     public SysdualTableManager(TableSpaceManager parent) {
         super(parent, TABLE);
         this.result = Collections.singletonList(RecordSerializer.makeRecord(

--- a/herddb-core/src/main/java/herddb/core/system/SysdualTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysdualTableManager.java
@@ -25,7 +25,7 @@ import herddb.model.ColumnTypes;
 import herddb.model.Record;
 import herddb.model.Table;
 import herddb.model.Transaction;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -46,19 +46,19 @@ public class SysdualTableManager extends AbstractSystemTableManager {
             .column("dummy", ColumnTypes.STRING)
             .primaryKey("dummy")
             .build();
-
+    private final List<Record> result;
+        
     public SysdualTableManager(TableSpaceManager parent) {
         super(parent, TABLE);
+        this.result = Collections.singletonList(RecordSerializer.makeRecord(
+                table,
+                "dummy", "X"
+        ));
     }
 
     @Override
     protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
-        List<Record> result = new ArrayList<>(1);
-        result.add(RecordSerializer.makeRecord(
-                table,
-                "dummy", "X"
-        ));
-        return result;
+       return result;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/core/system/SysdualTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysdualTableManager.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.core.system;
+
+import herddb.codec.RecordSerializer;
+import herddb.core.TableSpaceManager;
+import herddb.model.ColumnTypes;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.model.Transaction;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Table Manager for the DUAL virtual table.
+ * DUAL is a table automatically created by Oracle Database along with the data dictionary.
+ * DUAL is in the schema of the user SYS but is accessible by the name DUAL to all users.
+ * It has one column, DUMMY, defined to be VARCHAR2(1), and contains one row with a value X.
+ * Selecting from the DUAL table is useful for computing a constant expression with the SELECT statement.
+ * Because DUAL has only one row, the constant is returned only once.
+ *
+ * @author enrico.olivelli
+ */
+public class SysdualTableManager extends AbstractSystemTableManager {
+
+    private static final Table TABLE = Table
+            .builder()
+            .name("dual")
+            .column("dummy", ColumnTypes.STRING)
+            .primaryKey("dummy")
+            .build();
+
+    public SysdualTableManager(TableSpaceManager parent) {
+        super(parent, TABLE);
+    }
+
+    @Override
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
+        List<Record> result = new ArrayList<>(1);
+        result.add(RecordSerializer.makeRecord(
+                table,
+                "dummy", "X"
+        ));
+        return result;
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/core/system/SystablesTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SystablesTableManager.java
@@ -61,7 +61,7 @@ public class SystablesTableManager extends AbstractSystemTableManager {
                         "table_name", r.name,
                         "table_uuid", r.uuid,
                         "systemtable",
-                        r.name.startsWith("sys") ? "true" : "false"
+                        r.name.startsWith("sys") || r.name.equals("dual") ? "true" : "false"
                 ))
                 .collect(Collectors.toList());
     }

--- a/herddb-core/src/test/java/herddb/sql/SystemTablesTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SystemTablesTest.java
@@ -180,7 +180,7 @@ public class SystemTablesTest {
                         })
                         .findAny()
                         .isPresent());
-                assertEquals(24, records.size());
+                assertEquals(25, records.size());
             }
 
             try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.sysindexcolumns where table_name like '%tsql' order by index_name, column_name",

--- a/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
@@ -236,7 +236,7 @@ public class SystemTablesTest {
                             records.add(record);
                         }
                         // this is to be incremented at every new systable
-                        assertEquals(24, records.size());
+                        assertEquals(25, records.size());
                     }
                     try (ResultSet rs = metaData.getSchemas()) {
                         List<List<String>> records = new ArrayList<>();


### PR DESCRIPTION
Implement a system table named 'dual' like Oracle specs:

`DUAL is a table automatically created by Oracle Database along with the data dictionary. DUAL is in the schema of the user SYS but is accessible by the name DUAL to all users. It has one column, DUMMY, defined to be VARCHAR2(1), and contains one row with a value X. Selecting from the DUAL table is useful for computing a constant expression with the SELECT statement. Because DUAL has only one row, the constant is returned only once. `


see https://docs.oracle.com/cd/B19306_01/server.102/b14200/queries009.htm