### PR TITLE
Upgrade guava to 31.0.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <libs.zookeeper>3.6.2</libs.zookeeper>
         <libs.jsqlparser>3.2</libs.jsqlparser>
         <libs.curator>5.1.0</libs.curator>
-        <libs.guava>29.0-jre</libs.guava>
+        <libs.guava>31.0.1-jre</libs.guava>
         <libs.slf4j>1.7.29</libs.slf4j>
         <libs.commonscollections>3.2.2</libs.commonscollections>
         <libs.lz4>1.3.0</libs.lz4>


### PR DESCRIPTION
This upgrade is to address the vulnerability affected by version 29.0-jre.CVE-2020-8908, even if I don't think we are affected by this problem.

```
low severity
Vulnerable versions: <= 29.0
Patched version: No fix
A temp directory creation vulnerability exist in all Guava versions allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava com.google.common.io.Files.createTempDir(). The permissions granted to the directory created default to the standard unix-like /tmp ones, leaving the files open. We recommend explicitly change the permissions after the creation of the directory, or removing uses of the vulnerable method.
```

