### PR TITLE
Implement JDBC Metadata for foreign keys

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -36,6 +36,7 @@ import herddb.core.system.SysclientsTableManager;
 import herddb.core.system.SyscolumnsTableManager;
 import herddb.core.system.SysconfigTableManager;
 import herddb.core.system.SysdualTableManager;
+import herddb.core.system.SysforeignkeysTableManager;
 import herddb.core.system.SysindexcolumnsTableManager;
 import herddb.core.system.SysindexesTableManager;
 import herddb.core.system.SyslogstatusManager;
@@ -232,6 +233,7 @@ public class TableSpaceManager {
             registerSystemTableManager(new SystransactionsTableManager(this));
             registerSystemTableManager(new SyslogstatusManager(this));
             registerSystemTableManager(new SysdualTableManager(this));
+            registerSystemTableManager(new SysforeignkeysTableManager(this));
         }
         registerSystemTableManager(new SystablespacesTableManager(this));
         registerSystemTableManager(new SystablespacereplicastateTableManager(this));

--- a/herddb-core/src/main/java/herddb/core/system/SysforeignkeysTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/SysforeignkeysTableManager.java
@@ -1,0 +1,102 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.core.system;
+
+import herddb.codec.RecordSerializer;
+import herddb.core.TableSpaceManager;
+import herddb.model.ColumnTypes;
+import herddb.model.ForeignKeyDef;
+import herddb.model.Record;
+import herddb.model.Table;
+import herddb.model.Transaction;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Table Manager for the sysforeignkeys virtual table
+ *
+ * @author enrico.olivelli
+ */
+public class SysforeignkeysTableManager extends AbstractSystemTableManager {
+
+    private static final Table TABLE = Table
+            .builder()
+            .name("sysforeignkeys")
+            .column("child_table_name", ColumnTypes.STRING)
+            .column("child_table_column_name", ColumnTypes.STRING)
+            .column("child_table_cons_name", ColumnTypes.STRING)
+            .column("parent_table_name", ColumnTypes.STRING)
+            .column("parent_table_column_name", ColumnTypes.STRING)
+            .column("on_delete_action", ColumnTypes.STRING)
+            .column("on_update_action", ColumnTypes.STRING)
+            .column("ordinal_position", ColumnTypes.INTEGER)
+            .column("deferred", ColumnTypes.STRING)
+            .primaryKey("child_table_name", false)
+            .primaryKey("child_table_column_name", false)
+            .primaryKey("child_table_cons_name", false)
+            .build();
+
+    public SysforeignkeysTableManager(TableSpaceManager parent) {
+        super(parent, TABLE);
+    }
+
+    @Override
+    protected Iterable<Record> buildVirtualRecordList(Transaction transaction) {
+        List<Table> tables = tableSpaceManager.getAllVisibleTables(transaction);
+        List<Record> result = new ArrayList<>();
+        for (Table child : tables) {
+            if (child.foreignKeys == null) {
+                continue;
+            }
+            String child_table_name = child.name;
+            for (ForeignKeyDef fk : child.foreignKeys) {
+                Table parent =
+                        tables.stream()
+                                .filter(ta -> ta.uuid.equals(fk.parentTableId))
+                                .findAny()
+                                .orElse(null);
+                if (parent == null) {
+                    continue;
+                }
+                for (int i = 0; i < fk.columns.length; i++) {
+                String child_column_name = fk.columns[i];
+                String parent_column_name = fk.parentTableColumns[i];
+                String parent_table_name = parent.name;
+
+                result.add(RecordSerializer.makeRecord(
+                        table,
+                        "child_table_name", child_table_name,
+                        "child_table_column_name", child_column_name,
+                        "child_table_cons_name", fk.name,
+                        "parent_table_name", parent_table_name,
+                        "parent_table_column_name", parent_column_name,
+                        "on_delete_action", "importedNoAction",
+                        "on_update_action", "importedNoAction",
+                        "ordinal_position", (i + 1),
+                        "deferred", "importedKeyNotDeferrable"
+                ));
+                }
+            }
+        }
+        return result;
+    }
+
+}

--- a/herddb-core/src/test/java/herddb/sql/SystemTablesTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SystemTablesTest.java
@@ -180,7 +180,8 @@ public class SystemTablesTest {
                         })
                         .findAny()
                         .isPresent());
-                assertEquals(25, records.size());
+                // to be changed every time we add a new system table
+                assertEquals(28, records.size());
             }
 
             try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.sysindexcolumns where table_name like '%tsql' order by index_name, column_name",

