### PR TITLE
[security] Implement SASL username/password auth (prerequisite for JWT authentication)

### DIFF
--- a/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
+++ b/herddb-core/src/main/java/herddb/client/ClientConfiguration.java
@@ -67,6 +67,8 @@ public class ClientConfiguration {
 
     public static final String PROPERTY_MODE = "client.mode";
 
+    public static final String PROPERTY_AUTH_MECH = "client.auth.mech";
+
     public static final String PROPERTY_MODE_LOCAL = "local";
     public static final String PROPERTY_MODE_STANDALONE = "standalone";
     public static final String PROPERTY_MODE_CLUSTER = "cluster";

--- a/herddb-core/src/main/java/herddb/security/UserManager.java
+++ b/herddb-core/src/main/java/herddb/security/UserManager.java
@@ -24,21 +24,33 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Abstract over user management
+ * Abstract over user management.
  *
  * @author enrico.olivelli
  */
 public abstract class UserManager {
 
-    public abstract String getExpectedPassword(String username);
+    /**
+     * Return the expected password for a given user or null if the user doesn't exist.
+     * This method is needed only by the DIGEST-MD5 mechanism.
+     * @param username the username
+     * @return the password, or null if the user doesn't exist
+     */
+    public abstract String getExpectedPassword(String username) throws IOException;
 
+    /**
+     * Validate a username/password pair.
+     *
+     * @param username the username
+     * @param pwd the password
+     * @throws IOException in case of failure
+     */
     public void authenticate(String username, char[] pwd) throws IOException {
-        String password = new String(pwd);
+        String password = pwd != null ? new String(pwd) : null;
         String expectedPassword = getExpectedPassword(username);
-        if (expectedPassword == null
-                || password == null
+        if (expectedPassword == null // user does not exist
                 || !Objects.equals(password, expectedPassword)) {
-            throw new IOException("Password doesn't match for user " + username);
+            throw new IOException("Password doesn't match for user " + username + " (or user doesn't exist)");
         }
     }
 }

--- a/herddb-core/src/main/java/herddb/security/UserManager.java
+++ b/herddb-core/src/main/java/herddb/security/UserManager.java
@@ -20,6 +20,9 @@
 
 package herddb.security;
 
+import java.io.IOException;
+import java.util.Objects;
+
 /**
  * Abstract over user management
  *
@@ -28,4 +31,14 @@ package herddb.security;
 public abstract class UserManager {
 
     public abstract String getExpectedPassword(String username);
+
+    public void authenticate(String username, char[] pwd) throws IOException {
+        String password = new String(pwd);
+        String expectedPassword = getExpectedPassword(username);
+        if (expectedPassword == null
+                || password == null
+                || !Objects.equals(password, expectedPassword)) {
+            throw new IOException("Password doesn't match for user " + username);
+        }
+    }
 }

--- a/herddb-core/src/main/java/herddb/security/sasl/DigestLoginModule.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/DigestLoginModule.java
@@ -1,0 +1,41 @@
+package herddb.security.sasl;
+
+import java.util.Map;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.spi.LoginModule;
+
+public class DigestLoginModule  implements LoginModule {
+    private Subject subject;
+
+    public DigestLoginModule() {
+    }
+
+    public boolean abort() {
+        return false;
+    }
+
+    public boolean commit() {
+        return true;
+    }
+
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        if (options.containsKey("username")) {
+            this.subject = subject;
+            String username = (String) options.get("username");
+            this.subject.getPublicCredentials().add(username);
+            String password = (String) options.get("password");
+            this.subject.getPrivateCredentials().add(password);
+        }
+
+    }
+
+    public boolean logout() {
+        return true;
+    }
+
+    public boolean login() {
+        return true;
+    }
+}
+

--- a/herddb-core/src/main/java/herddb/security/sasl/DigestLoginModule.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/DigestLoginModule.java
@@ -1,3 +1,22 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
 package herddb.security.sasl;
 
 import java.util.Map;

--- a/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
@@ -21,6 +21,7 @@ package herddb.security.sasl;
 
 import herddb.client.ClientConfiguration;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.Provider;
 import java.util.Arrays;
 import java.util.Map;
@@ -72,7 +73,6 @@ public class PlainSaslServerProvider extends Provider {
 
 
         private boolean complete;
-        private String errorMessage = null;
         private final CallbackHandler callbackHandler;
 
         private String username;
@@ -98,9 +98,8 @@ public class PlainSaslServerProvider extends Provider {
                 throw new AuthenticationException("Invalid auth");
             }
             this.username = new String(response, 1, endusername - 1);
-            String password = new String(response, endusername + 1, response.length - endusername - 1);
-
-            errorMessage = null;
+            String password = new String(response, endusername + 1, response.length - endusername - 1,
+                    StandardCharsets.UTF_8);
 
             NameCallback nameCallback = new NameCallback("username", ClientConfiguration.PROPERTY_CLIENT_USERNAME_DEFAULT);
             nameCallback.setName(username);

--- a/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
@@ -97,7 +97,8 @@ public class PlainSaslServerProvider extends Provider {
             if (endusername < 0) {
                 throw new AuthenticationException("Invalid auth");
             }
-            this.username = new String(response, 1, endusername - 1);
+            this.username = new String(response, 1, endusername - 1,
+                    StandardCharsets.UTF_8);
             String password = new String(response, endusername + 1, response.length - endusername - 1,
                     StandardCharsets.UTF_8);
 

--- a/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
@@ -1,0 +1,157 @@
+package herddb.security.sasl;
+
+import herddb.client.ClientConfiguration;
+import java.io.IOException;
+import java.security.Provider;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthenticationException;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+public class PlainSaslServerProvider extends Provider {
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = Logger
+            .getLogger(PlainSaslServerProvider.class.getName());
+
+    protected PlainSaslServerProvider() {
+        super("SASL/PLAIN Server Provider", 1.0, "SASL/PLAIN Server Provider for HerdDB");
+        put("SaslServerFactory." + SaslUtils.AUTH_PLAIN,
+                PlainSaslServerFactory.class.getName());
+    }
+
+
+    public static class PlainSaslServerFactory implements SaslServerFactory {
+        @Override
+        public SaslServer createSaslServer(String mechanism, String protocol, String serverName, Map<String, ?> props,
+                                           CallbackHandler callbackHandler) {
+            String[] mechanismNamesCompatibleWithPolicy = getMechanismNames(props);
+            for (int i = 0; i < mechanismNamesCompatibleWithPolicy.length; i++) {
+                if (mechanismNamesCompatibleWithPolicy[i].equals(mechanism)) {
+                    return new PlainSaslServer(callbackHandler);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String[] getMechanismNames(Map<String, ?> props) {
+            return new String[]{SaslUtils.AUTH_PLAIN};
+        }
+    }
+
+    public static class PlainSaslServer implements SaslServer {
+
+
+        private boolean complete;
+        private String errorMessage = null;
+        private final CallbackHandler callbackHandler;
+
+        private String username;
+
+        public PlainSaslServer(CallbackHandler callbackHandler) {
+            this.callbackHandler = callbackHandler;
+        }
+
+        @Override
+        public byte[] evaluateResponse(byte[] response) throws SaslException {
+            LOG.info("evaluaterResponse " + new String(response));
+
+            if (response.length == 0 || response[0] != 0) {
+                throw new AuthenticationException("Invalid auth");
+            }
+            int endusername = -1;
+            for (int i = 1; i < response.length; i++) {
+                if (response[i] == 0) {
+                    endusername = i;
+                    break;
+                }
+            }
+            if (endusername < 0) {
+                throw new AuthenticationException("Invalid auth");
+            }
+            this.username = new String(response, 1, endusername - 1);
+            LOG.info("Username " + username);
+            String password = new String(response, endusername + 1, response.length - endusername - 1);
+            LOG.info("password " + password);
+
+            errorMessage = null;
+
+            NameCallback nameCallback = new NameCallback("username", ClientConfiguration.PROPERTY_CLIENT_USERNAME_DEFAULT);
+            nameCallback.setName(username);
+            PasswordCallback passwordCallback = new PasswordCallback("password", false);
+            passwordCallback.setPassword(password.toCharArray());
+            Callback[] callbacks = new Callback[] { nameCallback, passwordCallback };
+
+
+            try {
+                callbackHandler.handle(callbacks);
+            } catch (IOException | UnsupportedCallbackException error) {
+                LOG.log(Level.SEVERE, "Error", error);
+                throw new AuthenticationException("Error while performing SASL PLAIN authentication " + error, error);
+            }
+
+            complete = true;
+
+            return new byte[0];
+        }
+
+        @Override
+        public String getAuthorizationID() {
+            if (!complete) {
+                throw new IllegalStateException("Authentication exchange has not completed");
+            }
+            return username;
+        }
+
+        @Override
+        public String getMechanismName() {
+            return SaslUtils.AUTH_PLAIN;
+        }
+
+        @Override
+        public Object getNegotiatedProperty(String propName) {
+            if (!complete) {
+                throw new IllegalStateException("Authentication exchange has not completed");
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isComplete() {
+            return complete;
+        }
+
+        @Override
+        public byte[] unwrap(byte[] incoming, int offset, int len) {
+            if (!complete) {
+                throw new IllegalStateException("Authentication exchange has not completed");
+            }
+            return Arrays.copyOfRange(incoming, offset, offset + len);
+        }
+
+        @Override
+        public byte[] wrap(byte[] outgoing, int offset, int len) {
+            if (!complete) {
+                throw new IllegalStateException("Authentication exchange has not completed");
+            }
+            return Arrays.copyOfRange(outgoing, offset, offset + len);
+        }
+
+        @Override
+        public void dispose() {
+            complete = false;
+        }
+
+    }
+
+}

--- a/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
@@ -64,8 +64,7 @@ public class PlainSaslServerProvider extends Provider {
 
         @Override
         public byte[] evaluateResponse(byte[] response) throws SaslException {
-            LOG.info("evaluaterResponse " + new String(response));
-
+            // see https://www.rfc-editor.org/rfc/rfc4616.html
             if (response.length == 0 || response[0] != 0) {
                 throw new AuthenticationException("Invalid auth");
             }
@@ -80,9 +79,7 @@ public class PlainSaslServerProvider extends Provider {
                 throw new AuthenticationException("Invalid auth");
             }
             this.username = new String(response, 1, endusername - 1);
-            LOG.info("Username " + username);
             String password = new String(response, endusername + 1, response.length - endusername - 1);
-            LOG.info("password " + password);
 
             errorMessage = null;
 

--- a/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
@@ -1,3 +1,22 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
 package herddb.security.sasl;
 
 import herddb.client.ClientConfiguration;

--- a/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/PlainSaslServerProvider.java
@@ -166,6 +166,7 @@ public class PlainSaslServerProvider extends Provider {
         @Override
         public void dispose() {
             complete = false;
+            username = null;
         }
 
     }

--- a/herddb-core/src/main/java/herddb/security/sasl/SaslNettyServer.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/SaslNettyServer.java
@@ -80,9 +80,9 @@ public class SaslNettyServer {
 
     private CallbackHandler buildCallbackHandler(String mech) throws IOException {
         switch (mech + "") {
-            case "MD5-DIGEST":
+            case SaslUtils.AUTH_DIGEST_MD5:
                 return new SaslDigestCallbackHandler();
-            case "PLAIN":
+            case SaslUtils.AUTH_PLAIN:
                 return new SaslPlainCallbackHandler();
             default:
                 throw new IOException("Unsupported mechanism " + mech);

--- a/herddb-core/src/main/java/herddb/security/sasl/SaslUtils.java
+++ b/herddb-core/src/main/java/herddb/security/sasl/SaslUtils.java
@@ -33,11 +33,15 @@ import javax.security.sasl.Sasl;
 public class SaslUtils {
 
     public static final String AUTH_DIGEST_MD5 = "DIGEST-MD5";
+
+    public static final String AUTH_PLAIN = "PLAIN";
+
+
     public static final String DEFAULT_REALM = "default";
 
-    static Map<String, String> getSaslProps() {
+    static Map<String, String> getSaslProps(boolean allowPlain) {
         Map<String, String> props = new HashMap<String, String>();
-        props.put(Sasl.POLICY_NOPLAINTEXT, "true");
+        props.put(Sasl.POLICY_NOPLAINTEXT, !allowPlain + "");
         return props;
     }
 

--- a/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
+++ b/herddb-core/src/main/java/herddb/server/ServerSideConnectionPeer.java
@@ -1108,6 +1108,12 @@ public class ServerSideConnectionPeer implements ServerSideConnection, ChannelEv
                 saslNettyServer = new SaslNettyServer(server, mech);
             }
             byte[] responseToken = saslNettyServer.response(token);
+            if (saslNettyServer.isComplete()) {
+                username = saslNettyServer.getUserName();
+                authenticated = true;
+                LOGGER.log(Level.INFO, "client {0} connected as {1}", new Object[]{this.channel.getRemoteAddress(), username});
+                saslNettyServer = null;
+            }
             ByteBuf tokenChallenge = PduCodec.SaslTokenServerResponse.write(message.messageId, responseToken);
             channel.sendReplyMessage(message.messageId, tokenChallenge);
         } catch (Exception err) {

--- a/herddb-core/src/test/java/herddb/server/security/JAASKerberosTest.java
+++ b/herddb-core/src/test/java/herddb/server/security/JAASKerberosTest.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import javax.security.auth.login.Configuration;
 import org.apache.hadoop.minikdc.MiniKdc;
 import org.junit.After;
 import org.junit.Assert;
@@ -162,6 +163,7 @@ public class JAASKerberosTest {
             }
         } finally {
             System.clearProperty("java.security.auth.login.config");
+            Configuration.getConfiguration().refresh();
         }
     }
 }

--- a/herddb-core/src/test/resources/test_jaas_md5.conf
+++ b/herddb-core/src/test/resources/test_jaas_md5.conf
@@ -19,12 +19,12 @@
 */
 
 HerdDBServer {
-       org.apache.zookeeper.server.auth.DigestLoginModule required
+       herddb.security.sasl.DigestLoginModule required
        user_hd="testpwd";
 };
 
 HerdDBClient {
-       org.apache.zookeeper.server.auth.DigestLoginModule required
+       herddb.security.sasl.DigestLoginModule required
        username="hd"
        password="testpwd";
 };


### PR DESCRIPTION
### Motivation

* In order to implement JWT token authentication we need a auth mechanism that allows you to pass a plain token
* The idea will be eventually to carry the JWT token in the "password" field (like we do it in https://github.com/datastax/startlight-for-kafka)

### Modification
* implemented the PLAIN auth mechanism on both the client and the server
* add test cases
* implement a DigestModule in order to not require people use ZooKeeper implementation

### Note

Please note that MD5-DIGEST is recently considered not secure, adding a username/password mechanism doesn't add a security issue. 

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
