### PR TITLE
#737 update Netty to 4.1.59.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <libs.netty4>4.1.59.Final</libs.netty4>
-        <libs.netty4ssl>2.0.28.Final</libs.netty4ssl>
+        <libs.netty4ssl>2.0.36.Final</libs.netty4ssl>
         <!-- needed in tests for TLS certificate autogeneration on jdk-15+ -->
         <libs.bouncycastle>1.65</libs.bouncycastle>
         <libs.calcite>1.24.0</libs.calcite>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <libs.netty4>4.1.50.Final</libs.netty4>
+        <libs.netty4>4.1.59.Final</libs.netty4>
         <libs.netty4ssl>2.0.28.Final</libs.netty4ssl>
         <!-- needed in tests for TLS certificate autogeneration on jdk-15+ -->
         <libs.bouncycastle>1.65</libs.bouncycastle>


### PR DESCRIPTION
PR for #737
Updated Netty4 dependency to 4.1.59.Final

 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