--- a/herddb-jdbc/src/test/java/herddb/jdbc/JdbcForeignKeyMetadataTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/JdbcForeignKeyMetadataTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.model.TableSpace;
+import herddb.server.Server;
+import herddb.server.ServerConfiguration;
+import herddb.server.StaticClientSideMetadataProvider;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JdbcForeignKeyMetadataTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+        try (Server server = new Server(new ServerConfiguration(folder.newFolder().toPath()))) {
+            server.start();
+            server.waitForStandaloneBoot();
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()))) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+                try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client);
+                        Connection con = dataSource.getConnection();
+                        Statement statement = con.createStatement()) {
+                    statement.execute("CREATE TABLE ptable (pkey string primary key, p1 string, p2 string)");
+                    statement.execute("CREATE TABLE ctable (ckey string primary key, c1 string, c2 string,"
+                            + "        CONSTRAINT `fk1` FOREIGN KEY (`c1`,`c2`) REFERENCES ptable(`p1`,`p2`))");
+                    DatabaseMetaData metaData = con.getMetaData();
+                    try (ResultSet rs = metaData.getImportedKeys(null, null, "CTABLE");) {
+                        verifyForeignKeyResultSet(rs);
+                    }
+                    try (ResultSet rs = metaData.getImportedKeys(null, TableSpace.DEFAULT, "CTABLE");) {
+                        verifyForeignKeyResultSet(rs);
+                    }
+                    try (ResultSet rs = metaData.getImportedKeys(null, TableSpace.DEFAULT, "PTABLE");) {
+                        assertFalse(rs.next());
+                    }
+                    try (ResultSet rs = metaData.getExportedKeys(null, null, "ptable");) {
+                        verifyForeignKeyResultSet(rs);
+                    }
+                    try (ResultSet rs = metaData.getExportedKeys(null, TableSpace.DEFAULT, "ptable");) {
+                        verifyForeignKeyResultSet(rs);
+                    }
+                    try (ResultSet rs = metaData.getExportedKeys(null, null, "CTABLE");) {
+                        assertFalse(rs.next());
+                    }
+                    try (ResultSet rs = metaData.getCrossReference(null, TableSpace.DEFAULT, "ptable", null, TableSpace.DEFAULT, "ctable")) {
+                        verifyForeignKeyResultSet(rs);
+                    }
+                    try (ResultSet rs = metaData.getCrossReference(null, TableSpace.DEFAULT, "ptable", null, null, "ctable")) {
+                        verifyForeignKeyResultSet(rs);
+                    }
+                    try (ResultSet rs = metaData.getCrossReference(null, null, "ptable", null, null, "ctable")) {
+                        verifyForeignKeyResultSet(rs);
+                    }
+                }
+            }
+        }
+    }
+
+    private void verifyForeignKeyResultSet(final ResultSet importedKeys) throws SQLException {
+        int count = 0;
+        while (importedKeys.next()) {
+            assertEquals(count + 1, importedKeys.getInt("KEY_SEQ"));
+            assertEquals(null, importedKeys.getString("PKTABLE_CAT"));
+            assertEquals(TableSpace.DEFAULT, importedKeys.getString("PKTABLE_SCHEM"));
+            assertEquals("ctable", importedKeys.getString("PKTABLE_NAME"));
+
+            assertEquals(null, importedKeys.getString("FKTABLE_CAT"));
+            assertEquals(TableSpace.DEFAULT, importedKeys.getString("FKTABLE_SCHEM"));
+            assertEquals("ptable", importedKeys.getString("FKTABLE_NAME"));
+
+            assertEquals("fk1", importedKeys.getString("FK_NAME"));
+            assertEquals(null, importedKeys.getString("PK_NAME"));
+            assertEquals("importedKeyNotDeferrable", importedKeys.getString("DEFERRABILITY"));
+            if (count == 0) {
+                assertEquals("c1", importedKeys.getString("PKCOLUMN_NAME"));
+                assertEquals("p1", importedKeys.getString("FKCOLUMN_NAME"));
+            } else {
+                assertEquals("c2", importedKeys.getString("PKCOLUMN_NAME"));
+                assertEquals("p2", importedKeys.getString("FKCOLUMN_NAME"));
+            }
+            assertEquals("importedNoAction", importedKeys.getString("UPDATE_RULE"));
+            assertEquals("importedNoAction", importedKeys.getString("DELETE_RULE"));
+            count++;
+        }
+        assertEquals(2, count);
+    }
+}

--- a/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/SystemTablesTest.java
@@ -236,7 +236,7 @@ public class SystemTablesTest {
                             records.add(record);
                         }
                         // this is to be incremented at every new systable
-                        assertEquals(25, records.size());
+                        assertEquals(28, records.size());
                     }
                     try (ResultSet rs = metaData.getSchemas()) {
                         List<List<String>> records = new ArrayList<>();


### PR DESCRIPTION
- add new sysforeignkeys table
- Implement JDBC getImportedKey,getExportedKeys and getCrossReference functions in JDBC DatabaseMetadata