### PR TITLE
Basic support for ForeignKey - part 2 - ADD/DROP

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -585,7 +585,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     public CompletableFuture<StatementExecutionResult> executeStatementAsync(Statement statement, Transaction transaction, StatementEvaluationContext context) {
         CompletableFuture<StatementExecutionResult> res;
         long lockStamp = checkpointLock.readLock();
-        LOGGER.log(Level.SEVERE, "LOCK "+table.name+" START " + statement + ": " +lockStamp);
         if (statement instanceof UpdateStatement) {
             UpdateStatement update = (UpdateStatement) statement;
             res = executeUpdateAsync(update, transaction, context);
@@ -613,7 +612,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             res = Futures.exception(new StatementExecutionException("not implemented " + statement.getClass()));
         }
         res = res.whenComplete((r, error) -> {
-            LOGGER.log(Level.SEVERE, "LOCK "+table.name+" END " + statement + ": " + r+" "+lockStamp, error);
             checkpointLock.unlockRead(lockStamp);
         });
         if (statement instanceof TruncateTableStatement) {

--- a/herddb-core/src/main/java/herddb/model/commands/AlterTableStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/AlterTableStatement.java
@@ -22,6 +22,8 @@ package herddb.model.commands;
 
 import herddb.model.Column;
 import herddb.model.DDLStatement;
+import herddb.model.ForeignKeyDef;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,6 +39,9 @@ public class AlterTableStatement extends DDLStatement {
     private final String table;
     private final Boolean changeAutoIncrement;
     private final String newTableName;
+    private final List<String> dropForeignKeys;
+    private final List<ForeignKeyDef> addForeignKeys;
+
 
     public AlterTableStatement(
             List<Column> addColumns,
@@ -45,7 +50,10 @@ public class AlterTableStatement extends DDLStatement {
             Boolean changeAutoIncrement,
             String table,
             String tableSpace,
-            String newTableName
+            String newTableName,
+            List<String> dropForeignKeys,
+            List<ForeignKeyDef> addForeignKeys
+
     ) {
         super(tableSpace);
         this.table = table;
@@ -54,6 +62,8 @@ public class AlterTableStatement extends DDLStatement {
         this.dropColumns = dropColumns;
         this.changeAutoIncrement = changeAutoIncrement;
         this.newTableName = newTableName;
+        this.dropForeignKeys = dropForeignKeys;
+        this.addForeignKeys = addForeignKeys;
     }
 
     public String getNewTableName() {
@@ -78,6 +88,14 @@ public class AlterTableStatement extends DDLStatement {
 
     public List<Column> getModifyColumns() {
         return modifyColumns;
+    }
+
+    public List<String> getDropForeignKeys() {
+        return dropForeignKeys;
+    }
+
+    public List<ForeignKeyDef> getAddForeignKeys() {
+        return addForeignKeys;
     }
 
 }

--- a/herddb-core/src/main/java/herddb/model/commands/AlterTableStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/AlterTableStatement.java
@@ -23,7 +23,6 @@ package herddb.model.commands;
 import herddb.model.Column;
 import herddb.model.DDLStatement;
 import herddb.model.ForeignKeyDef;
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -1202,7 +1202,7 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
             case DROP:
                 if (alterExpression.getColumnName() != null) {
                     dropColumns.add(fixMySqlBackTicks(alterExpression.getColumnName()));
-                } else if (alterExpression.getConstraintName()!= null) {
+                } else if (alterExpression.getConstraintName() != null) {
                     dropForeignKeys.add(fixMySqlBackTicks(alterExpression.getConstraintName()));
                 } else {
                     throw new StatementExecutionException("Unrecognized ALTER TABLE DROP ... statement");

--- a/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
@@ -1,23 +1,22 @@
 /*
- Licensed to Diennea S.r.l. under one
- or more contributor license agreements. See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership. Diennea S.r.l. licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
-
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
  */
-
 package herddb.sql;
 
 import static herddb.core.TestUtils.beginTransaction;
@@ -26,6 +25,7 @@ import static herddb.core.TestUtils.execute;
 import static herddb.utils.TestUtils.expectThrows;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import herddb.core.DBManager;
 import herddb.core.TestUtils;
 import herddb.mem.MemoryCommitLogManager;
@@ -73,36 +73,35 @@ public class ForeignKeySQLTest {
             assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
             assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
 
-            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID); // test without transaction
+            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1"); // test without transaction
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
             long tx = beginTransaction(manager, "tblspace1");
-            testChildSideOfForeignKey(manager, tx);  // test with transaction
+            testChildSideOfForeignKey(manager, tx, "fk1");  // test with transaction
             TestUtils.commitTransaction(manager, "tblspace1", tx);
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID); // test without transaction
-
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1"); // test without transaction
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
             tx = beginTransaction(manager, "tblspace1");
-            testServerSideOfForeignKey(manager, tx);  // test with transaction
+            testServerSideOfForeignKey(manager, tx, "fk1");  // test with transaction
             TestUtils.commitTransaction(manager, "tblspace1", tx);
 
         }
     }
 
-    private void testChildSideOfForeignKey(final DBManager manager, long tx) throws DataScannerException, StatementExecutionException {
+    private void testChildSideOfForeignKey(final DBManager manager, long tx, String fkName) throws DataScannerException, StatementExecutionException {
         ForeignKeyViolationException err = expectThrows(ForeignKeyViolationException.class, () -> {
             execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('a',2,'pvalue')", Collections.emptyList(), new TransactionContext(tx));
         });
-        assertEquals("fk1", err.getForeignKeyName());
+        assertEquals(fkName, err.getForeignKeyName());
 
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('a',2,'pvalue')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('c1',2,'a')", Collections.emptyList(), new TransactionContext(tx));
@@ -110,15 +109,14 @@ public class ForeignKeySQLTest {
         ForeignKeyViolationException errOnUpdate = expectThrows(ForeignKeyViolationException.class, () -> {
             execute(manager, "UPDATE tblspace1.child set s2='badvalue'", Collections.emptyList(), new TransactionContext(tx));
         });
-        assertEquals("fk1", errOnUpdate.getForeignKeyName());
+        assertEquals(fkName, errOnUpdate.getForeignKeyName());
 
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('newvalue',2,'foo')", Collections.emptyList(), new TransactionContext(tx));
         dump(manager, "SELECT * FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "UPDATE tblspace1.child set s2='newvalue'", Collections.emptyList(), new TransactionContext(tx));
     }
 
-
-    private void testServerSideOfForeignKey(final DBManager manager, long tx) throws DataScannerException, StatementExecutionException {
+    private void testServerSideOfForeignKey(final DBManager manager, long tx, String fkName) throws DataScannerException, StatementExecutionException {
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('a',2,'pvalue')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('newvalue',2,'foo')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('c1',2,'a')", Collections.emptyList(), new TransactionContext(tx));
@@ -164,6 +162,94 @@ public class ForeignKeySQLTest {
                 execute(manager, "ALTER TABLE tblspace1.parent DROP COLUMN n1", Collections.emptyList());
             });
             assertEquals("Cannot drop column parent.n1 because of foreign key constraint fk1 on table child", errCannotDropColumn.getMessage());
+        }
+    }
+
+    @Test
+    public void alterTableDropForeignKey() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.parent (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+            execute(manager, "CREATE TABLE tblspace1.child (k2 string primary key,n2 int,"
+                    + "s2 string, "
+                    + "CONSTRAINT fk1 FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1) ON DELETE NO ACTION ON UPDATE NO ACTION,"
+                    + "CONSTRAINT fk2 FOREIGN KEY (s2) REFERENCES parent(k1) ON DELETE NO ACTION ON UPDATE NO ACTION)", Collections.emptyList());
+            Table parentTable = manager.getTableSpaceManager("tblspace1").getTableManager("parent").getTable();
+            Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
+            assertEquals(2, childTable.foreignKeys.length);
+            assertEquals("fk1", childTable.foreignKeys[0].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
+            assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
+            assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
+
+            assertEquals("fk2", childTable.foreignKeys[1].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onUpdateCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onDeleteCascadeAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[1].parentTableId);
+            assertArrayEquals(new String[]{"s2"}, childTable.foreignKeys[1].columns);
+            assertArrayEquals(new String[]{"k1"}, childTable.foreignKeys[1].parentTableColumns);
+
+            // test FK is working
+            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1");
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1");
+
+            execute(manager, "ALTER TABLE tblspace1.child DROP CONSTRAINT fk1", Collections.emptyList());
+            childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
+            assertEquals(1, childTable.foreignKeys.length);
+
+            assertEquals("fk2", childTable.foreignKeys[0].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
+            assertArrayEquals(new String[]{"s2"}, childTable.foreignKeys[0].columns);
+            assertArrayEquals(new String[]{"k1"}, childTable.foreignKeys[0].parentTableColumns);
+
+            // TRUCATE requires a checkpoint lock, we are also testing that the tables are free from global locks
+            execute(manager, "TRUNCATE TABLE tblspace1.child", Collections.emptyList(), TransactionContext.NO_TRANSACTION);
+            execute(manager, "TRUNCATE TABLE tblspace1.parent", Collections.emptyList(), TransactionContext.NO_TRANSACTION);
+
+            execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('a',2,'pvalue')", Collections.emptyList(), TransactionContext.NO_TRANSACTION);
+            // insert a record that could violate the old FK1 (but not FK2)
+            execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('no',10,'a')", Collections.emptyList(), TransactionContext.NO_TRANSACTION);
+
+            execute(manager, "TRUNCATE TABLE tblspace1.child", Collections.emptyList(), TransactionContext.NO_TRANSACTION);
+            execute(manager, "TRUNCATE TABLE tblspace1.parent", Collections.emptyList(), TransactionContext.NO_TRANSACTION);
+
+            // add the FK again
+            execute(manager, "ALTER TABLE tblspace1.`CHILD` Add CONSTRAINT `fk3` FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1) ON DELETE RESTRICT", Collections.emptyList());
+
+            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk2");
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
+            assertEquals(2, childTable.foreignKeys.length);
+            assertEquals("fk2", childTable.foreignKeys[0].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
+            assertArrayEquals(new String[]{"s2"}, childTable.foreignKeys[0].columns);
+            assertArrayEquals(new String[]{"k1"}, childTable.foreignKeys[0].parentTableColumns);
+
+            assertEquals("fk3", childTable.foreignKeys[1].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onUpdateCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onDeleteCascadeAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[1].parentTableId);
+            assertArrayEquals(new String[]{"s2","n2"}, childTable.foreignKeys[1].columns);
+            assertArrayEquals(new String[]{"k1","n1"}, childTable.foreignKeys[1].parentTableColumns);
+
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk2");
+
         }
     }
 

--- a/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
@@ -25,7 +25,6 @@ import static herddb.core.TestUtils.execute;
 import static herddb.utils.TestUtils.expectThrows;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import herddb.core.DBManager;
 import herddb.core.TestUtils;
 import herddb.mem.MemoryCommitLogManager;
@@ -124,12 +123,12 @@ public class ForeignKeySQLTest {
         ForeignKeyViolationException errOnUpdate = expectThrows(ForeignKeyViolationException.class, () -> {
             execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
         });
-        assertEquals("fk1", errOnUpdate.getForeignKeyName());
+        assertEquals(fkName, errOnUpdate.getForeignKeyName());
 
         ForeignKeyViolationException errOnDelete = expectThrows(ForeignKeyViolationException.class, () -> {
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
         });
-        assertEquals("fk1", errOnDelete.getForeignKeyName());
+        assertEquals(fkName, errOnDelete.getForeignKeyName());
 
         execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
@@ -245,8 +244,8 @@ public class ForeignKeySQLTest {
             assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onUpdateCascadeAction);
             assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onDeleteCascadeAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[1].parentTableId);
-            assertArrayEquals(new String[]{"s2","n2"}, childTable.foreignKeys[1].columns);
-            assertArrayEquals(new String[]{"k1","n1"}, childTable.foreignKeys[1].parentTableColumns);
+            assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[1].columns);
+            assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[1].parentTableColumns);
 
             testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk2");
 


### PR DESCRIPTION
Changes:
- ALTER TABLE DROP fk
- ALTER TABLE ADD CONSTRAINT fk ....
- Fix release table lock in INSERT in case of FK violation

Unfortunately in jsqlparser in "CREATE TABLE" the syntax is "CREATE TABLE .... ON DELETE NO ACTION"
and in "ALTER TABLE" we have "ALTER TABLE ADD CONSTRAINT xxx ... ON DELETE RESTRICT"

Omitting "NO ACTION" and "RESTRICT" also works well, so probably it is better to not use it.
A follow up patch will implement "ON DELETE CASCADE"

Also in case of "ADD CONSTRAINT" we are not checking if the FK is consistent, new patch will come