### PR TITLE
Improve memory configuration #755

### DIFF
--- a/herddb-core/src/main/java/herddb/core/MemoryManager.java
+++ b/herddb-core/src/main/java/herddb/core/MemoryManager.java
@@ -75,7 +75,7 @@ public class MemoryManager {
 
         LOGGER.log(Level.INFO, "Maximum amount of memory for primary key indexes {0} ({1} pages)",
                 new Object[]{(maxPKUsedMemory / (1024 * 1024)) + " MB", pkPages});
-        
+
         if (indexPages > 0) {
             LOGGER.log(Level.INFO, "Maximum amount of memory for data {0} ({1} pages)",
                     new Object[]{(maxDataUsedMemory / (1024 * 1024)) + " MB", dataPages});

--- a/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BRINIndexManager.java
@@ -88,7 +88,7 @@ public class BRINIndexManager extends AbstractIndexManager {
                                              writeLockTimeout, readLockTimeout);
         this.data = new BlockRangeIndex<>(
                 memoryManager.getMaxLogicalPageSize(),
-                memoryManager.getDataPageReplacementPolicy(),
+                memoryManager.getIndexPageReplacementPolicy(),
                 storageLayer);
     }
 

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -286,6 +286,19 @@ public final class ServerConfiguration {
     public static final String PROPERTY_MAX_PK_MEMORY = "server.memory.pk.limit";
     public static final long PROPERTY_MAX_PK_MEMORY_DEFAULT = 0L;
 
+    /**
+     * Percentage of maximum memory used for data pages, will be used if {@link PROPERTY_MAX_PK_MEMORY} is not given
+     */
+    public static final String PROPERTY_MAX_DATA_MEMORY_PERCENTAGE = "server.memory.data.percentage";
+    public static final double PROPERTY_MAX_DATA_MEMORY_PERCENTAGE_DEFAULT = 0.50D;
+
+    /**
+     * Percentage of maximum memory used for primary index pages, will be used if {@link PROPERTY_MAX_DATA_MEMORY} is
+     * not given
+     */
+    public static final String PROPERTY_MAX_PK_MEMORY_PERCENTAGE = "server.memory.pk.percentage";
+    public static final double PROPERTY_MAX_PK_MEMORY_PERCENTAGE_DEFAULT = 0.20D;
+
     public static final String PROPERTY_JMX_ENABLE = "server.jmx.enable";
     public static final boolean PROPERTY_JMX_ENABLE_DEFAULT = true;
 

--- a/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
+++ b/herddb-core/src/main/java/herddb/server/ServerConfiguration.java
@@ -281,19 +281,32 @@ public final class ServerConfiguration {
     public static final long PROPERTY_MAX_DATA_MEMORY_DEFAULT = 0L;
 
     /**
+     * Maximum amount of memory used for data pages
+     */
+    public static final String PROPERTY_MAX_INDEX_MEMORY = "server.memory.index.limit";
+    public static final long PROPERTY_MAX_INDEX_MEMORY_DEFAULT = 0L;
+
+    /**
      * Maximum amount of memory used for primary index pages
      */
     public static final String PROPERTY_MAX_PK_MEMORY = "server.memory.pk.limit";
     public static final long PROPERTY_MAX_PK_MEMORY_DEFAULT = 0L;
 
     /**
-     * Percentage of maximum memory used for data pages, will be used if {@link PROPERTY_MAX_PK_MEMORY} is not given
+     * Percentage of maximum memory used for data pages, will be used if {@link PROPERTY_MAX_DATA_MEMORY} is not given
      */
     public static final String PROPERTY_MAX_DATA_MEMORY_PERCENTAGE = "server.memory.data.percentage";
     public static final double PROPERTY_MAX_DATA_MEMORY_PERCENTAGE_DEFAULT = 0.50D;
 
     /**
-     * Percentage of maximum memory used for primary index pages, will be used if {@link PROPERTY_MAX_DATA_MEMORY} is
+     * Percentage of maximum memory used for index pages, will be used if {@link PROPERTY_MAX_INDEX_MEMORY} is not given.
+     * A value of zero means "no dedicated index memory": data memory will be used instead.
+     */
+    public static final String PROPERTY_MAX_INDEX_MEMORY_PERCENTAGE = "server.memory.index.percentage";
+    public static final double PROPERTY_MAX_INDEX_MEMORY_PERCENTAGE_DEFAULT = 0.00D;
+
+    /**
+     * Percentage of maximum memory used for primary index pages, will be used if {@link PROPERTY_MAX_PK_MEMORY} is
      * not given
      */
     public static final String PROPERTY_MAX_PK_MEMORY_PERCENTAGE = "server.memory.pk.percentage";

--- a/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
@@ -103,11 +103,13 @@ public class ChangeRoleTest extends MultiServerBase {
                     new HashSet<>(Arrays.asList("server1", "server2")), "server1", 1, 0), StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
 
             assertEquals(0, server2MemoryManager.getDataPageReplacementPolicy().size());
+            assertEquals(0, server2MemoryManager.getIndexPageReplacementPolicy().size());
             assertEquals(0, server2MemoryManager.getPKPageReplacementPolicy().size());
 
             server_2.waitForTableSpaceBoot(TableSpace.DEFAULT, false);
 
-            assertEquals(2, server2MemoryManager.getDataPageReplacementPolicy().size());
+            assertEquals(1, server2MemoryManager.getDataPageReplacementPolicy().size());
+            assertEquals(1, server2MemoryManager.getIndexPageReplacementPolicy().size());
             assertEquals(1, server2MemoryManager.getPKPageReplacementPolicy().size());
 
             // stop tablespace on server2
@@ -125,6 +127,7 @@ public class ChangeRoleTest extends MultiServerBase {
 
             // memory must have been totally released
             assertEquals(0, server2MemoryManager.getDataPageReplacementPolicy().size());
+            assertEquals(0, server2MemoryManager.getIndexPageReplacementPolicy().size());
             assertEquals(0, server2MemoryManager.getPKPageReplacementPolicy().size());
 
             // start tablespace on server2, as let it become leader
@@ -135,6 +138,7 @@ public class ChangeRoleTest extends MultiServerBase {
 
             assertTrue("unexpected value " + server2MemoryManager.getDataPageReplacementPolicy().size(),
                     server2MemoryManager.getDataPageReplacementPolicy().size() >= 1);
+            assertEquals(1, server2MemoryManager.getIndexPageReplacementPolicy().size());
             assertEquals(1, server2MemoryManager.getPKPageReplacementPolicy().size());
 
             server_1.getManager().executeStatement(new AlterTableSpaceStatement(TableSpace.DEFAULT,
@@ -149,6 +153,7 @@ public class ChangeRoleTest extends MultiServerBase {
 
             // memory must have been totally released again
             assertEquals(0, server2MemoryManager.getDataPageReplacementPolicy().size());
+            assertEquals(0, server2MemoryManager.getIndexPageReplacementPolicy().size());
             assertEquals(0, server2MemoryManager.getPKPageReplacementPolicy().size());
 
         }

--- a/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
@@ -45,7 +45,7 @@ public class BLinkKeyToPageIndexTest extends KeyToPageIndexTest {
     @Override
     KeyToPageIndex createIndex() {
 
-        MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), (128L << 10));
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), 0, (128L << 10));
         MemoryDataStorageManager ds = new MemoryDataStorageManager();
         BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
 

--- a/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
+++ b/herddb-core/src/test/java/herddb/index/BLinkKeyToPageIndexTest.java
@@ -45,7 +45,7 @@ public class BLinkKeyToPageIndexTest extends KeyToPageIndexTest {
     @Override
     KeyToPageIndex createIndex() {
 
-        MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), 0, (128L << 10));
+        MemoryManager mem = new MemoryManager(5 * (1L << 20), 0, 10 * (128L << 10), (128L << 10));
         MemoryDataStorageManager ds = new MemoryDataStorageManager();
         BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds);
 

--- a/herddb-core/src/test/java/herddb/index/blink/BlinkBench.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BlinkBench.java
@@ -122,7 +122,7 @@ public class BlinkBench {
                 PrintStream eps = new PrintStream(eos);
                 System.setErr(eps);
 
-                MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), (128L << 10));
+                MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), 0, (128L << 10));
 
                 try (MemoryDataStorageManager ds = new MemoryDataStorageManager();
                      BLinkKeyToPageIndex idx = new BLinkKeyToPageIndex("tblspc", "tbl", mem, ds)) {

--- a/herddb-core/src/test/java/herddb/index/blink/BlinkRandomBench.java
+++ b/herddb-core/src/test/java/herddb/index/blink/BlinkRandomBench.java
@@ -122,7 +122,7 @@ public class BlinkRandomBench {
                 PrintStream eps = new PrintStream(eos);
                 System.setErr(eps);
 
-                MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), (128L << 10));
+                MemoryManager mem = new MemoryManager(5 * (1L << 20), 10 * (128L << 10), 0, (128L << 10));
                 // MemoryManager mem = new MemoryManager(5 * (1L << 20), (128L << 10), (128L << 10));
 
                 try (MemoryDataStorageManager ds = new MemoryDataStorageManager();

--- a/herddb-services/src/main/resources/conf/server.properties
+++ b/herddb-services/src/main/resources/conf/server.properties
@@ -177,11 +177,25 @@ server.users.file=../conf/users
 # overall limit on memory usage. it defaults to maximum heap size configured on the JVM
 #server.memory.max.limit=
 
-# maximum amount of memory (in bytes) used for data. Defaults to 30% of server.memory.max.limit
+# Maximum amount of memory (in bytes) used for data. Defaults to 50% of server.memory.max.limit
 #server.memory.data.limit=
 
-# maximum amount of memory (in bytes) used for primary indexes. Defaults to 20% of server.memory.max.limit
+# Maximum amount of memory (in bytes) used for indexes. Defaults to 0% of server.memory.max.limit.
+# If no memory for indexes is configured between server.memory.index.limit and server.memory.index.percentage
+# indexes will not use dedicated memory but will share data memory (default behaviour)
+#server.memory.index.limit=
+
+# Maximum amount of memory (in bytes) used for primary indexes. Defaults to 20% of server.memory.max.limit
 #server.memory.pk.limit=
+
+# Percentage of maximum memory used for data, defaults to 50%. Used only if server.memory.data.limit isn't configured
+#server.memory.data.percentage=
+
+# Percentage of maximum memory used for indexes, defaults to 0%. Used only if server.memory.index.limit isn't configured
+#server.memory.index.percentage=
+
+# Percentage of maximum memory used for primary indexes, defaults to 20%. Used only if server.memory.pk.limit isn't configured
+#server.memory.pk.percentage=
 
 # enable/disable JMX
 #server.jmx.enable=true


### PR DESCRIPTION
This patch solves #755:

- add a new set of configuration to be able to configure memory constraints based on a percentage of maximum memory and not an absolute number: server.memory.data.percentage, server.memory.index.percentage server.memory.pk.percentage. Actually data and pk are simply a configurable value for a previous fixed one. The index is new, see below
- add a new set of configuration to enable indexes / data pages memory separation. Up untill now data and indexes was stored in the same memory space with the same constraint. Now you can configure server.memory.index.percentage (maximum memory percentage value, defaults to 0%) or server.memory.index.limit (byte fixed value, default to 0). If dedicated index memory resolves to a value more than 0 it will be used instead of data memory. By default index will continue to share data memory
- Due to memory inspections I noted that memory occupancy is evaluated enough well, we don't need to keep up to 50% memory free by default for "every else". Increased data default space from 30% to 50%.

 - [ x ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
