### PR TITLE
Foreign Keys: implement FK actions (ON DELETE CASCADE, ON DELETE SET NULL, ON UPDATE SET NULL)

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -783,7 +783,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
         ScanResult scanResult = (ScanResult) executeSimpleStatement(tableSpace, query, parameters, maxRows, keepReadLocks, transactionContext, context);
         return scanResult.dataScanner;
     }
-    
+
     /**
      * Internal method used to execute simple data accesses, like foreign key cascade actions.
      */

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -780,11 +780,19 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
      */
     public DataScanner executeSimpleQuery(String tableSpace, String query, List<Object> parameters,
             int maxRows, boolean keepReadLocks, TransactionContext transactionContext, StatementEvaluationContext context) {
+        ScanResult scanResult = (ScanResult) executeSimpleStatement(tableSpace, query, parameters, maxRows, keepReadLocks, transactionContext, context);
+        return scanResult.dataScanner;
+    }
+    
+    /**
+     * Internal method used to execute simple data accesses, like foreign key cascade actions.
+     */
+    public StatementExecutionResult executeSimpleStatement(String tableSpace, String query, List<Object> parameters,
+            int maxRows, boolean keepReadLocks, TransactionContext transactionContext, StatementEvaluationContext context) {
         TranslatedQuery translatedQuery = planner.translate(tableSpace,
                 query, parameters, true, true, false, maxRows);
         translatedQuery.context.setForceRetainReadLock(keepReadLocks);
-        ScanResult scanResult = (ScanResult) executePlan(translatedQuery.plan, context != null ? context : translatedQuery.context, transactionContext);
-        return scanResult.dataScanner;
+        return executePlan(translatedQuery.plan, context != null ? context : translatedQuery.context, transactionContext);
     }
 
     public DataScanner scan(ScanStatement statement, StatementEvaluationContext context, TransactionContext transactionContext) throws StatementExecutionException {

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -1250,28 +1250,44 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         return res;
     }
 
