### PR TITLE
More OpenJPA compatibility for DDL with backticks

### DIFF
--- a/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
@@ -53,7 +53,7 @@ public abstract class AbstractSQLPlanner {
 
     public abstract TranslatedQuery translate(String defaultTableSpace, String query, List<Object> parameters, boolean scan, boolean allowCache, boolean returnValues, int maxRows) throws StatementExecutionException;
 
-    protected final void ensureDefaultTableSpaceBootedLocally(String defaultTableSpace) {        
+    protected final void ensureDefaultTableSpaceBootedLocally(String defaultTableSpace) {
         TableSpaceManager tableSpaceManager = getTableSpaceManager(defaultTableSpace);
         if (tableSpaceManager == null) {
             throw new NotLeaderException("tablespace " + defaultTableSpace + " not available here (at server " + manager.getNodeId() + ")");

--- a/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/AbstractSQLPlanner.java
@@ -53,7 +53,7 @@ public abstract class AbstractSQLPlanner {
 
     public abstract TranslatedQuery translate(String defaultTableSpace, String query, List<Object> parameters, boolean scan, boolean allowCache, boolean returnValues, int maxRows) throws StatementExecutionException;
 
-    protected final void ensureDefaultTableSpaceBootedLocally(String defaultTableSpace) {
+    protected final void ensureDefaultTableSpaceBootedLocally(String defaultTableSpace) {        
         TableSpaceManager tableSpaceManager = getTableSpaceManager(defaultTableSpace);
         if (tableSpaceManager == null) {
             throw new NotLeaderException("tablespace " + defaultTableSpace + " not available here (at server " + manager.getNodeId() + ")");

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -1173,6 +1173,7 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
         if (tableSpace == null) {
             tableSpace = defaultTableSpace;
         }
+        tableSpace = fixMySqlBackTicks(tableSpace);
         List<Column> addColumns = new ArrayList<>();
         List<Column> modifyColumns = new ArrayList<>();
         List<String> dropColumns = new ArrayList<>();
@@ -1707,6 +1708,7 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
         if (tableSpace == null) {
             tableSpace = defaultTableSpace;
         }
+        tableSpace = fixMySqlBackTicks(tableSpace);
         TableSpaceManager tableSpaceManager = getTableSpaceManager(tableSpace);
         if (tableSpaceManager == null) {
             clearCache();
@@ -1735,6 +1737,7 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
         if (tableSpace == null) {
             tableSpace = defaultTableSpace;
         }
+        tableSpace = fixMySqlBackTicks(tableSpace);
         TableSpaceManager tableSpaceManager = getTableSpaceManager(tableSpace);
         if (tableSpaceManager == null) {
             clearCache();

--- a/herddb-core/src/test/java/herddb/sql/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/RawSQLTest.java
@@ -2744,12 +2744,12 @@ public class RawSQLTest {
         String nodeId = "localhost";
         try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
             manager.start();
-            assertTrue(manager.waitForBootOfLocalTablespaces(10000));            
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
             execute(manager, "CREATE TABLE `herd`.`parentTable` (`k1` VARCHAR NOT NULL, `p1` INTEGER)", Collections.emptyList());
             execute(manager, "CREATE TABLE `herd`.`childTable` (`k1` VARCHAR NOT NULL, `n1` INTEGER, PRIMARY KEY (`k1`), CONSTRAINT `un1` UNIQUE (`n1`))", Collections.emptyList());
             execute(manager, "ALTER TABLE `herd`.`childTable` ADD CONSTRAINT `fk1` FOREIGN KEY (`n1`) REFERENCES `herd`.`parentTable` (`p1`) ON DELETE CASCADE", Collections.emptyList());
             execute(manager, "ALTER TABLE `herd`.`childTable` DROP CONSTRAINT `fk1`", Collections.emptyList());
-            
+
             List<Index> availableIndexes = manager.getTableSpaceManager("herd").getTableManager("childtable").getAvailableIndexes();
             assertEquals(1, availableIndexes.size());
             assertEquals("un1", availableIndexes.get(0).name);

--- a/herddb-core/src/test/java/herddb/sql/RawSQLTest.java
+++ b/herddb-core/src/test/java/herddb/sql/RawSQLTest.java
@@ -51,6 +51,7 @@ import herddb.model.DMLStatementExecutionResult;
 import herddb.model.DataScanner;
 import herddb.model.DuplicatePrimaryKeyException;
 import herddb.model.GetResult;
+import herddb.model.Index;
 import herddb.model.IndexAlreadyExistsException;
 import herddb.model.IndexDoesNotExistException;
 import herddb.model.MissingJDBCParameterException;
@@ -2737,6 +2738,25 @@ public class RawSQLTest {
             }
         }
     }
+
+    @Test
+    public void openJPATest() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));            
+            execute(manager, "CREATE TABLE `herd`.`parentTable` (`k1` VARCHAR NOT NULL, `p1` INTEGER)", Collections.emptyList());
+            execute(manager, "CREATE TABLE `herd`.`childTable` (`k1` VARCHAR NOT NULL, `n1` INTEGER, PRIMARY KEY (`k1`), CONSTRAINT `un1` UNIQUE (`n1`))", Collections.emptyList());
+            execute(manager, "ALTER TABLE `herd`.`childTable` ADD CONSTRAINT `fk1` FOREIGN KEY (`n1`) REFERENCES `herd`.`parentTable` (`p1`) ON DELETE CASCADE", Collections.emptyList());
+            execute(manager, "ALTER TABLE `herd`.`childTable` DROP CONSTRAINT `fk1`", Collections.emptyList());
+            
+            List<Index> availableIndexes = manager.getTableSpaceManager("herd").getTableManager("childtable").getAvailableIndexes();
+            assertEquals(1, availableIndexes.size());
+            assertEquals("un1", availableIndexes.get(0).name);
+            assertTrue(availableIndexes.get(0).unique);
+        }
+    }
+
 
     @Test
     public void jdbcAliasList() throws Exception {


### PR DESCRIPTION
- Add tests for foreign keys and unique constrains as created by OpenJPA (see https://github.com/apache/openjpa/pull/76)
- Handle backticks in tablespace name on DDL statements