### PR TITLE
Validate alter table add fk

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -779,11 +779,11 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
      * Internal method used to execute simple data accesses, like foreign key checks.
      */
     public DataScanner executeSimpleQuery(String tableSpace, String query, List<Object> parameters,
-            int maxRows, boolean keepReadLocks, TransactionContext transactionContext) {
+            int maxRows, boolean keepReadLocks, TransactionContext transactionContext, StatementEvaluationContext context) {
         TranslatedQuery translatedQuery = planner.translate(tableSpace,
                 query, parameters, true, true, false, maxRows);
         translatedQuery.context.setForceRetainReadLock(keepReadLocks);
-        ScanResult scanResult = (ScanResult) executePlan(translatedQuery.plan, translatedQuery.context, transactionContext);
+        ScanResult scanResult = (ScanResult) executePlan(translatedQuery.plan, context != null ? context : translatedQuery.context, transactionContext);
         return scanResult.dataScanner;
     }
 

--- a/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableSpaceManager.java
@@ -1558,7 +1558,7 @@ public class TableSpaceManager {
             } catch (IllegalArgumentException error) {
                 throw new StatementExecutionException(error);
             }
-            validateAlterTable(newTable, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT());
+            validateAlterTable(newTable, context);
             LogEntry entry = LogEntryFactory.alterTable(newTable, null);
             try {
                 CommitLogResult pos = log.log(entry, entry.transactionId <= 0);

--- a/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
+++ b/herddb-core/src/main/java/herddb/core/system/AbstractSystemTableManager.java
@@ -215,7 +215,7 @@ public abstract class AbstractSystemTableManager implements AbstractTableManager
     }
 
     @Override
-    public void tableAltered(Table table, Transaction transaction) throws DDLException {
+    public final void tableAltered(Table table, Transaction transaction) throws DDLException {
         throw new InvalidTableException("cannot alter system tables");
     }
 


### PR DESCRIPTION
- Validate FK constraint while issuing an ALTER TABLE ADD ... FOREIGN KEY ...
- Take current transaction into consideration
- Please remember that ALTER TABLE implicitly commits the transaction
