### PR TITLE
Basic support for ForeignKeys

### DIFF
--- a/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/AbstractTableManager.java
@@ -147,6 +147,9 @@ public interface AbstractTableManager extends AutoCloseable {
 
     void scanForIndexRebuild(Consumer<Record> records) throws DataStorageManagerException;
 
+    default void rebuildForeignKeyReferences(Table table) {
+    }
+
     final class TableCheckpoint {
 
         final String tableName;

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1254,7 +1254,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         // invalidated consistently during DML operations.
         for (ForeignKeyDef fk : childTable.foreignKeys) {
             String query = parentForeignKeyQueries.computeIfAbsent(childTable.name + "." + fk.name, (l -> {
-                // with '*' we are not gping to perform projections or copies
+                // with '*' we are not going to perform projections or copies
                 StringBuilder q = new StringBuilder("SELECT * FROM ");
                 q.append(childTable.tablespace);
                 q.append(".");
@@ -1306,7 +1306,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         // invalidated consistently during DML operations.
         String query = childForeignKeyQueries.computeIfAbsent(fk.name, (l -> {
             Table parentTable = tableSpaceManager.getTableManagerByUUID(fk.parentTableId).getTable();
-            // with '*' we are not gping to perform projections or copies
+            // with '*' we are not going to perform projections or copies
             StringBuilder q = new StringBuilder("SELECT * FROM ");
             q.append(parentTable.tablespace);
             q.append(".");

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1556,11 +1556,9 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
 
     private void releaseMultiplePendingLogEntryWorks(List<CompletableFuture<PendingLogEntryWork>> writes) {
         for (CompletableFuture<PendingLogEntryWork> pending : writes) {
-            if (!pending.isCompletedExceptionally()) {
-                PendingLogEntryWork now = pending.getNow(null);
-                if (now != null) {
-                    releasePendingLogEntryWorkLocks(now);
-                }
+            PendingLogEntryWork now = Futures.getIfSuccess(pending);
+            if (now != null) {
+                releasePendingLogEntryWorkLocks(now);
             }
         }
     }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1602,8 +1602,10 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                     try {
                         if (indexes != null || childrenTables != null) {
                             DataAccessor dataAccessor = current.getDataAccessor(table);
-                            for (Table childTable : childrenTables) {
-                                checkForeignKeyConstraintsAsParentTable(childTable, dataAccessor, context, transaction);
+                            if (childrenTables != null) {
+                                for (Table childTable : childrenTables) {
+                                    checkForeignKeyConstraintsAsParentTable(childTable, dataAccessor, context, transaction);
+                                }
                             }
                             if (indexes != null) {
                                 for (AbstractIndexManager index : indexes.values()) {

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -838,27 +838,27 @@ public class TableSpaceManager {
         dataStorageManager.tableSpaceMetadataUpdated(tableSpace.uuid, tableSpace.expectedReplicaCount);
     }
 
-    AbstractTableManager getTableManagerByUUID(String parentTableId) {
+    AbstractTableManager getTableManagerByUUID(String uuid) {
         //TODO: make this method more efficient
         for (AbstractTableManager manager : tables.values()) {
-            if (manager.getTable().uuid.equals(parentTableId)) {
+            if (manager.getTable().uuid.equals(uuid)) {
                 return manager;
             }
         }
-        throw new HerdDBInternalException("Cannot find tablemanager for " + parentTableId);
+        throw new HerdDBInternalException("Cannot find tablemanager for " + uuid);
     }
 
-    public Table[] collectChildrenTables(Table childTable) {
+    public Table[] collectChildrenTables(Table parentTable) {
         List<Table> list = new ArrayList<>();
         for (AbstractTableManager manager : tables.values()) {
             Table table = manager.getTable();
-            if (table.isChildTable(childTable.uuid)) {
+            if (table.isChildOfTable(parentTable.uuid)) {
                 list.add(table);
             }
         }
         // selft reference
-        if (childTable.isChildTable(childTable.uuid)) {
-            list.add(childTable);
+        if (parentTable.isChildOfTable(parentTable.uuid)) {
+            list.add(parentTable);
         }
         return list.isEmpty() ? null : list.toArray(new Table[0]);
     }

--- a/herddb-core/src/main/java/herddb/model/ColumnTypes.java
+++ b/herddb-core/src/main/java/herddb/model/ColumnTypes.java
@@ -209,7 +209,7 @@ public class ColumnTypes {
         if (type == otherType) {
             return true;
         }
-        return getNonNullTypeForPrimitiveType(type) != getNonNullTypeForPrimitiveType(otherType);
+        return getNonNullTypeForPrimitiveType(type) == getNonNullTypeForPrimitiveType(otherType);
     }
 
     public static boolean isNotNullToNullConversion(int oldType, int newType) {

--- a/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
+++ b/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
@@ -35,18 +35,20 @@ public final class ForeignKeyDef {
     public final String parentTableId; // uuid, not name
     public final String[] columns;
     public final String[] parentTableColumns;
-    public final int cascadeAction;
+    public final int onUpdateCascadeAction;
+    public final int onDeleteCascadeAction;
 
-    public static Builder bulder() {
+    public static Builder builder() {
         return new Builder();
     }
 
-    private ForeignKeyDef(String name, String parentTableId, String[] columns, String[] parentTableColumns, int cascadeAction) {
+    private ForeignKeyDef(String name, String parentTableId, String[] columns, String[] parentTableColumns, int onUpdateCascadeAction, int onDeleteCascadeAction) {
         this.name = name;
         this.parentTableId = parentTableId;
         this.columns = columns;
         this.parentTableColumns = parentTableColumns;
-        this.cascadeAction = cascadeAction;
+        this.onUpdateCascadeAction = onUpdateCascadeAction;
+        this.onDeleteCascadeAction = onDeleteCascadeAction;
     }
 
     public static class Builder {
@@ -55,7 +57,9 @@ public final class ForeignKeyDef {
         private String parentTableId; // uuid, not name
         private final List<String> columns = new ArrayList<>();
         private final List<String> parentTableColumns = new ArrayList<>();
-        private int cascadeAction;
+        private int onUpdateCascadeAction;
+        private int onDeleteCascadeAction;
+
 
         public Builder name(String name) {
             this.name = name;
@@ -77,8 +81,13 @@ public final class ForeignKeyDef {
             return this;
         }
 
-        public Builder cascadeAction(int cascadeAction) {
-            this.cascadeAction = cascadeAction;
+        public Builder onUpdateCascadeAction(int onUpdateCascadeAction) {
+            this.onUpdateCascadeAction = onUpdateCascadeAction;
+            return this;
+        }
+
+        public Builder onDeleteCascadeAction(int onDeleteCascadeAction) {
+            this.onDeleteCascadeAction = onDeleteCascadeAction;
             return this;
         }
 
@@ -86,8 +95,11 @@ public final class ForeignKeyDef {
             if (parentTableId == null || parentTableId.isEmpty()) {
                 throw new IllegalArgumentException("parentTableId must be set");
             }
-            if (cascadeAction != ACTION_NO_ACTION) {
-                throw new IllegalArgumentException("invalid cascadeAction " + cascadeAction);
+            if (onUpdateCascadeAction != ACTION_NO_ACTION) {
+                throw new IllegalArgumentException("invalid onUpdateCascadeAction " + onUpdateCascadeAction);
+            }
+            if (onDeleteCascadeAction != ACTION_NO_ACTION) {
+                throw new IllegalArgumentException("invalid onDeleteCascadeAction " + onDeleteCascadeAction);
             }
             if (parentTableColumns.size() != columns.size()) {
                 throw new IllegalArgumentException("the number of columns in child and parent table must be the same");
@@ -98,7 +110,7 @@ public final class ForeignKeyDef {
             return new ForeignKeyDef(name, parentTableId,
                     columns.toArray(new String[0]),
                     parentTableColumns.toArray(new String[0]),
-                    cascadeAction);
+                    onUpdateCascadeAction, onDeleteCascadeAction);
         }
 
     }

--- a/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
+++ b/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.model;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Definition of a ForeignKey constaint.
+ */
+@SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
+public final class ForeignKeyDef {
+
+    public static final int ACTION_NO_ACTION = 0; // NO_ACTION means to reject the operation
+
+    public final String parentTableId; // uuid, not name
+    public final String[] columns;
+    public final String[] parentTableColumns;
+    public final int cascadeAction;
+
+    public static Builder bulder() {
+        return new Builder();
+    }
+
+    private ForeignKeyDef(String parentTableId, String[] columns, String[] parentTableColumns, int cascadeAction) {
+        this.parentTableId = parentTableId;
+        this.columns = columns;
+        this.parentTableColumns = parentTableColumns;
+        this.cascadeAction = cascadeAction;
+    }
+
+    public static class Builder {
+
+        private String parentTableId; // uuid, not name
+        private final List<String> columns = new ArrayList<>();
+        private final List<String> parentTableColumns = new ArrayList<>();
+        private int cascadeAction;
+
+        public Builder parentTableId(String parentTableId) {
+            this.parentTableId = parentTableId;
+            return this;
+        }
+
+        public Builder column(String column) {
+            this.columns.add(column);
+            return this;
+        }
+
+        public Builder parentTableColumn(String parentTableColumn) {
+            this.parentTableColumns.add(parentTableColumn);
+            return this;
+        }
+
+        public Builder cascadeAction(int cascadeAction) {
+            this.cascadeAction = cascadeAction;
+            return this;
+        }
+
+        public ForeignKeyDef build() {
+            if (parentTableId == null || parentTableId.isEmpty()) {
+                throw new IllegalArgumentException("parentTableId must be set");
+            }
+            if (cascadeAction != ACTION_NO_ACTION) {
+                throw new IllegalArgumentException("invalid cascadeAction "+cascadeAction);
+            }
+            if (parentTableColumns.size() != columns.size()) {
+                throw new IllegalArgumentException("the number of columns in child and parent table must be the same");
+            }
+            if (columns.isEmpty()) {
+                throw new IllegalArgumentException("a foreign key constaint must refer to at least one column");
+            }
+            return new ForeignKeyDef(parentTableId,
+                    columns.toArray(new String[0]),
+                    parentTableColumns.toArray(new String[0]),
+                    cascadeAction);
+        }
+
+    }
+}

--- a/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
+++ b/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
@@ -22,6 +22,7 @@ package herddb.model;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Definition of a ForeignKey constaint.
@@ -30,7 +31,7 @@ import java.util.List;
 public final class ForeignKeyDef {
 
     public static final int ACTION_NO_ACTION = 0; // NO_ACTION means to reject the operation
-
+    public final String name;
     public final String parentTableId; // uuid, not name
     public final String[] columns;
     public final String[] parentTableColumns;
@@ -40,7 +41,8 @@ public final class ForeignKeyDef {
         return new Builder();
     }
 
-    private ForeignKeyDef(String parentTableId, String[] columns, String[] parentTableColumns, int cascadeAction) {
+    private ForeignKeyDef(String name, String parentTableId, String[] columns, String[] parentTableColumns, int cascadeAction) {
+        this.name = name;
         this.parentTableId = parentTableId;
         this.columns = columns;
         this.parentTableColumns = parentTableColumns;
@@ -49,10 +51,16 @@ public final class ForeignKeyDef {
 
     public static class Builder {
 
+        private String name = UUID.randomUUID().toString();
         private String parentTableId; // uuid, not name
         private final List<String> columns = new ArrayList<>();
         private final List<String> parentTableColumns = new ArrayList<>();
         private int cascadeAction;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
 
         public Builder parentTableId(String parentTableId) {
             this.parentTableId = parentTableId;
@@ -79,7 +87,7 @@ public final class ForeignKeyDef {
                 throw new IllegalArgumentException("parentTableId must be set");
             }
             if (cascadeAction != ACTION_NO_ACTION) {
-                throw new IllegalArgumentException("invalid cascadeAction "+cascadeAction);
+                throw new IllegalArgumentException("invalid cascadeAction " + cascadeAction);
             }
             if (parentTableColumns.size() != columns.size()) {
                 throw new IllegalArgumentException("the number of columns in child and parent table must be the same");
@@ -87,7 +95,7 @@ public final class ForeignKeyDef {
             if (columns.isEmpty()) {
                 throw new IllegalArgumentException("a foreign key constaint must refer to at least one column");
             }
-            return new ForeignKeyDef(parentTableId,
+            return new ForeignKeyDef(name, parentTableId,
                     columns.toArray(new String[0]),
                     parentTableColumns.toArray(new String[0]),
                     cascadeAction);

--- a/herddb-core/src/main/java/herddb/model/ForeignKeyViolationException.java
+++ b/herddb-core/src/main/java/herddb/model/ForeignKeyViolationException.java
@@ -1,0 +1,42 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.model;
+
+/**
+ * Record already exists
+ *
+ * @author enrico.olivelli
+ */
+public class ForeignKeyViolationException extends StatementExecutionException {
+
+    private final String foreignKeyName;
+
+    public ForeignKeyViolationException(String fkName, String message) {
+        super(message);
+        this.foreignKeyName = fkName;
+    }
+
+    public String getForeignKeyName() {
+        return foreignKeyName;
+    }
+
+
+}

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -221,7 +221,7 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
                 if (numForeignKeys > 0) {
                     foreignKeys = new ForeignKeyDef[numForeignKeys];
                     for (int i = 0; i < numForeignKeys; i++) {
-                        ForeignKeyDef.Builder builder = ForeignKeyDef.bulder();
+                        ForeignKeyDef.Builder builder = ForeignKeyDef.builder();
                         String fkName = dii.readUTF();
                         String parentTableId = dii.readUTF();
                         builder.parentTableId(parentTableId);
@@ -235,8 +235,8 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
                             String col = dii.readUTF();
                             builder.parentTableColumn(col);
                         }
-                        int cascadeAction = dii.readVInt();
-                        builder.cascadeAction(cascadeAction);
+                        builder.onUpdateCascadeAction(dii.readVInt());
+                        builder.onDeleteCascadeAction(dii.readVInt());
                         foreignKeys[i] = builder.build();
                     }
                 }
@@ -289,7 +289,8 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
                     for (String col : k.parentTableColumns) {
                         doo.writeUTF(col);
                     }
-                    doo.writeVInt(k.cascadeAction);
+                    doo.writeVInt(k.onUpdateCascadeAction);
+                    doo.writeVInt(k.onDeleteCascadeAction);
                 }
             }
         } catch (IOException ee) {

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -159,7 +159,7 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
         return foreignKeys;
     }
 
-    public boolean isChildTable(String parentUuid) {
+    public boolean isChildOfTable(String parentUuid) {
         if (foreignKeys == null) {
             return false;
         }

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -436,17 +436,6 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
         return new Table(uuid, name, columns, primaryKey, tablespace, auto_increment, maxSerialPosition, foreignKeys);
     }
 
-    public int getColumnIndex(String column) {
-        int i = 0;
-        for (String c : columnNames) {
-            if (c.equals(column)) {
-                return i;
-            }
-            i++;
-        }
-        throw new IllegalArgumentException("Cannot find column " + column);
-    }
-
     public static class Builder {
 
         private final List<Column> columns = new ArrayList<>();

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -159,6 +159,18 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
         return foreignKeys;
     }
 
+    public boolean isChildTable(String parentUuid) {
+        if (foreignKeys == null) {
+            return false;
+        }
+        for (ForeignKeyDef fk : foreignKeys) {
+            if (fk.parentTableId.equals(parentUuid)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -36,6 +36,7 @@ import herddb.model.Column;
 import herddb.model.ColumnTypes;
 import herddb.model.DMLStatement;
 import herddb.model.ExecutionPlan;
+import herddb.model.ForeignKeyDef;
 import herddb.model.Predicate;
 import herddb.model.Projection;
 import herddb.model.RecordFunction;
@@ -130,6 +131,7 @@ import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.table.ColDataType;
 import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
 import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.create.table.ForeignKeyIndex;
 import net.sf.jsqlparser.statement.create.table.Index;
 import net.sf.jsqlparser.statement.delete.Delete;
 import net.sf.jsqlparser.statement.drop.Drop;
@@ -533,6 +535,7 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
 
             Table table = tablebuilder.build();
             List<herddb.model.Index> otherIndexes = new ArrayList<>();
+            List<herddb.model.ForeignKeyDef> foreignKeys = new ArrayList<>();
             if (s.getIndexes() != null) {
                 for (Index index : s.getIndexes()) {
                     if (index.getType().equalsIgnoreCase("PRIMARY KEY")) {
@@ -564,6 +567,48 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
                         }
 
                         otherIndexes.add(builder.build());
+                    } else if (index.getType().equals("FOREIGN KEY")) {
+                        ForeignKeyIndex fk = (ForeignKeyIndex) index;
+                        String indexName = fixMySqlBackTicks(fk.getName().toLowerCase());
+                        int cascadeAction = ForeignKeyDef.ACTION_NO_ACTION;
+                        if (fk.getOnDeleteReferenceOption() != null) {
+                            throw new StatementExecutionException("Unsupported option " + fk.getOnDeleteReferenceOption());
+                        }
+                        if (fk.getOnUpdateReferenceOption() != null) {
+                            throw new StatementExecutionException("Unsupported option " + fk.getOnUpdateReferenceOption());
+                        }
+
+                        Table parentTableSchema = getTable(table.tablespace, fk.getTable());
+                        herddb.model.ForeignKeyDef.Builder builder = herddb.model.ForeignKeyDef
+                                .bulder()
+                                .name(indexName)
+                                .parentTableId(parentTableSchema.uuid)
+                                .cascadeAction(cascadeAction);
+
+                        for (String columnName : fk.getColumnsNames()) {
+                            columnName = fixMySqlBackTicks(columnName.toLowerCase());
+                            Column column = table.getColumn(columnName);
+                            if (column == null) {
+                                throw new StatementExecutionException(
+                                        "no such column " + columnName + " on table " + tableName + " in tablespace " + tableSpace);
+                            }
+                            builder.column(column.name);
+                        }
+
+                        for (String columnName : fk.getReferencedColumnNames()) {
+                            columnName = fixMySqlBackTicks(columnName.toLowerCase());
+                            Column column = parentTableSchema.getColumn(columnName);
+                            if (column == null) {
+                                throw new StatementExecutionException(
+                                        "no such column " + columnName + " on table " + parentTableSchema.name + " in tablespace " + parentTableSchema.tablespace);
+                            }
+                            builder.parentTableColumn(column.name);
+                        }
+
+                        foreignKeys.add(builder.build());
+
+                    } else {
+                        throw new StatementExecutionException("Unsupported index type " + index.getType());
                     }
                 }
             }
@@ -577,6 +622,9 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
                         .uuid(UUID.randomUUID().toString())
                         .column(col, table.getColumn(col).type);
                 otherIndexes.add(builder.build());
+            }
+            if (!foreignKeys.isEmpty()) {
+                table = table.withForeignKeys(foreignKeys.toArray(new ForeignKeyDef[0]));
             }
 
             CreateTableStatement statement = new CreateTableStatement(table, otherIndexes, isNotExsists);
@@ -1659,6 +1707,24 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
             refs[i] = new ColumnRef(aliasTable, tableImpl.columns[i]);
         }
         return new OpSchema(tableSpace, tableName, aliasTable, tableImpl.columnNames, refs);
+    }
+
+    private Table getTable(String defaultTableSpace, net.sf.jsqlparser.schema.Table table) {
+        String tableSpace = table.getSchemaName();
+        if (tableSpace == null) {
+            tableSpace = defaultTableSpace;
+        }
+        TableSpaceManager tableSpaceManager = getTableSpaceManager(tableSpace);
+        if (tableSpaceManager == null) {
+            clearCache();
+            throw new StatementExecutionException("tablespace " + defaultTableSpace + " is not available");
+        }
+        String tableName = fixMySqlBackTicks(table.getName().toLowerCase());
+        AbstractTableManager tableManager = tableSpaceManager.getTableManager(tableName);
+        if (tableManager == null) {
+            throw new TableDoesNotExistException("no table " + tableName + " here for " + tableSpace);
+        }
+        return tableManager.getTable();
     }
 
     private PlannerOp planAggregate(List<SelectExpressionItem> fieldList, OpSchema inputSchema, PlannerOp input, OpSchema originalTableSchema,

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -570,20 +570,22 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
                     } else if (index.getType().equals("FOREIGN KEY")) {
                         ForeignKeyIndex fk = (ForeignKeyIndex) index;
                         String indexName = fixMySqlBackTicks(fk.getName().toLowerCase());
-                        int cascadeAction = ForeignKeyDef.ACTION_NO_ACTION;
-                        if (fk.getOnDeleteReferenceOption() != null) {
+                        int onUpdateCascadeAction = ForeignKeyDef.ACTION_NO_ACTION;
+                        int onDeleteCascadeAction = ForeignKeyDef.ACTION_NO_ACTION;
+                        if (fk.getOnDeleteReferenceOption() != null && !fk.getOnDeleteReferenceOption().equalsIgnoreCase("NO ACTION")) {
                             throw new StatementExecutionException("Unsupported option " + fk.getOnDeleteReferenceOption());
                         }
-                        if (fk.getOnUpdateReferenceOption() != null) {
+                        if (fk.getOnUpdateReferenceOption() != null && !fk.getOnUpdateReferenceOption().equalsIgnoreCase("NO ACTION")) {
                             throw new StatementExecutionException("Unsupported option " + fk.getOnUpdateReferenceOption());
                         }
 
                         Table parentTableSchema = getTable(table.tablespace, fk.getTable());
                         herddb.model.ForeignKeyDef.Builder builder = herddb.model.ForeignKeyDef
-                                .bulder()
+                                .builder()
                                 .name(indexName)
                                 .parentTableId(parentTableSchema.uuid)
-                                .cascadeAction(cascadeAction);
+                                .onUpdateCascadeAction(onUpdateCascadeAction)
+                                .onDeleteCascadeAction(onDeleteCascadeAction);
 
                         for (String columnName : fk.getColumnsNames()) {
                             columnName = fixMySqlBackTicks(columnName.toLowerCase());

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -1324,9 +1324,7 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
                 tableSpace = defaultTableSpace;
             }
             String tableName = fixMySqlBackTicks(drop.getName().getName());
-            net.sf.jsqlparser.schema.Table fakeTable = new net.sf.jsqlparser.schema.Table(tableSpace, tableName);
-            Table table = getTable(defaultTableSpace, fakeTable);
-            return new DropTableStatement(tableSpace, table.name, drop.isIfExists());
+            return new DropTableStatement(tableSpace, tableName, drop.isIfExists());
         }
         if (drop.getType().equalsIgnoreCase("index")) {
             if (drop.getName() == null) {

--- a/herddb-core/src/test/java/herddb/core/CreateTableTest.java
+++ b/herddb-core/src/test/java/herddb/core/CreateTableTest.java
@@ -105,9 +105,10 @@ public class CreateTableTest {
                     .column("parenttableid", ColumnTypes.NOTNULL_STRING)
                     .primaryKey("id")
                     .foreingKey(ForeignKeyDef
-                            .bulder()
+                            .builder()
                             .name("myfk")
-                            .cascadeAction(ForeignKeyDef.ACTION_NO_ACTION)
+                            .onDeleteCascadeAction(ForeignKeyDef.ACTION_NO_ACTION)
+                            .onUpdateCascadeAction(ForeignKeyDef.ACTION_NO_ACTION)
                             .column("parenttableid")
                             .parentTableId(parentTable.uuid)
                             .parentTableColumn("id")

--- a/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
@@ -81,6 +81,19 @@ public class ForeignKeySQLTest {
             testChildSideOfForeignKey(manager, tx);  // test with transaction
             TestUtils.commitTransaction(manager, "tblspace1", tx);
 
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            testServerSideOfForeignKey(manager, 0); // test without transaction
+
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            tx = beginTransaction(manager, "tblspace1");
+            testServerSideOfForeignKey(manager, tx);  // test with transaction
+            TestUtils.commitTransaction(manager, "tblspace1", tx);
+
         }
     }
 
@@ -101,6 +114,28 @@ public class ForeignKeySQLTest {
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('newvalue',2,'foo')", Collections.emptyList(), new TransactionContext(tx));
         dump(manager, "SELECT * FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "UPDATE tblspace1.child set s2='newvalue'", Collections.emptyList(), new TransactionContext(tx));
+    }
+
+
+    private void testServerSideOfForeignKey(final DBManager manager, long tx) throws DataScannerException, StatementExecutionException {
+        execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('a',2,'pvalue')", Collections.emptyList(), new TransactionContext(tx));
+        execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('newvalue',2,'foo')", Collections.emptyList(), new TransactionContext(tx));
+        execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('c1',2,'a')", Collections.emptyList(), new TransactionContext(tx));
+
+        ForeignKeyViolationException errOnUpdate = expectThrows(ForeignKeyViolationException.class, () -> {
+            execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
+        });
+        assertEquals("fk1", errOnUpdate.getForeignKeyName());
+
+        ForeignKeyViolationException errOnDelete = expectThrows(ForeignKeyViolationException.class, () -> {
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
+        });
+        assertEquals("fk1", errOnDelete.getForeignKeyName());
+
+        execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList(), new TransactionContext(tx));
+        execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
+        execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
+
     }
 
 }

--- a/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
@@ -1,0 +1,72 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.sql;
+
+import static herddb.core.TestUtils.execute;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import herddb.core.DBManager;
+import herddb.mem.MemoryCommitLogManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import herddb.model.ForeignKeyDef;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.Table;
+import herddb.model.TransactionContext;
+import herddb.model.commands.CreateTableSpaceStatement;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * Tests on table creation
+ *
+ * @author enrico.olivelli
+ */
+public class ForeignKeySQLTest {
+
+    @Test
+    public void createTableWithForeignKey() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.parent (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+            execute(manager, "CREATE TABLE tblspace1.child (k2 string primary key,n2 int,"
+                    + "s2 string, "
+                    + "CONSTRAINT fk1 FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1))", Collections.emptyList());
+            Table parentTable = manager.getTableSpaceManager("tblspace1").getTableManager("parent").getTable();
+
+            Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
+            assertEquals(1, childTable.foreignKeys.length);
+            assertEquals("fk1", childTable.foreignKeys[0].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].cascadeAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
+            assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
+            assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
+
+
+        }
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
@@ -61,18 +61,19 @@ public class ForeignKeySQLTest {
             execute(manager, "CREATE TABLE tblspace1.parent (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
             execute(manager, "CREATE TABLE tblspace1.child (k2 string primary key,n2 int,"
                     + "s2 string, "
-                    + "CONSTRAINT fk1 FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1))", Collections.emptyList());
+                    + "CONSTRAINT fk1 FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1) ON DELETE NO ACTION ON UPDATE NO ACTION)", Collections.emptyList());
             Table parentTable = manager.getTableSpaceManager("tblspace1").getTableManager("parent").getTable();
 
             Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
             assertEquals(1, childTable.foreignKeys.length);
             assertEquals("fk1", childTable.foreignKeys[0].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].cascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
             assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
             assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
 
-            testChildSideOfForeignKey(manager, 0); // test without transaction
+            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID); // test without transaction
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
@@ -84,7 +85,7 @@ public class ForeignKeySQLTest {
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
-            testServerSideOfForeignKey(manager, 0); // test without transaction
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID); // test without transaction
 
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());

--- a/herddb-utils/src/main/java/herddb/utils/Futures.java
+++ b/herddb-utils/src/main/java/herddb/utils/Futures.java
@@ -19,6 +19,7 @@
  */
 package herddb.utils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -60,9 +61,17 @@ public class Futures {
         return result(future, DEFAULT_EXCEPTION_HANDLER, timeout, timeUnit);
     }
 
-     public static <T, ExceptionT extends Throwable> T result(
+    public static <T, ExceptionT extends Throwable> T result(
             CompletableFuture<T> future) throws ExceptionT, TimeoutException, InterruptedException, Exception {
         return result(future, DEFAULT_EXCEPTION_HANDLER);
+    }
+
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
+    public static <T> T getIfSuccess(CompletableFuture<T> future)  {
+        if (future.isDone() && !future.isCompletedExceptionally()) {
+            return future.getNow(null);
+        }
+        return null;
     }
 
     public static <T, ExceptionT extends Throwable> T result(


### PR DESCRIPTION
Introduce basic support for Foreign Keys:
- store metadata on Table (serialize/deserialize)
- DDL support in SQL
- implement ForeignKey checks on the child table
- implement "NO ACTION" option (fail the write on the parent table if the constraint would be violated)
- block ALTER TABLE/DROP TABLE commands that would break references with children tables
- fix a bug on releasing locks in case of multiple records modified with UPDATE/DELETE and only some records not passing pre-validation

Every check (both on the child and the parent sides) is performed using SQL commands, this way we can leverage existing logic:
- use the best index (among secondary and PK)
- use zero-copy data access to the other side of the relation
- write less code