### PR TITLE
Feature/checkpoint command

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -36,8 +36,37 @@ import herddb.mem.MemoryMetadataStorageManager;
 import herddb.metadata.MetadataChangeListener;
 import herddb.metadata.MetadataStorageManager;
 import herddb.metadata.MetadataStorageManagerException;
-import herddb.model.*;
-import herddb.model.commands.*;
+import herddb.model.DDLException;
+import herddb.model.DDLStatement;
+import herddb.model.DDLStatementExecutionResult;
+import herddb.model.DMLStatement;
+import herddb.model.DMLStatementExecutionResult;
+import herddb.model.DataConsistencyStatementResult;
+import herddb.model.DataScanner;
+import herddb.model.DataScannerException;
+import herddb.model.ExecutionPlan;
+import herddb.model.GetResult;
+import herddb.model.NodeMetadata;
+import herddb.model.NotLeaderException;
+import herddb.model.ScanResult;
+import herddb.model.Statement;
+import herddb.model.StatementEvaluationContext;
+import herddb.model.StatementExecutionException;
+import herddb.model.StatementExecutionResult;
+import herddb.model.Table;
+import herddb.model.TableSpace;
+import herddb.model.TableSpaceDoesNotExistException;
+import herddb.model.TableSpaceReplicaState;
+import herddb.model.TransactionContext;
+import herddb.model.commands.AlterTableSpaceStatement;
+import herddb.model.commands.CheckpointStatement;
+import herddb.model.commands.CheckpointStatementResult;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.model.commands.DropTableSpaceStatement;
+import herddb.model.commands.GetStatement;
+import herddb.model.commands.ScanStatement;
+import herddb.model.commands.TableConsistencyCheckStatement;
+import herddb.model.commands.TableSpaceConsistencyCheckStatement;
 import herddb.network.Channel;
 import herddb.network.ServerHostData;
 import herddb.proto.Pdu;
@@ -676,7 +705,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
             if (transactionContext.transactionId > 0) {
                 return Futures.exception(new StatementExecutionException("CHECKPOINT cannot be issue inside a transaction"));
             }
