### PR TITLE
Upgrade Guava to 29.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <libs.zookeeper>3.6.2</libs.zookeeper>
         <libs.jsqlparser>3.2</libs.jsqlparser>
         <libs.curator>2.12.0</libs.curator>
-        <libs.guava>21.0</libs.guava>
+        <libs.guava>29.0-jre</libs.guava>
         <libs.slf4j>1.7.29</libs.slf4j>
         <libs.commonscollections>3.2.2</libs.commonscollections>
         <libs.lz4>1.3.0</libs.lz4>


### PR DESCRIPTION
This upgraded is needed to address a known vulnerability of Guava, even if we are not affected directly

> CVE-2018-10237
> moderate severity
> Vulnerable versions: > 11.0, < 24.1.1
> Patched version: 24.1.1
> Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.