### PR TITLE
Do not marshal/unmarshal to ByteBufs during 'local' communication

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/client/ClientSideConnectionPeer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.client;
+
+import herddb.network.Channel;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Connection from a client to a server.
+ */
+public interface ClientSideConnectionPeer {
+
+    void close();
+
+    Channel getChannel();
+
+    Channel ensureOpen() throws HDBException;
+
+    String getClientId();
+
+    String getNodeId();
+
+    DMLResult executeUpdate(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException;
+
+    GetResult executeGet(String tableSpace, String query, long tx, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException;
+
+    long beginTransaction(String tableSpace) throws HDBException, ClientSideMetadataProviderException;
+
+    void commitTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException;
+
+    void rollbackTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException;
+
+    ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize,
+                              boolean keepReadLocks) throws HDBException, ClientSideMetadataProviderException;
+
+    CompletableFuture<DMLResult> executeUpdateAsync(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params);
+
+    CompletableFuture<List<DMLResult>> executeUpdatesAsync(
+            String tableSpace, String query, long tx, boolean returnValues,
+            boolean usePreparedStatement, List<List<Object>> batch
+    );
+
+    List<DMLResult> executeUpdates(
+            String tableSpace, String query, long tx, boolean returnValues,
+            boolean usePreparedStatement, List<List<Object>> batch
+    ) throws HDBException, ClientSideMetadataProviderException;
+
+    void dumpTableSpace(String tableSpace, int fetchSize, boolean includeTransactionLog, TableSpaceDumpReceiver receiver) throws HDBException, ClientSideMetadataProviderException;
+
+    void restoreTableSpace(String tableSpace, TableSpaceRestoreSource source) throws HDBException, ClientSideMetadataProviderException;
+}

--- a/herddb-core/src/main/java/herddb/client/HDBClient.java
+++ b/herddb-core/src/main/java/herddb/client/HDBClient.java
@@ -61,6 +61,7 @@ public class HDBClient implements AutoCloseable {
     private final StatsLogger statsLogger;
     private final int maxOperationRetryCount;
     private final int operationRetryDelay;
+    private final boolean localMode;
 
     public HDBClient(ClientConfiguration configuration) {
         this(configuration, NullStatsLogger.INSTANCE);
@@ -74,6 +75,9 @@ public class HDBClient implements AutoCloseable {
         int corePoolSizeDefault = ClientConfiguration.PROPERTY_CLIENT_CALLBACKS_DEFAULT;
         if (ClientConfiguration.PROPERTY_MODE_LOCAL.equals(mode)) {
             corePoolSizeDefault = 0;
+            localMode = true;
+        } else {
+            localMode = false;
         }
         int corePoolSize = configuration.getInt(ClientConfiguration.PROPERTY_CLIENT_CALLBACKS, corePoolSizeDefault);
         boolean connectRemoteServers = configuration.getBoolean(ClientConfiguration.PROPERTY_CLIENT_CONNECT_REMOTE_SERVER, ClientConfiguration.PROPERTY_CLIENT_CONNECT_REMOTE_SERVER_DEFAULT);
@@ -195,5 +199,9 @@ public class HDBClient implements AutoCloseable {
 
     StatsLogger getStatsLogger() {
         return statsLogger;
+    }
+
+    boolean isLocalMode() {
+        return localMode;
     }
 }

--- a/herddb-core/src/main/java/herddb/client/NonMarshallingClientSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/client/NonMarshallingClientSideConnectionPeer.java
@@ -1,0 +1,127 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.client;
+
+import herddb.network.Channel;
+import herddb.network.netty.LocalVMChannel;
+import herddb.server.ServerSideConnectionPeer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This is a wrapper around RoutedClientSideConnection that skips serialization to netty ByteBufs
+ * in order to save CPU cycles in 'local' mode.
+ */
+public class NonMarshallingClientSideConnectionPeer implements ClientSideConnectionPeer {
+
+    private final RoutedClientSideConnection fallback;
+
+    public NonMarshallingClientSideConnectionPeer(RoutedClientSideConnection fallback) {
+        this.fallback = fallback;
+    }
+
+    @Override
+    public String getNodeId() {
+        return fallback.getNodeId();
+    }
+
+    @Override
+    public String getClientId() {
+        return fallback.getClientId();
+    }
+
+    @Override
+    public void close() {
+        fallback.close();
+    }
+
+    @Override
+    public Channel getChannel() {
+        return fallback.getChannel();
+    }
+
+    @Override
+    public Channel ensureOpen() throws HDBException {
+        return fallback.ensureOpen();
+    }
+
+    @Override
+    public DMLResult executeUpdate(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException {
+        LocalVMChannel channel = (LocalVMChannel) fallback.ensureOpen();
+        ServerSideConnectionPeer serverSidePeer = (ServerSideConnectionPeer) channel.getServerSideChannel().getMessagesReceiver();
+        return serverSidePeer.executeUpdate(tableSpace, query, tx, returnValues, params);
+    }
+
+    @Override
+    public CompletableFuture<DMLResult> executeUpdateAsync(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params) {
+        return fallback.executeUpdateAsync(tableSpace, query, tx, returnValues, usePreparedStatement, params);
+    }
+
+    @Override
+    public List<DMLResult> executeUpdates(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<List<Object>> batch) throws HDBException, ClientSideMetadataProviderException {
+        return fallback.executeUpdates(tableSpace, query, tx, returnValues, usePreparedStatement, batch);
+    }
+
+    @Override
+    public CompletableFuture<List<DMLResult>> executeUpdatesAsync(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<List<Object>> batch) {
+        return fallback.executeUpdatesAsync(tableSpace, query, tx, returnValues, usePreparedStatement, batch);
+    }
+
+    @Override
+    public GetResult executeGet(String tableSpace, String query, long tx, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException {
+        return fallback.executeGet(tableSpace, query, tx, usePreparedStatement, params);
+    }
+
+    @Override
+    public long beginTransaction(String tableSpace) throws HDBException, ClientSideMetadataProviderException {
+        return fallback.beginTransaction(tableSpace);
+    }
+
+    @Override
+    public void commitTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException {
+        LocalVMChannel channel = (LocalVMChannel) fallback.ensureOpen();
+        ServerSideConnectionPeer serverSidePeer = (ServerSideConnectionPeer) channel.getServerSideChannel().getMessagesReceiver();
+        serverSidePeer.commitTransaction(tableSpace, tx);
+    }
+
+    @Override
+    public void rollbackTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException {
+        LocalVMChannel channel = (LocalVMChannel) fallback.ensureOpen();
+        ServerSideConnectionPeer serverSidePeer = (ServerSideConnectionPeer) channel.getServerSideChannel().getMessagesReceiver();
+        serverSidePeer.rollbackTransaction(tableSpace, tx);
+    }
+
+    @Override
+    public ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize, boolean keepReadLocks) throws HDBException, ClientSideMetadataProviderException {
+        return fallback.executeScan(tableSpace, query, usePreparedStatement, params, tx, maxRows, fetchSize, keepReadLocks);
+    }
+
+    @Override
+    public void dumpTableSpace(String tableSpace, int fetchSize, boolean includeTransactionLog, TableSpaceDumpReceiver receiver) throws HDBException, ClientSideMetadataProviderException {
+        fallback.dumpTableSpace(tableSpace, fetchSize, includeTransactionLog, receiver);
+    }
+
+    @Override
+    public void restoreTableSpace(String tableSpace, TableSpaceRestoreSource source) throws HDBException, ClientSideMetadataProviderException {
+        fallback.restoreTableSpace(tableSpace, source);
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
+++ b/herddb-core/src/main/java/herddb/client/RoutedClientSideConnection.java
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
  *
  * @author enrico.olivelli
  */
-public class RoutedClientSideConnection implements ChannelEventListener {
+public class RoutedClientSideConnection implements ChannelEventListener, ClientSideConnectionPeer {
 
     private static final Logger LOGGER = Logger.getLogger(RoutedClientSideConnection.class.getName());
     private static final RawString RAWSTRING_KEY = RawString.of("_key");
@@ -94,10 +94,12 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         this.clientId = connection.getClient().getConfiguration().getString(ClientConfiguration.PROPERTY_CLIENTID, ClientConfiguration.PROPERTY_CLIENTID_DEFAULT);
     }
 
+    @Override
     public String getNodeId() {
         return nodeId;
     }
 
+    @Override
     public String getClientId() {
         return clientId;
     }
@@ -274,10 +276,12 @@ public class RoutedClientSideConnection implements ChannelEventListener {
 
     }
 
-    Channel getChannel() {
+    @Override
+    public Channel getChannel() {
         return channel;
     }
 
+    @Override
     public void close() {
         LOGGER.log(Level.FINER, "{0} - close", this);
 
@@ -294,7 +298,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    private Channel ensureOpen() throws HDBException {
+    @Override
+    public Channel ensureOpen() throws HDBException {
         connectionLock.readLock().lock();
         try {
             Channel channel = this.channel;
@@ -378,7 +383,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    DMLResult executeUpdate(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException {
+    @Override
+    public DMLResult executeUpdate(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         try {
             long requestId = channel.generateRequestId();
@@ -411,7 +417,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    CompletableFuture<DMLResult> executeUpdateAsync(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params) {
+    @Override
+    public CompletableFuture<DMLResult> executeUpdateAsync(String tableSpace, String query, long tx, boolean returnValues, boolean usePreparedStatement, List<Object> params) {
         CompletableFuture<DMLResult> res = new CompletableFuture<>();
         try {
             Channel channel = ensureOpen();
@@ -454,7 +461,7 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         return res;
     }
 
-    List<DMLResult> executeUpdates(
+    public List<DMLResult> executeUpdates(
             String tableSpace, String query, long tx, boolean returnValues,
             boolean usePreparedStatement, List<List<Object>> batch
     ) throws HDBException, ClientSideMetadataProviderException {
@@ -504,7 +511,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    CompletableFuture<List<DMLResult>> executeUpdatesAsync(
+    @Override
+    public CompletableFuture<List<DMLResult>> executeUpdatesAsync(
             String tableSpace, String query, long tx, boolean returnValues,
             boolean usePreparedStatement, List<List<Object>> batch
     ) {
@@ -563,7 +571,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         return res;
     }
 
-    GetResult executeGet(String tableSpace, String query, long tx, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException {
+    @Override
+    public GetResult executeGet(String tableSpace, String query, long tx, boolean usePreparedStatement, List<Object> params) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         try {
             long requestId = channel.generateRequestId();
@@ -611,7 +620,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         return data;
     }
 
-    long beginTransaction(String tableSpace) throws HDBException, ClientSideMetadataProviderException {
+    @Override
+    public long beginTransaction(String tableSpace) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         try {
             long requestId = channel.generateRequestId();
@@ -638,7 +648,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    void commitTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException {
+    @Override
+    public void commitTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         try {
             long requestId = channel.generateRequestId();
@@ -659,7 +670,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    void rollbackTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException {
+    @Override
+    public void rollbackTransaction(String tableSpace, long tx) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         try {
             long requestId = channel.generateRequestId();
@@ -706,7 +718,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize,
+    @Override
+    public ScanResultSet executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> params, long tx, int maxRows, int fetchSize,
                               boolean keepReadLocks) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         Pdu reply = null;
@@ -749,7 +762,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    void dumpTableSpace(String tableSpace, int fetchSize, boolean includeTransactionLog, TableSpaceDumpReceiver receiver) throws HDBException, ClientSideMetadataProviderException {
+    @Override
+    public void dumpTableSpace(String tableSpace, int fetchSize, boolean includeTransactionLog, TableSpaceDumpReceiver receiver) throws HDBException, ClientSideMetadataProviderException {
         Channel channel = ensureOpen();
         try {
             String dumpId = this.clientId + ":" + scannerIdGenerator.incrementAndGet();
@@ -773,7 +787,8 @@ public class RoutedClientSideConnection implements ChannelEventListener {
         }
     }
 
-    void restoreTableSpace(String tableSpace, TableSpaceRestoreSource source) throws HDBException, ClientSideMetadataProviderException {
+    @Override
+    public void restoreTableSpace(String tableSpace, TableSpaceRestoreSource source) throws HDBException, ClientSideMetadataProviderException {
         List<DumpedTableMetadata> tables = new ArrayList<>();
         try {
             while (true) {

--- a/herddb-core/src/main/java/herddb/server/LocalClientScanResultSetImpl.java
+++ b/herddb-core/src/main/java/herddb/server/LocalClientScanResultSetImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package herddb.server;
+
+import herddb.client.HDBException;
+import herddb.client.ScanResultSet;
+import herddb.client.ScanResultSetMetadata;
+import herddb.model.DataScanner;
+import herddb.model.DataScannerException;
+import herddb.utils.DataAccessor;
+
+/**
+ * Adapted from DataScanner to ScanResultSet.
+ */
+public class LocalClientScanResultSetImpl extends ScanResultSet {
+
+    private final DataScanner dataScanner;
+    private final ScanResultSetMetadata metadata;
+
+    LocalClientScanResultSetImpl(DataScanner dataScanner) {
+        super(dataScanner.getTransactionId());
+        this.dataScanner = dataScanner;
+        this.metadata = new ScanResultSetMetadata(dataScanner.getFieldNames());
+    }
+
+    @Override
+    public ScanResultSetMetadata getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public void close() {
+        if (dataScanner.isClosed()) {
+            return;
+        }
+        try {
+            dataScanner.close();
+        } catch (DataScannerException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public boolean hasNext() throws HDBException {
+        try {
+            return dataScanner.hasNext();
+        } catch (DataScannerException ex) {
+            throw new HDBException(ex);
+        }
+    }
+
+    @Override
+    public DataAccessor next() throws HDBException {
+        try {
+            return dataScanner.next();
+        } catch (DataScannerException ex) {
+            throw new HDBException(ex);
+        }
+    }
+
+    @Override
+    public String getCursorName() {
+        return "<scanner-" + System.identityHashCode(dataScanner) + "-@tx" + transactionId + ">";
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -100,6 +100,7 @@ import org.apache.calcite.tools.ValidationException;
 public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEventListener {
 
     private static final Logger LOGGER = Logger.getLogger(ServerSideConnectionPeer.class.getName());
+    private static final RawString RAWSTRING_KEY = RawString.of("_key");
     private static final AtomicLong IDGENERATOR = new AtomicLong();
     private final long id = IDGENERATOR.incrementAndGet();
     private final Channel channel;
@@ -711,7 +712,65 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         }
     }
 
+    /**
+     * This method is like {@link #handleExecuteStatement(herddb.proto.Pdu, herddb.network.Channel) } but in "local" mode,
+     * we do not want here to marshal/unmarshal values, in order to save resources
+     */
+    public herddb.client.GetResult executeGet(String tablespace, String query, long txId, List<Object> parameters) throws HDBException {
+        // ensure we are dealing with the same data types that we see when the request id coming from the wire
+        parameters = PduCodec.normalizeParametersList(parameters);
+        TransactionContext transactionContext = new TransactionContext(txId);
+        TranslatedQuery translatedQuery;
+        try {
+            translatedQuery = server.getManager().getPlanner().translate(tablespace,
+                    query, parameters, false, true, true, -1);
+            Statement statement = translatedQuery.plan.mainStatement;
+            CompletableFuture<StatementExecutionResult> res = server
+                    .getManager()
+                    .executePlanAsync(translatedQuery.plan, translatedQuery.context, transactionContext);
+            CompletableFuture<herddb.client.GetResult> finalResult = res.handle((result, err) -> {
+                if (err != null) {
+                    while (err instanceof CompletionException) {
+                        err = err.getCause();
+                    }
+                    if (err instanceof DuplicatePrimaryKeyException) {
+                        throw new CompletionException(new SQLIntegrityConstraintViolationException(err));
+                    } else {
+                        throw new CompletionException(new SQLException(err));
+                    }
+                }
+                if (result instanceof GetResult) {
+                    GetResult get = (GetResult) result;
+                    if (!get.found()) {
+                        return new herddb.client.GetResult(null, get.transactionId);
+                    } else {
+                        Map<String, Object> record = get.getRecord().toBean(get.getTable());
+                        Map<RawString, Object> recordForClient = new HashMap<>(record.size());
+                        record.forEach((k, v) -> {
+                            recordForClient.put(RawString.of(k), v);
+                        });
+                        return new herddb.client.GetResult(recordForClient, get.transactionId);
+                    }
+                } else {
+                    throw new CompletionException(new SQLException("Unknown result type " + result.getClass() + ": " + result));
+                }
+            });
+            return finalResult.get();
+        } catch (Throwable err) {
+            while (err instanceof CompletionException) {
+                err = err.getCause();
+            }
+            throw new HDBException(err);
+        }
+    }
+
+    /**
+     * This method is like {@link #handleExecuteStatement(herddb.proto.Pdu, herddb.network.Channel) } but in "local" mode,
+     * we do not want here to marshal/unmarshal values, in order to save resources
+     */
     public DMLResult executeUpdate(String tablespace, String query, long txId, boolean returnValues, List<Object> parameters) throws HDBException {
+        // ensure we are dealing with the same data types that we see when the request id coming from the wire
+        parameters = PduCodec.normalizeParametersList(parameters);
         TransactionContext transactionContext = new TransactionContext(txId);
         TranslatedQuery translatedQuery;
         try {
@@ -721,7 +780,6 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
             CompletableFuture<StatementExecutionResult> res = server
                     .getManager()
                     .executePlanAsync(translatedQuery.plan, translatedQuery.context, transactionContext);
-//                    LOGGER.log(Level.SEVERE, "query " + query + ", " + parameters + ", result:" + result);
             CompletableFuture<DMLResult> finalResult = res.handle((result, err) -> {
                 if (err != null) {
                     while (err instanceof CompletionException) {
@@ -743,7 +801,7 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                                 .getTableSpaceManager(statement.getTableSpace()).getTableManager(tableStatement.getTable()).getTable();
                         final Map<RawString, Object> newRecord = new HashMap<>();
                         Object newKey = RecordSerializer.deserializePrimaryKey(dml.getKey(), table);
-                        newRecord.put(RawString.of("_key"), newKey);
+                        newRecord.put(RAWSTRING_KEY, newKey);
                         if (dml.getNewvalue() != null) {
                             Map<String, Object> toBean = RecordSerializer.toBean(new Record(dml.getKey(), dml.getNewvalue()), table);
                             toBean.forEach((k, v) -> {
@@ -935,6 +993,16 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         }
     }
 
+    public long beginTransaction(String tableSpace) throws HDBException {
+        try {
+            BeginTransactionStatement statement = new BeginTransactionStatement(tableSpace);
+            TransactionContext transactionContext = TransactionContext.NO_TRANSACTION;
+            return server.getManager().executeStatement(statement, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), transactionContext).transactionId;
+        } catch (HerdDBInternalException t) {
+            throw new HDBException(t);
+        }
+    }
+
     private void handleTxCommand(Pdu message, Channel channel) {
         long txId = PduCodec.TxCommand.readTx(message);
         int type = PduCodec.TxCommand.readCommand(message);
@@ -1071,6 +1139,45 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
     @Override
     public String toString() {
         return "ServerSideConnectionPeer{" + "id=" + id + ", channel=" + channel + ", address=" + address + ", username=" + username + '}';
+    }
+
+    public LocalClientScanResultSetImpl executeScan(String tableSpace, String query, boolean usePreparedStatement, List<Object> parameters, long txId, int maxRows, int fetchSize, boolean keepReadLocks) throws HDBException {
+
+        if (query == null) {
+            throw new HDBException("bad query null");
+        }
+
+        parameters = PduCodec.normalizeParametersList(parameters);
+
+        try {
+            TranslatedQuery translatedQuery = server
+                    .getManager()
+                    .getPlanner().translate(tableSpace,
+                            query, parameters, true, true, false, maxRows);
+            translatedQuery.context.setForceRetainReadLock(keepReadLocks);
+
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "{0} -> {1}", new Object[]{query, translatedQuery.plan.mainStatement});
+            }
+
+            TransactionContext transactionContext = new TransactionContext(txId);
+            if (translatedQuery.plan.mainStatement instanceof SQLPlannedOperationStatement
+                    || translatedQuery.plan.mainStatement instanceof ScanStatement) {
+                ScanResult scanResult = (ScanResult) server.getManager().executePlan(translatedQuery.plan, translatedQuery.context, transactionContext);
+                DataScanner dataScanner = scanResult.dataScanner;
+                return new LocalClientScanResultSetImpl(dataScanner);
+            } else {
+                throw new HDBException("unsupported query type for scan " + query + ": PLAN is " + translatedQuery.plan);
+            }
+        } catch (HerdDBInternalException err) {
+            if (err.getCause() != null && err.getCause() instanceof ValidationException) {
+                // no stacktraces for bad queries
+                LOGGER.log(Level.FINE, "SQL error on scanner: " + err);
+            } else {
+                LOGGER.log(Level.SEVERE, "error on scanner: " + err, err);
+            }
+            throw new HDBException(err);
+        }
     }
 
 }

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -26,6 +26,8 @@ import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_COMMIT_TRANSACTION;
 import static herddb.proto.PduCodec.TxCommand.TX_COMMAND_ROLLBACK_TRANSACTION;
 import herddb.backup.DumpedLogEntry;
 import herddb.client.ClientConfiguration;
+import herddb.client.DMLResult;
+import herddb.client.HDBException;
 import herddb.codec.RecordSerializer;
 import herddb.core.HerdDBInternalException;
 import herddb.core.RunningStatementInfo;
@@ -68,9 +70,11 @@ import herddb.security.sasl.SaslNettyServer;
 import herddb.sql.TranslatedQuery;
 import herddb.utils.Bytes;
 import herddb.utils.DataAccessor;
+import herddb.utils.RawString;
 import herddb.utils.TuplesList;
 import io.netty.buffer.ByteBuf;
 import java.io.EOFException;
+import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -707,6 +711,64 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
         }
     }
 
+    public DMLResult executeUpdate(String tablespace, String query, long txId, boolean returnValues, List<Object> parameters) throws HDBException {
+        TransactionContext transactionContext = new TransactionContext(txId);
+        TranslatedQuery translatedQuery;
+        try {
+            translatedQuery = server.getManager().getPlanner().translate(tablespace,
+                    query, parameters, false, true, returnValues, -1);
+            Statement statement = translatedQuery.plan.mainStatement;
+            CompletableFuture<StatementExecutionResult> res = server
+                    .getManager()
+                    .executePlanAsync(translatedQuery.plan, translatedQuery.context, transactionContext);
+//                    LOGGER.log(Level.SEVERE, "query " + query + ", " + parameters + ", result:" + result);
+            CompletableFuture<DMLResult> finalResult = res.handle((result, err) -> {
+                if (err != null) {
+                    while (err instanceof CompletionException) {
+                        err = err.getCause();
+                    }
+                    if (err instanceof DuplicatePrimaryKeyException) {
+                        throw new CompletionException(new SQLIntegrityConstraintViolationException(err));
+                    } else {
+                        throw new CompletionException(new SQLException(err));
+                    }
+                }
+                if (result instanceof DMLStatementExecutionResult) {
+                    DMLStatementExecutionResult dml = (DMLStatementExecutionResult) result;
+
+                    if (returnValues && dml.getKey() != null) {
+                        TableAwareStatement tableStatement = statement.unwrap(TableAwareStatement.class);
+                        Table table = server
+                                .getManager()
+                                .getTableSpaceManager(statement.getTableSpace()).getTableManager(tableStatement.getTable()).getTable();
+                        final Map<RawString, Object> newRecord = new HashMap<>();
+                        Object newKey = RecordSerializer.deserializePrimaryKey(dml.getKey(), table);
+                        newRecord.put(RawString.of("_key"), newKey);
+                        if (dml.getNewvalue() != null) {
+                            Map<String, Object> toBean = RecordSerializer.toBean(new Record(dml.getKey(), dml.getNewvalue()), table);
+                            toBean.forEach((k, v) -> {
+                                newRecord.put(RawString.of(k), v);
+                            });
+                        }
+                        return new DMLResult(dml.getUpdateCount(), newKey, newRecord, dml.transactionId);
+                    } else {
+                        return new DMLResult(dml.getUpdateCount(), null, null, dml.transactionId);
+                    }
+                } else if (result instanceof DDLStatementExecutionResult) {
+                    return new DMLResult(1, null, null, result.transactionId);
+                } else {
+                    throw new CompletionException(new SQLException("Unknown result type " + result.getClass() + ": " + result));
+                }
+            });
+            return finalResult.get();
+        } catch (Throwable err) {
+            while (err instanceof CompletionException) {
+                err = err.getCause();
+            }
+            throw new HDBException(err);
+        }
+    }
+
     private void handleExecuteStatement(Pdu message, Channel channel) {
         long txId = PduCodec.ExecuteStatement.readTx(message);
         String tablespace = PduCodec.ExecuteStatement.readTablespace(message);
@@ -850,6 +912,26 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                             message.messageId, newId));
         } finally {
             message.close();
+        }
+    }
+
+    public void rollbackTransaction(String tableSpace, long txId) throws HDBException {
+        try {
+            RollbackTransactionStatement statement = new RollbackTransactionStatement(tableSpace, txId);
+            TransactionContext transactionContext = new TransactionContext(txId);
+            server.getManager().executeStatement(statement, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), transactionContext);
+        } catch (HerdDBInternalException t) {
+            throw new HDBException(t);
+        }
+    }
+
+    public void commitTransaction(String tableSpace, long txId) throws HDBException {
+        try {
+            CommitTransactionStatement statement = new CommitTransactionStatement(tableSpace, txId);
+            TransactionContext transactionContext = new TransactionContext(txId);
+            server.getManager().executeStatement(statement, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), transactionContext);
+        } catch (HerdDBInternalException t) {
+            throw new HDBException(t);
         }
     }
 

--- a/herddb-core/src/test/java/herddb/client/SimpleClientServerTest.java
+++ b/herddb-core/src/test/java/herddb/client/SimpleClientServerTest.java
@@ -524,7 +524,7 @@ public class SimpleClientServerTest {
     public void testClientCloseOnConnectionAndResumeTransaction() throws Exception {
         Path baseDir = folder.newFolder().toPath();
         AtomicInteger connectionToUse = new AtomicInteger();
-        AtomicReference<RoutedClientSideConnection[]> connections = new AtomicReference<>();
+        AtomicReference<ClientSideConnectionPeer[]> connections = new AtomicReference<>();
         try (Server server = new Server(new ServerConfiguration(baseDir))) {
             server.start();
             server.waitForStandaloneBoot();
@@ -536,7 +536,7 @@ public class SimpleClientServerTest {
                 public HDBConnection openConnection() {
                     HDBConnection con = new HDBConnection(this) {
                         @Override
-                        protected RoutedClientSideConnection chooseConnection(RoutedClientSideConnection[] all) {
+                        protected ClientSideConnectionPeer chooseConnection(ClientSideConnectionPeer[] all) {
                             connections.set(all);
                             LOG.log(Level.INFO,
                                     "chooseConnection among " + all.length + " connections, getting " + connectionToUse);
@@ -759,7 +759,7 @@ public class SimpleClientServerTest {
     @Test
     public void testEnsureOpen() throws Exception {
         Path baseDir = folder.newFolder().toPath();
-        AtomicReference<RoutedClientSideConnection[]> connections = new AtomicReference<>();
+        AtomicReference<ClientSideConnectionPeer[]> connections = new AtomicReference<>();
         ServerConfiguration serverConfiguration = new ServerConfiguration(baseDir);
         try (Server server = new Server(new ServerConfiguration(baseDir))) {
             server.getNetworkServer().setEnableJVMNetwork(false);
@@ -774,7 +774,7 @@ public class SimpleClientServerTest {
                 public HDBConnection openConnection() {
                     HDBConnection con = new HDBConnection(this) {
                         @Override
-                        protected RoutedClientSideConnection chooseConnection(RoutedClientSideConnection[] all) {
+                        protected ClientSideConnectionPeer chooseConnection(ClientSideConnectionPeer[] all) {
                             connections.set(all);
                             return all[0];
                         }

--- a/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/RetryOnLeaderChangedTest.java
@@ -24,12 +24,12 @@ import static herddb.core.TestUtils.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import herddb.client.ClientConfiguration;
+import herddb.client.ClientSideConnectionPeer;
 import herddb.client.ClientSideMetadataProviderException;
 import herddb.client.GetResult;
 import herddb.client.HDBClient;
 import herddb.client.HDBConnection;
 import herddb.client.HDBException;
-import herddb.client.RoutedClientSideConnection;
 import herddb.client.ScanResultSet;
 import herddb.core.ActivatorRunRequest;
 import herddb.core.DBManager;
@@ -554,7 +554,7 @@ public class RetryOnLeaderChangedTest {
         }
 
         @Override
-        public RoutedClientSideConnection getRouteToTableSpace(String tableSpace)
+        public ClientSideConnectionPeer getRouteToTableSpace(String tableSpace)
                 throws ClientSideMetadataProviderException, HDBException {
             return super.getRouteToTableSpace(tableSpace);
         }


### PR DESCRIPTION
In "local" mode we can same a lot of CPU cycles if we pass Java objects directly to the server side logic.

Changes:
- introduce a new interface ClientSideConnectionPeer
- RoutedClientSideConnection now is the common implementation of ClientSideConnectionPeer
- introduce NonMarshallingClientSideConnectionPeer, a new implementation of ClientSideConnectionPeer that wraps a RoutedClientSideConnection and for known commands it passes the control directly to ServerSideConnectionPeer

This way we save a lot of marshalling/unmarshalling and Netty memory while working in "local" mode