-            return  CompletableFuture.completedFuture(forceCheckpoint((CheckpointStatement) statement));
+            return CompletableFuture.completedFuture(forceCheckpoint((CheckpointStatement) statement));
         }
         TableSpaceManager manager = tablesSpaces.get(tableSpace);
         if (manager == null) {

--- a/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
@@ -24,9 +24,10 @@ import herddb.model.Statement;
 
 /**
  * TableSpace consistency check statement
+ *
  * @author lorenzobalzani
  */
-public class CheckpointStatement extends Statement{
+public class CheckpointStatement extends Statement {
 
     public CheckpointStatement(String tableSpace) {
         super(tableSpace);

--- a/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
@@ -1,3 +1,23 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
 package herddb.model.commands;
 
 import herddb.model.Statement;

--- a/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CheckpointStatement.java
@@ -1,0 +1,14 @@
+package herddb.model.commands;
+
+import herddb.model.Statement;
+
+/**
+ * TableSpace consistency check statement
+ * @author lorenzobalzani
+ */
+public class CheckpointStatement extends Statement{
+
+    public CheckpointStatement(String tableSpace) {
+        super(tableSpace);
+    }
+}

--- a/herddb-core/src/main/java/herddb/model/commands/CheckpointStatementResult.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CheckpointStatementResult.java
@@ -24,6 +24,7 @@ import herddb.model.StatementExecutionResult;
 
 /**
  * Statement result for a checkpoint operation
+ *
  * @author lorenzobalzani
  */
 public class CheckpointStatementResult extends StatementExecutionResult {

--- a/herddb-core/src/main/java/herddb/model/commands/CheckpointStatementResult.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CheckpointStatementResult.java
@@ -1,4 +1,26 @@
-package herddb.model;
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.model.commands;
+
+import herddb.model.StatementExecutionResult;
 
 /**
  * Statement result for a checkpoint operation

--- a/herddb-core/src/main/java/herddb/model/commands/CheckpointStatementResult.java
+++ b/herddb-core/src/main/java/herddb/model/commands/CheckpointStatementResult.java
@@ -1,0 +1,32 @@
+package herddb.model;
+
+/**
+ * Statement result for a checkpoint operation
+ * @author lorenzobalzani
+ */
+public class CheckpointStatementResult extends StatementExecutionResult {
+
+    private final String message;
+    private final boolean ok;
+
+    public CheckpointStatementResult(boolean ok) {
+        super(0);
+        this.ok = ok;
+        this.message = null;
+    }
+
+    public CheckpointStatementResult(boolean ok, String message) {
+        super(0);
+        this.ok = ok;
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public boolean getOk() {
+        return this.ok;
+    }
+}
+

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -185,6 +185,7 @@ public class CalcitePlanner extends AbstractSQLPlanner {
     private final AbstractSQLPlanner fallback;
     public static final String TABLE_CONSISTENCY_COMMAND = "tableconsistencycheck";
     public static final String TABLESPACE_CONSISTENCY_COMMAND = "tablespaceconsistencycheck";
+    public static final String FORCE_CHECKPOINT_COMMAND = "checkpoint";
 
     private static final SqlTypeFactoryImpl SQL_TYPE_FACTORY_IMPL = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     private static final RexBuilder REX_BUILDER  = new RexBuilder(SQL_TYPE_FACTORY_IMPL);
@@ -266,6 +267,10 @@ public class CalcitePlanner extends AbstractSQLPlanner {
             return fallback.translate(defaultTableSpace, query, parameters, scan, allowCache, returnValues, maxRows);
         }
         if (query.startsWith(TABLESPACE_CONSISTENCY_COMMAND)) {
+            query = JSQLParserPlanner.rewriteExecuteSyntax(query);
+            return fallback.translate(defaultTableSpace, query, parameters, scan, allowCache, returnValues, maxRows);
+        }
+        if (query.startsWith(FORCE_CHECKPOINT_COMMAND)) {
             query = JSQLParserPlanner.rewriteExecuteSyntax(query);
             return fallback.translate(defaultTableSpace, query, parameters, scan, allowCache, returnValues, maxRows);
         }

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -48,7 +48,27 @@ import herddb.model.TableDoesNotExistException;
 import herddb.model.TableSpace;
 import herddb.model.TableSpaceDoesNotExistException;
 import herddb.model.TupleComparator;
-import herddb.model.commands.*;
+import herddb.model.commands.AlterTableSpaceStatement;
+import herddb.model.commands.AlterTableStatement;
+import herddb.model.commands.BeginTransactionStatement;
+import herddb.model.commands.CheckpointStatement;
+import herddb.model.commands.CommitTransactionStatement;
+import herddb.model.commands.CreateIndexStatement;
+import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.model.commands.CreateTableStatement;
+import herddb.model.commands.DeleteStatement;
+import herddb.model.commands.DropIndexStatement;
+import herddb.model.commands.DropTableSpaceStatement;
+import herddb.model.commands.DropTableStatement;
+import herddb.model.commands.GetStatement;
+import herddb.model.commands.InsertStatement;
+import herddb.model.commands.RollbackTransactionStatement;
+import herddb.model.commands.SQLPlannedOperationStatement;
+import herddb.model.commands.ScanStatement;
+import herddb.model.commands.TableConsistencyCheckStatement;
+import herddb.model.commands.TableSpaceConsistencyCheckStatement;
+import herddb.model.commands.TruncateTableStatement;
+import herddb.model.commands.UpdateStatement;
 import herddb.model.planner.AggregateOp;
 import herddb.model.planner.BindableTableScanOp;
 import herddb.model.planner.FilterOp;
@@ -1165,9 +1185,6 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
         }
     }
 
-    /**
-     * It forces a checkpoint operation on given tablespace
-     */
     public Statement forceTableSpaceCheckPoint(String query) {
         if (query.startsWith(FORCE_CHECKPOINT_COMMAND)) {
             String tableSpace = query.substring(query.substring(0, 10).length()).replace("\'", "");

--- a/herddb-core/src/test/java/herddb/checkpoint/CheckpointCommandTest.java
+++ b/herddb-core/src/test/java/herddb/checkpoint/CheckpointCommandTest.java
@@ -1,0 +1,72 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package herddb.checkpoint;
+
+import herddb.core.DBManager;
+import herddb.mem.MemoryCommitLogManager;
+import herddb.mem.MemoryDataStorageManager;
+import herddb.mem.MemoryMetadataStorageManager;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static herddb.core.TestUtils.execute;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Checkpoint command test
+ * @author lorenzobalzani
+ */
+public class CheckpointCommandTest {
+
+    @Test
+    public void checkpointCommandSuccessTest() throws Exception {
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
+            execute(manager, "CREATE TABLESPACE 'consistence'", Collections.emptyList());
+            manager.waitForTablespace("tblspace1", 10000);
+            execute(manager, "CREATE TABLE consistence.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+            for (int i = 0; i < 10; i++) {
+                execute(manager, "INSERT INTO consistence.tsql (k1,n1 ,s1) values (?,?,?)", Arrays.asList(i, 1, "b"));
+            }
+            execute(manager, "checkpoint consistence", Collections.emptyList());
+        }
+    }
+
+    @Test(expected = herddb.model.TableSpaceDoesNotExistException.class)
+    public void checkpointCommandFailureTest() throws Exception {
+        final String WRONG_TABLE_SPACE = "THIS_TABLESPACE_DOES_NOT_EXISTS";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            assertTrue(manager.waitForBootOfLocalTablespaces(10000));
+            execute(manager, "CREATE TABLESPACE 'consistence'", Collections.emptyList());
+            manager.waitForTablespace("tblspace1", 10000);
+            execute(manager, "CREATE TABLE consistence.tsql (k1 string primary key,n1 int,s1 string)", Collections.emptyList());
+            for (int i = 0; i < 10; i++) {
+                execute(manager, "INSERT INTO consistence.tsql (k1,n1 ,s1) values (?,?,?)", Arrays.asList(i, 1, "b"));
+            }
+            execute(manager, "checkpoint " + WRONG_TABLE_SPACE, Collections.emptyList());
+        }
+    }
+}
+

--- a/herddb-core/src/test/java/herddb/checkpoint/CheckpointCommandTest.java
+++ b/herddb-core/src/test/java/herddb/checkpoint/CheckpointCommandTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Checkpoint command test
+ *
  * @author lorenzobalzani
  */
 public class CheckpointCommandTest {


### PR DESCRIPTION
I have implemented the checkpoint command for a tablespace passing through the CalcitePlanner. It finally invokes a forced checkpoint by calling DBManager#forceCheckpoint. I have written two tests in order to verify the command syntax.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)