### PR TITLE
Cleanup local channel memory, fixes #798

### DIFF
--- a/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/AbstractChannel.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -186,17 +187,17 @@ public abstract class AbstractChannel extends Channel {
         });
     }
 
-    private volatile boolean closed = false;
+    private AtomicBoolean closed = new AtomicBoolean(false);
 
     protected abstract String describeSocket();
     protected abstract void doClose();
 
     @Override
     public final void close() {
-        if (closed) {
+        if (!closed.compareAndSet(false,true)) {
+            // Already closed or in closing procedure
             return;
         }
-        closed = true;
         LOGGER.log(Level.FINE, "{0}: closing", this);
         String socketDescription = describeSocket();
         doClose();
@@ -205,7 +206,7 @@ public abstract class AbstractChannel extends Channel {
 
     @Override
     public final boolean isClosed() {
-        return closed;
+        return closed.get();
     }
     private void failPendingMessages(String socketDescription) {
 

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannel.java
@@ -39,11 +39,13 @@ import java.util.concurrent.ExecutorService;
 public class LocalVMChannel extends AbstractChannel implements Comparable<LocalVMChannel> {
 
     private final ServerSideLocalVMChannel serverSideChannel;
+    private final LocalVMChannelAcceptor parent;
 
-    LocalVMChannel(String name, ChannelEventListener clientSidePeer, ExecutorService executorService) {
+    LocalVMChannel(String name, ChannelEventListener clientSidePeer, ExecutorService executorService, LocalVMChannelAcceptor parent) {
         super(name, ADDRESS_JVM_LOCAL, executorService);
         setMessagesReceiver(clientSidePeer);
         serverSideChannel = new ServerSideLocalVMChannel(ADDRESS_JVM_LOCAL, ADDRESS_JVM_LOCAL, executorService);
+        this.parent = parent;
     }
 
     public Channel getServerSideChannel() {
@@ -75,6 +77,7 @@ public class LocalVMChannel extends AbstractChannel implements Comparable<LocalV
 
     @Override
     protected void doClose() {
+        parent.deregister(this);
         // emulate Netty on channel close
         channelClosed();
         serverSideChannel.close();

--- a/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
+++ b/herddb-net/src/main/java/herddb/network/netty/LocalVMChannelAcceptor.java
@@ -48,10 +48,19 @@ public class LocalVMChannelAcceptor {
     }
 
     public Channel connect(String name, ChannelEventListener clientSidePeer, ExecutorService executorService) {
-        LocalVMChannel channel = new LocalVMChannel(name, clientSidePeer, executorService);
+        LocalVMChannel channel = new LocalVMChannel(name, clientSidePeer, executorService, this);
         acceptor.createConnection(channel.getServerSideChannel());
         channels.add(channel);
         return channel;
+    }
+
+    void deregister(LocalVMChannel channel) {
+        channels.remove(channel);
+    }
+
+    // Visible for testing
+    Set<LocalVMChannel> channels() {
+        return channels;
     }
 
 }


### PR DESCRIPTION
Fixes #798.

Added LocalVMChannel deregistration method from LocalVMChannelAcceptor to avoid to keep stacking old channels without be able to reclaim their memory.

Added a test check to verify channels deregistration
Modified AbstractChannel close procedure to use an atomic boolean to ensure only once doClose invocation

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
