### PR TITLE
Trace data fetch page retry

### DIFF
--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3975,21 +3975,21 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 if (dataPage != null) {
                     Collection<Bytes> keysForDebug = dataPage.getKeysForDebug(); // this may in an inconsistent state
                     throw new DataStorageManagerException("Inconsistency! Table " + table.name
-                    	    + " no record in memory for " + key
-                    	    + ", attempted pages " + Arrays.toString(trialPages)
-                    	    + ", next page " + pageId
-                    	    + ", activePages " + pageSet.getActivePages()
-                    	    + ", dataPage " + dataPage
-                    	    + ", dataPageKeys " + keysForDebug
-                    	    + " after many trials");
+                            + " no record in memory for " + key
+                            + ", attempted pages " + Arrays.toString(trialPages)
+                            + ", next page " + pageId
+                            + ", activePages " + pageSet.getActivePages()
+                            + ", dataPage " + dataPage
+                            + ", dataPageKeys " + keysForDebug
+                            + " after many trials");
                 } else {
                     throw new DataStorageManagerException("Inconsistency! Table " + table.name
-                    	    + " no record in memory for " + key
-                    	    + ", attempted pages " + Arrays.toString(trialPages)
-                    	    + ", next page " + pageId
-                    	    + ", activePages " + pageSet.getActivePages()
-                    	    + ", dataPage " + dataPage
-                    	    + " after many trials");
+                            + " no record in memory for " + key
+                            + ", attempted pages " + Arrays.toString(trialPages)
+                            + ", next page " + pageId
+                            + ", activePages " + pageSet.getActivePages()
+                            + ", dataPage " + dataPage
+                            + " after many trials");
                 }
             }
         }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3923,7 +3923,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
     }
 
     private Record fetchRecord(Bytes key, Long pageId, LocalScanPageCache localScanPageCache) throws StatementExecutionException, DataStorageManagerException {
-        int maxTrials = 2;
+        int maxTrials = 3;
         long[] trialPages = null;
         while (true) {
             DataPage dataPage = fetchDataPage(pageId, localScanPageCache);
@@ -3971,7 +3971,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             }
             trialPages[trialPages.length - maxTrials] = pageId;
             pageId = relocatedPageId;
-            if (maxTrials-- == 0) {
+            if (--maxTrials == 0) {
                 if (dataPage != null) {
                     Collection<Bytes> keysForDebug = dataPage.getKeysForDebug(); // this may in an inconsistent state
                     throw new DataStorageManagerException("Inconsistency! Table " + table.name

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3967,7 +3967,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 return null;
             }
             if (trialPages == null) {
-            	trialPages = new long[maxTrials];
+                trialPages = new long[maxTrials];
             }
             trialPages[trialPages.length - maxTrials] = pageId;
             pageId = relocatedPageId;
@@ -3975,21 +3975,21 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                 if (dataPage != null) {
                     Collection<Bytes> keysForDebug = dataPage.getKeysForDebug(); // this may in an inconsistent state
                     throw new DataStorageManagerException("Inconsistency! Table " + table.name
-                    		+ " no record in memory for " + key
-                    		+ ", attempted pages " + Arrays.toString(trialPages)
-                    		+ ", next page " + pageId
-                    		+ ", activePages " + pageSet.getActivePages()
-                    		+ ", dataPage " + dataPage
-                    		+ ", dataPageKeys " + keysForDebug
-                    		+ " after many trials");
+                    	    + " no record in memory for " + key
+                    	    + ", attempted pages " + Arrays.toString(trialPages)
+                    	    + ", next page " + pageId
+                    	    + ", activePages " + pageSet.getActivePages()
+                    	    + ", dataPage " + dataPage
+                    	    + ", dataPageKeys " + keysForDebug
+                    	    + " after many trials");
                 } else {
                     throw new DataStorageManagerException("Inconsistency! Table " + table.name
-                    		+ " no record in memory for " + key
-                    		+ ", attempted pages " + Arrays.toString(trialPages)
-                    		+ ", next page " + pageId
-                    		+ ", activePages " + pageSet.getActivePages()
-                    		+ ", dataPage " + dataPage
-                    		+ " after many trials");
+                    	    + " no record in memory for " + key
+                    	    + ", attempted pages " + Arrays.toString(trialPages)
+                    	    + ", next page " + pageId
+                    	    + ", activePages " + pageSet.getActivePages()
+                    	    + ", dataPage " + dataPage
+                    	    + " after many trials");
                 }
             }
         }

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -3988,7 +3988,6 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
                             + ", attempted pages " + Arrays.toString(trialPages)
                             + ", next page " + pageId
                             + ", activePages " + pageSet.getActivePages()
-                            + ", dataPage " + dataPage
                             + " after many trials");
                 }
             }


### PR DESCRIPTION
This is just a log improvement. When receiving DataStorageManagerException for "moved" record we don't have any trace of attempted pages without setting the whole TableManager to FINE log.
Added a trace of attempted page and the next page to attempt (but aborted due to too many attempts) at the resulting exception message

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