-    private void checkForeignKeyConstraintsAsParentTable(Table childTable, DataAccessor values, StatementEvaluationContext context, Transaction transaction) throws StatementExecutionException {
+    private void executeForeignKeyConstraintsAsParentTable(Table childTable, DataAccessor values, StatementEvaluationContext context, Transaction transaction, boolean delete) throws StatementExecutionException {
         // We are creating a SQL query and then using DBManager
         // using an SQL query will let us leverage the SQL Planner
         // and use the best index to perform the execution
         // the SQL Planner will cache the plan, and the plan will also be
         // invalidated consistently during DML operations.
         for (ForeignKeyDef fk : childTable.foreignKeys) {
-            String query = parentForeignKeyQueries.computeIfAbsent(childTable.name + "." + fk.name, (l -> {
-                // with '*' we are not going to perform projections or copies
-                StringBuilder q = new StringBuilder("SELECT * FROM ");
-                q.append(childTable.tablespace);
-                q.append(".");
-                q.append(childTable.name);
-                q.append(" WHERE ");
-                for (int i = 0; i < fk.columns.length; i++) {
-                    if (i > 0) {
-                        q.append(" AND ");
+            String query = parentForeignKeyQueries.computeIfAbsent(childTable.name + "." + fk.name + ".#" + delete, (l -> {
+                if (fk.onDeleteAction == ForeignKeyDef.ACTION_CASCADE && delete) {
+                    StringBuilder q = new StringBuilder("DELETE FROM ");
+                    q.append(childTable.tablespace);
+                    q.append(".");
+                    q.append(childTable.name);
+                    q.append(" WHERE ");
+                    for (int i = 0; i < fk.columns.length; i++) {
+                        if (i > 0) {
+                            q.append(" AND ");
+                        }
+                        q.append(fk.columns[i]);
+                        q.append("=?");
                     }
-                    q.append(fk.columns[i]);
-                    q.append("=?");
+                    return q.toString();
+                } else {
+                    // with '*' we are not going to perform projections or copies
+                    StringBuilder q = new StringBuilder("SELECT * FROM ");
+                    q.append(childTable.tablespace);
+                    q.append(".");
+                    q.append(childTable.name);
+                    q.append(" WHERE ");
+                    for (int i = 0; i < fk.columns.length; i++) {
+                        if (i > 0) {
+                            q.append(" AND ");
+                        }
+                        q.append(fk.columns[i]);
+                        q.append("=?");
+                    }
+                    return q.toString();
                 }
-                return q.toString();
             }));
 
             final List<Object> valuesToMatch = new ArrayList<>(fk.parentTableColumns.length);
@@ -1280,24 +1296,34 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
 
             TransactionContext tx = transaction != null ? new TransactionContext(transaction.transactionId) : TransactionContext.NO_TRANSACTION;
-            boolean fkOk;
-            try (DataScanner scan = tableSpaceManager.getDbmanager().executeSimpleQuery(tableSpaceManager.getTableSpaceName(),
-                    query,
-                    valuesToMatch,
-                    1, // only one record
-                    true, // keep read locks in TransactionContext
-                    tx,
-                    null);) {
-                List<DataAccessor> resultSet = scan.consume();
-                // we are on the parent side of the relation
-                // we are okay if there is no matching record
-                // TODO: return the list of PKs in order to implement CASCADE operations
-                fkOk = resultSet.isEmpty();
-            } catch (DataScannerException err) {
-                throw new StatementExecutionException(err);
-            }
-            if (!fkOk) {
-                throw new ForeignKeyViolationException(fk.name, "foreignKey " + childTable.name + "." + fk.name + " violated");
+            if (fk.onDeleteAction == ForeignKeyDef.ACTION_CASCADE && delete) {
+                tableSpaceManager.getDbmanager().executeSimpleStatement(tableSpaceManager.getTableSpaceName(),
+                        query,
+                        valuesToMatch,
+                        -1, // every record
+                        true, // keep read locks in TransactionContext
+                        tx,
+                        null);
+            } else {
+                boolean fkOk;
+                try (DataScanner scan = tableSpaceManager.getDbmanager().executeSimpleQuery(tableSpaceManager.getTableSpaceName(),
+                        query,
+                        valuesToMatch,
+                        1, // only one record
+                        true, // keep read locks in TransactionContext
+                        tx,
+                        null);) {
+                    List<DataAccessor> resultSet = scan.consume();
+                    // we are on the parent side of the relation
+                    // we are okay if there is no matching record
+                    // TODO: return the list of PKs in order to implement CASCADE operations
+                    fkOk = resultSet.isEmpty();
+                } catch (DataScannerException err) {
+                    throw new StatementExecutionException(err);
+                }
+                if (!fkOk) {
+                    throw new ForeignKeyViolationException(fk.name, "foreignKey " + childTable.name + "." + fk.name + " violated");
+                }
             }
         }
     }
@@ -1475,7 +1501,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                         if (childrenTables != null) {
                             DataAccessor currentValues = current.getDataAccessor(table);
                             for (Table childTable : childrenTables) {
-                                checkForeignKeyConstraintsAsParentTable(childTable, currentValues, context, transaction);
+                                executeForeignKeyConstraintsAsParentTable(childTable, currentValues, context, transaction, false);
                             }
                         }
 
@@ -1644,7 +1670,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                             DataAccessor dataAccessor = current.getDataAccessor(table);
                             if (childrenTables != null) {
                                 for (Table childTable : childrenTables) {
-                                    checkForeignKeyConstraintsAsParentTable(childTable, dataAccessor, context, transaction);
+                                    executeForeignKeyConstraintsAsParentTable(childTable, dataAccessor, context, transaction, true);
                                 }
                             }
                             if (indexes != null) {
@@ -4034,6 +4060,10 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
         if (this.table.auto_increment) {
             rebuildNextPrimaryKeyValue();
         }
+        
+        // clear FK caches, foreignkeys may change
+        parentForeignKeyQueries.clear();
+        childForeignKeyQueries.clear();
     }
 
     @Override

--- a/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
+++ b/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
@@ -31,24 +31,26 @@ import java.util.UUID;
 public final class ForeignKeyDef {
 
     public static final int ACTION_NO_ACTION = 0; // NO_ACTION means to reject the operation
+    public static final int ACTION_CASCADE = 1;
+    public static final int ACTION_SETNULL = 2;
     public final String name;
     public final String parentTableId; // uuid, not name
     public final String[] columns;
     public final String[] parentTableColumns;
-    public final int onUpdateCascadeAction;
-    public final int onDeleteCascadeAction;
+    public final int onUpdateAction;
+    public final int onDeleteAction;
 
     public static Builder builder() {
         return new Builder();
     }
 
-    private ForeignKeyDef(String name, String parentTableId, String[] columns, String[] parentTableColumns, int onUpdateCascadeAction, int onDeleteCascadeAction) {
+    private ForeignKeyDef(String name, String parentTableId, String[] columns, String[] parentTableColumns, int onUpdateAction, int onDeleteAction) {
         this.name = name;
         this.parentTableId = parentTableId;
         this.columns = columns;
         this.parentTableColumns = parentTableColumns;
-        this.onUpdateCascadeAction = onUpdateCascadeAction;
-        this.onDeleteCascadeAction = onDeleteCascadeAction;
+        this.onUpdateAction = onUpdateAction;
+        this.onDeleteAction = onDeleteAction;
     }
 
     public static class Builder {
@@ -57,8 +59,8 @@ public final class ForeignKeyDef {
         private String parentTableId; // uuid, not name
         private final List<String> columns = new ArrayList<>();
         private final List<String> parentTableColumns = new ArrayList<>();
-        private int onUpdateCascadeAction;
-        private int onDeleteCascadeAction;
+        private int onUpdateAction;
+        private int onDeleteAction;
 
 
         public Builder name(String name) {
@@ -81,13 +83,13 @@ public final class ForeignKeyDef {
             return this;
         }
 
-        public Builder onUpdateCascadeAction(int onUpdateCascadeAction) {
-            this.onUpdateCascadeAction = onUpdateCascadeAction;
+        public Builder onUpdateAction(int onUpdateAction) {
+            this.onUpdateAction = onUpdateAction;
             return this;
         }
 
-        public Builder onDeleteCascadeAction(int onDeleteCascadeAction) {
-            this.onDeleteCascadeAction = onDeleteCascadeAction;
+        public Builder onDeleteAction(int onDeleteCascadeAction) {
+            this.onDeleteAction = onDeleteCascadeAction;
             return this;
         }
 
@@ -95,11 +97,13 @@ public final class ForeignKeyDef {
             if (parentTableId == null || parentTableId.isEmpty()) {
                 throw new IllegalArgumentException("parentTableId must be set");
             }
-            if (onUpdateCascadeAction != ACTION_NO_ACTION) {
-                throw new IllegalArgumentException("invalid onUpdateCascadeAction " + onUpdateCascadeAction);
+            if (onUpdateAction != ACTION_NO_ACTION) {
+                throw new IllegalArgumentException("invalid onUpdateCascadeAction " + onUpdateAction);
             }
-            if (onDeleteCascadeAction != ACTION_NO_ACTION) {
-                throw new IllegalArgumentException("invalid onDeleteCascadeAction " + onDeleteCascadeAction);
+            if (onDeleteAction != ACTION_NO_ACTION
+                    && onDeleteAction != ACTION_CASCADE
+                    && onDeleteAction != ACTION_SETNULL) {
+                throw new IllegalArgumentException("invalid onDeleteCascadeAction " + onDeleteAction);
             }
             if (parentTableColumns.size() != columns.size()) {
                 throw new IllegalArgumentException("the number of columns in child and parent table must be the same");
@@ -110,7 +114,7 @@ public final class ForeignKeyDef {
             return new ForeignKeyDef(name, parentTableId,
                     columns.toArray(new String[0]),
                     parentTableColumns.toArray(new String[0]),
-                    onUpdateCascadeAction, onDeleteCascadeAction);
+                    onUpdateAction, onDeleteAction);
         }
 
     }

--- a/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
+++ b/herddb-core/src/main/java/herddb/model/ForeignKeyDef.java
@@ -97,13 +97,14 @@ public final class ForeignKeyDef {
             if (parentTableId == null || parentTableId.isEmpty()) {
                 throw new IllegalArgumentException("parentTableId must be set");
             }
-            if (onUpdateAction != ACTION_NO_ACTION) {
-                throw new IllegalArgumentException("invalid onUpdateCascadeAction " + onUpdateAction);
+            if (onUpdateAction != ACTION_NO_ACTION
+                    && onUpdateAction != ACTION_SETNULL) {
+                throw new IllegalArgumentException("invalid onUpdateAction " + onDeleteAction);
             }
             if (onDeleteAction != ACTION_NO_ACTION
                     && onDeleteAction != ACTION_CASCADE
                     && onDeleteAction != ACTION_SETNULL) {
-                throw new IllegalArgumentException("invalid onDeleteCascadeAction " + onDeleteAction);
+                throw new IllegalArgumentException("invalid onDeleteAction " + onDeleteAction);
             }
             if (parentTableColumns.size() != columns.size()) {
                 throw new IllegalArgumentException("the number of columns in child and parent table must be the same");

--- a/herddb-core/src/main/java/herddb/model/Table.java
+++ b/herddb-core/src/main/java/herddb/model/Table.java
@@ -235,8 +235,8 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
                             String col = dii.readUTF();
                             builder.parentTableColumn(col);
                         }
-                        builder.onUpdateCascadeAction(dii.readVInt());
-                        builder.onDeleteCascadeAction(dii.readVInt());
+                        builder.onUpdateAction(dii.readVInt());
+                        builder.onDeleteAction(dii.readVInt());
                         foreignKeys[i] = builder.build();
                     }
                 }
@@ -289,8 +289,8 @@ public class Table implements ColumnsList, BindableTableScanColumnNameResolver {
                     for (String col : k.parentTableColumns) {
                         doo.writeUTF(col);
                     }
-                    doo.writeVInt(k.onUpdateCascadeAction);
-                    doo.writeVInt(k.onDeleteCascadeAction);
+                    doo.writeVInt(k.onUpdateAction);
+                    doo.writeVInt(k.onDeleteAction);
                 }
             }
         } catch (IOException ee) {

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -605,7 +605,20 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
         int onDeleteCascadeAction = ForeignKeyDef.ACTION_NO_ACTION;
         if (fk.getOnDeleteReferenceOption() != null && !(fk.getOnDeleteReferenceOption().equalsIgnoreCase("RESTRICT")
                 || fk.getOnDeleteReferenceOption().equalsIgnoreCase("NO ACTION"))) {
-            throw new StatementExecutionException("Unsupported option " + fk.getOnDeleteReferenceOption());
+            switch (fk.getOnDeleteReferenceOption().toUpperCase().trim()) {
+                case "NO ACTION":
+                case "RESTRICT":
+                    onDeleteCascadeAction = ForeignKeyDef.ACTION_NO_ACTION;
+                    break;
+                case "CASCADE":
+                    onDeleteCascadeAction = ForeignKeyDef.ACTION_CASCADE;
+                    break;
+                case "SET NULL":
+                    onDeleteCascadeAction = ForeignKeyDef.ACTION_SETNULL;
+                    break;
+                default:
+                    throw new StatementExecutionException("Unsupported option " + fk.getOnDeleteReferenceOption());
+            }
         }
         if (fk.getOnUpdateReferenceOption() != null && !(
                 fk.getOnUpdateReferenceOption().equalsIgnoreCase("RESTRICT")
@@ -617,8 +630,8 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
                 .builder()
                 .name(indexName)
                 .parentTableId(parentTableSchema.uuid)
-                .onUpdateCascadeAction(onUpdateCascadeAction)
-                .onDeleteCascadeAction(onDeleteCascadeAction);
+                .onUpdateAction(onUpdateCascadeAction)
+                .onDeleteAction(onDeleteCascadeAction);
         for (String columnName : fk.getColumnsNames()) {
             columnName = fixMySqlBackTicks(columnName.toLowerCase());
             Column column = table.getColumn(columnName);

--- a/herddb-core/src/test/java/herddb/core/CreateTableTest.java
+++ b/herddb-core/src/test/java/herddb/core/CreateTableTest.java
@@ -107,8 +107,8 @@ public class CreateTableTest {
                     .foreingKey(ForeignKeyDef
                             .builder()
                             .name("myfk")
-                            .onDeleteCascadeAction(ForeignKeyDef.ACTION_NO_ACTION)
-                            .onUpdateCascadeAction(ForeignKeyDef.ACTION_NO_ACTION)
+                            .onDeleteAction(ForeignKeyDef.ACTION_NO_ACTION)
+                            .onUpdateAction(ForeignKeyDef.ACTION_NO_ACTION)
                             .column("parenttableid")
                             .parentTableId(parentTable.uuid)
                             .parentTableColumn("id")

--- a/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import herddb.core.DBManager;
 import herddb.core.TestUtils;
+import static herddb.core.TestUtils.scan;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;
@@ -41,6 +42,7 @@ import herddb.model.Table;
 import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
 import java.util.Collections;
+import static org.junit.Assert.fail;
 import org.junit.Test;
 
 /**
@@ -68,8 +70,8 @@ public class ForeignKeySQLTest {
             Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
             assertEquals(1, childTable.foreignKeys.length);
             assertEquals("fk1", childTable.foreignKeys[0].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
             assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
             assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
@@ -86,13 +88,13 @@ public class ForeignKeySQLTest {
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1"); // test without transaction
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION"); // test without transaction
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
             tx = beginTransaction(manager, "tblspace1");
-            testServerSideOfForeignKey(manager, tx, "fk1");  // test with transaction
+            testServerSideOfForeignKey(manager, tx, "fk1", "NO ACTION");  // test with transaction
             TestUtils.commitTransaction(manager, "tblspace1", tx);
 
         }
@@ -117,24 +119,34 @@ public class ForeignKeySQLTest {
         execute(manager, "UPDATE tblspace1.child set s2='newvalue'", Collections.emptyList(), new TransactionContext(tx));
     }
 
-    private void testServerSideOfForeignKey(final DBManager manager, long tx, String fkName) throws DataScannerException, StatementExecutionException {
+    private void testServerSideOfForeignKey(final DBManager manager, long tx, String fkName, String deleteAction) throws DataScannerException, StatementExecutionException {
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('a',2,'pvalue')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('newvalue',2,'foo')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('c1',2,'a')", Collections.emptyList(), new TransactionContext(tx));
+        execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('c2',2,'newvalue')", Collections.emptyList(), new TransactionContext(tx));
 
         ForeignKeyViolationException errOnUpdate = expectThrows(ForeignKeyViolationException.class, () -> {
             execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
         });
         assertEquals(fkName, errOnUpdate.getForeignKeyName());
 
-        ForeignKeyViolationException errOnDelete = expectThrows(ForeignKeyViolationException.class, () -> {
-            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
-        });
-        assertEquals(fkName, errOnDelete.getForeignKeyName());
+        if ("CASCADE".equals(deleteAction)) {
+            execute(manager, "DELETE FROM tblspace1.parent where k1='a'", Collections.emptyList(), new TransactionContext(tx));
+            // assert that we are deleting only the expected record
+            assertEquals(0, scan(manager, "SELECT * FROM tblspace1.child WHERE s2='a'", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.child WHERE s2='newvalue'", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
+        } else if ("NO ACTION".equals(deleteAction)) {
+            ForeignKeyViolationException errOnDelete = expectThrows(ForeignKeyViolationException.class, () -> {
+                execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
+            });
+            assertEquals(fkName, errOnDelete.getForeignKeyName());
 
-        execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList(), new TransactionContext(tx));
-        execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
-        execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList(), new TransactionContext(tx));
+            execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList(), new TransactionContext(tx));
+        } else {
+            fail();
+        }
 
     }
 
@@ -184,15 +196,15 @@ public class ForeignKeySQLTest {
             Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
             assertEquals(2, childTable.foreignKeys.length);
             assertEquals("fk1", childTable.foreignKeys[0].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
             assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
             assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
 
             assertEquals("fk2", childTable.foreignKeys[1].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onUpdateCascadeAction);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onDeleteCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onDeleteAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[1].parentTableId);
             assertArrayEquals(new String[]{"s2"}, childTable.foreignKeys[1].columns);
             assertArrayEquals(new String[]{"k1"}, childTable.foreignKeys[1].parentTableColumns);
@@ -202,15 +214,15 @@ public class ForeignKeySQLTest {
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1");
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION");
 
             execute(manager, "ALTER TABLE tblspace1.child DROP CONSTRAINT fk1", Collections.emptyList());
             childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
             assertEquals(1, childTable.foreignKeys.length);
 
             assertEquals("fk2", childTable.foreignKeys[0].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
             assertArrayEquals(new String[]{"s2"}, childTable.foreignKeys[0].columns);
             assertArrayEquals(new String[]{"k1"}, childTable.foreignKeys[0].parentTableColumns);
@@ -236,20 +248,20 @@ public class ForeignKeySQLTest {
             childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
             assertEquals(2, childTable.foreignKeys.length);
             assertEquals("fk2", childTable.foreignKeys[0].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
             assertArrayEquals(new String[]{"s2"}, childTable.foreignKeys[0].columns);
             assertArrayEquals(new String[]{"k1"}, childTable.foreignKeys[0].parentTableColumns);
 
             assertEquals("fk3", childTable.foreignKeys[1].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onUpdateCascadeAction);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onDeleteCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[1].onDeleteAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[1].parentTableId);
             assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[1].columns);
             assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[1].parentTableColumns);
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk2");
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk2", "NO ACTION");
 
         }
     }
@@ -297,11 +309,59 @@ public class ForeignKeySQLTest {
             assertEquals(1, childTable.foreignKeys.length);
 
             assertEquals("fk1", childTable.foreignKeys[0].name);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateCascadeAction);
-            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteCascadeAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteAction);
             assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
             assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
             assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
+
+        }
+    }
+
+    @Test
+    public void createTableWithOnDeleteCascade() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.parent (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+            execute(manager, "CREATE TABLE tblspace1.child (k2 string primary key,n2 int,"
+                    + "s2 string, "
+                    + "CONSTRAINT fk1 FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1) ON DELETE CASCADE ON UPDATE NO ACTION)", Collections.emptyList());
+            Table parentTable = manager.getTableSpaceManager("tblspace1").getTableManager("parent").getTable();
+
+            Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
+            assertEquals(1, childTable.foreignKeys.length);
+            assertEquals("fk1", childTable.foreignKeys[0].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_CASCADE, childTable.foreignKeys[0].onDeleteAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
+            assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
+            assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
+
+            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1"); // test without transaction
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            long tx = beginTransaction(manager, "tblspace1");
+            testChildSideOfForeignKey(manager, tx, "fk1");  // test with transaction
+            TestUtils.commitTransaction(manager, "tblspace1", tx);
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "CASCADE"); // test without transaction
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            tx = beginTransaction(manager, "tblspace1");
+            testServerSideOfForeignKey(manager, tx, "fk1", "CASCADE");  // test with transaction
+            TestUtils.commitTransaction(manager, "tblspace1", tx);
 
         }
     }

--- a/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/ForeignKeySQLTest.java
@@ -22,14 +22,16 @@ package herddb.sql;
 import static herddb.core.TestUtils.beginTransaction;
 import static herddb.core.TestUtils.dump;
 import static herddb.core.TestUtils.execute;
+import static herddb.core.TestUtils.scan;
 import static herddb.utils.TestUtils.expectThrows;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import herddb.core.DBManager;
 import herddb.core.TestUtils;
-import static herddb.core.TestUtils.scan;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
 import herddb.mem.MemoryMetadataStorageManager;
@@ -42,7 +44,6 @@ import herddb.model.Table;
 import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
 import java.util.Collections;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 
 /**
@@ -88,13 +89,13 @@ public class ForeignKeySQLTest {
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION"); // test without transaction
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION", "NO ACTION"); // test without transaction
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
             tx = beginTransaction(manager, "tblspace1");
-            testServerSideOfForeignKey(manager, tx, "fk1", "NO ACTION");  // test with transaction
+            testServerSideOfForeignKey(manager, tx, "fk1", "NO ACTION", "NO ACTION");  // test with transaction
             TestUtils.commitTransaction(manager, "tblspace1", tx);
 
         }
@@ -119,21 +120,37 @@ public class ForeignKeySQLTest {
         execute(manager, "UPDATE tblspace1.child set s2='newvalue'", Collections.emptyList(), new TransactionContext(tx));
     }
 
-    private void testServerSideOfForeignKey(final DBManager manager, long tx, String fkName, String deleteAction) throws DataScannerException, StatementExecutionException {
+    private void testServerSideOfForeignKey(final DBManager manager, long tx, String fkName, String updateAction, String deleteAction) throws DataScannerException, StatementExecutionException {
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('a',2,'pvalue')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.parent(k1,n1,s1) values('newvalue',2,'foo')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('c1',2,'a')", Collections.emptyList(), new TransactionContext(tx));
         execute(manager, "INSERT INTO tblspace1.child(k2,n2,s2) values('c2',2,'newvalue')", Collections.emptyList(), new TransactionContext(tx));
 
-        ForeignKeyViolationException errOnUpdate = expectThrows(ForeignKeyViolationException.class, () -> {
-            execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
-        });
-        assertEquals(fkName, errOnUpdate.getForeignKeyName());
+        if ("SET NULL".equals(updateAction)) {
+            // assert that we are setting null only on the expected record
+            execute(manager, "UPDATE tblspace1.parent set n1=983 where k1='a'", Collections.emptyList(), new TransactionContext(tx));
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.child WHERE s2 is NULL and n2 is NULL", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.child WHERE s2='newvalue'", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
+        } else if ("CASCADE".equals(updateAction)) {
+            // not implemented
+        } else if ("NO ACTION".equals(updateAction)) {
+            ForeignKeyViolationException errOnUpdate = expectThrows(ForeignKeyViolationException.class, () -> {
+                execute(manager, "UPDATE tblspace1.parent set n1=983", Collections.emptyList(), new TransactionContext(tx));
+            });
+            assertEquals(fkName, errOnUpdate.getForeignKeyName());
+        } else {
+            fail();
+        }
 
         if ("CASCADE".equals(deleteAction)) {
             execute(manager, "DELETE FROM tblspace1.parent where k1='a'", Collections.emptyList(), new TransactionContext(tx));
             // assert that we are deleting only the expected record
             assertEquals(0, scan(manager, "SELECT * FROM tblspace1.child WHERE s2='a'", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.child WHERE s2='newvalue'", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
+        } else if ("SET NULL".equals(deleteAction)) {
+            execute(manager, "DELETE FROM tblspace1.parent where k1='a'", Collections.emptyList(), new TransactionContext(tx));
+            // assert that we are setting null only on the expected record
+            assertEquals(1, scan(manager, "SELECT * FROM tblspace1.child WHERE s2 is NULL and n2 is NULL", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
             assertEquals(1, scan(manager, "SELECT * FROM tblspace1.child WHERE s2='newvalue'", Collections.emptyList(), new TransactionContext(tx)).consumeAndClose().size());
         } else if ("NO ACTION".equals(deleteAction)) {
             ForeignKeyViolationException errOnDelete = expectThrows(ForeignKeyViolationException.class, () -> {
@@ -214,7 +231,7 @@ public class ForeignKeySQLTest {
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION");
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION", "NO ACTION");
 
             execute(manager, "ALTER TABLE tblspace1.child DROP CONSTRAINT fk1", Collections.emptyList());
             childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
@@ -261,7 +278,7 @@ public class ForeignKeySQLTest {
             assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[1].columns);
             assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[1].parentTableColumns);
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk2", "NO ACTION");
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk2", "NO ACTION", "NO ACTION");
 
         }
     }
@@ -354,13 +371,110 @@ public class ForeignKeySQLTest {
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
-            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "CASCADE"); // test without transaction
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION", "CASCADE"); // test without transaction
 
             execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
             execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
 
             tx = beginTransaction(manager, "tblspace1");
-            testServerSideOfForeignKey(manager, tx, "fk1", "CASCADE");  // test with transaction
+            testServerSideOfForeignKey(manager, tx, "fk1", "NO ACTION", "CASCADE");  // test with transaction
+            TestUtils.commitTransaction(manager, "tblspace1", tx);
+
+        }
+    }
+
+    @Test
+    public void createTableWithOnDeleteSetNull() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.parent (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+            execute(manager, "CREATE TABLE tblspace1.child (k2 string primary key,n2 int,"
+                    + "s2 string, "
+                    + "CONSTRAINT fk1 FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1) ON DELETE SET NULL ON UPDATE NO ACTION)", Collections.emptyList());
+            Table parentTable = manager.getTableSpaceManager("tblspace1").getTableManager("parent").getTable();
+
+            Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
+            assertEquals(1, childTable.foreignKeys.length);
+            assertEquals("fk1", childTable.foreignKeys[0].name);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_SETNULL, childTable.foreignKeys[0].onDeleteAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
+            assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
+            assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
+
+            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1"); // test without transaction
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            long tx = beginTransaction(manager, "tblspace1");
+            testChildSideOfForeignKey(manager, tx, "fk1");  // test with transaction
+            TestUtils.commitTransaction(manager, "tblspace1", tx);
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "NO ACTION", "SET NULL"); // test without transaction
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            tx = beginTransaction(manager, "tblspace1");
+            testServerSideOfForeignKey(manager, tx, "fk1", "NO ACTION", "SET NULL");  // test with transaction
+            TestUtils.commitTransaction(manager, "tblspace1", tx);
+
+        }
+    }
+
+    @Test
+    public void createTableWithOnUpdateSetNull() throws Exception {
+        assumeTrue("only jsqlparser 4.x support ON UPDATE set NULL", false);
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.parent (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+            execute(manager, "CREATE TABLE tblspace1.child (k2 string primary key,n2 int,"
+                    + "s2 string, "
+                    + "CONSTRAINT fk1 FOREIGN KEY (s2,n2) REFERENCES parent(k1,n1) ON DELETE NO ACTION ON UPDATE SET NULL)", Collections.emptyList());
+            Table parentTable = manager.getTableSpaceManager("tblspace1").getTableManager("parent").getTable();
+
+            Table childTable = manager.getTableSpaceManager("tblspace1").getTableManager("child").getTable();
+            assertEquals(1, childTable.foreignKeys.length);
+            assertEquals("fk1", childTable.foreignKeys[0].name);
+            assertEquals(ForeignKeyDef.ACTION_SETNULL, childTable.foreignKeys[0].onUpdateAction);
+            assertEquals(ForeignKeyDef.ACTION_NO_ACTION, childTable.foreignKeys[0].onDeleteAction);
+            assertEquals(parentTable.uuid, childTable.foreignKeys[0].parentTableId);
+            assertArrayEquals(new String[]{"s2", "n2"}, childTable.foreignKeys[0].columns);
+            assertArrayEquals(new String[]{"k1", "n1"}, childTable.foreignKeys[0].parentTableColumns);
+
+            testChildSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1"); // test without transaction
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            long tx = beginTransaction(manager, "tblspace1");
+            testChildSideOfForeignKey(manager, tx, "fk1");  // test with transaction
+            TestUtils.commitTransaction(manager, "tblspace1", tx);
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            testServerSideOfForeignKey(manager, TransactionContext.NOTRANSACTION_ID, "fk1", "SET NULL", "NO ACTION"); // test without transaction
+
+            execute(manager, "DELETE FROM tblspace1.child", Collections.emptyList());
+            execute(manager, "DELETE FROM tblspace1.parent", Collections.emptyList());
+
+            tx = beginTransaction(manager, "tblspace1");
+            testServerSideOfForeignKey(manager, tx, "fk1", "SET NULL", "NO ACTION");  // test with transaction
             TestUtils.commitTransaction(manager, "tblspace1", tx);
 
         }


### PR DESCRIPTION
Implement Foreign Key common actions:
- ON DELETE CASCADE -> delete matching records from the children tables
- ON DELETE SET NULL -> set NULL on matching records from the children tables
- ON UPDATE SET NULL -> set NULL on matching records from the children tables 

This patch does not include:
- ON DELETE/UPDATE SET DEFAULT -> is it somehow useful ?
- ON UPDATE CASCADE -> this will be trickier to implement, because we should update the child table AFTER the parent table, I had implemented it but it is not worth the complexity if no user needs it

Also please note that "ON UPDATE SET NULL" and other SQL DDL constructs are not available on current version of jsqlParser, but they are available only on 4.0-SNAPSHOT.
I tested 4.0-SNAPSHOT locally and left the test cases disabled (assumeTrue(false)) 

Please note that with autocommit=true (outside of a transaction) the FK actions are performed BEFORE applying the change to the parent table.
When you are inside a transaction everything works as expected, that is that all of the actions are executed inside the same transaction scope.