### PR TITLE
Implement the Vector of Floats data type and basic vector search scalar functions

### DIFF
--- a/herddb-core/src/main/java/herddb/model/ColumnTypes.java
+++ b/herddb-core/src/main/java/herddb/model/ColumnTypes.java
@@ -37,6 +37,7 @@ public class ColumnTypes {
     public static final int NULL = 5;
     public static final int DOUBLE = 6;
     public static final int BOOLEAN = 7;
+    public static final int FLOATARRAY = 8;
     public static final int ANYTYPE = 10;
 
     public static final int NOTNULL_STRING = 11;
@@ -46,6 +47,8 @@ public class ColumnTypes {
     public static final int NOTNULL_TIMESTAMP = 15;
     public static final int NOTNULL_DOUBLE = 16;
     public static final int NOTNULL_BOOLEAN = 17;
+
+    public static final int NOTNULL_FLOATARRAY = 18;
 
 
     public static String typeToString(int type) {
@@ -58,6 +61,8 @@ public class ColumnTypes {
                 return "integer";
             case BYTEARRAY:
                 return "bytearray";
+            case FLOATARRAY:
+                return "floatarray";
             case TIMESTAMP:
                 return "timestamp";
             case NULL:
@@ -122,6 +127,9 @@ public class ColumnTypes {
             case BYTEARRAY:
             case NOTNULL_BYTEARRAY:
                 return NOTNULL_BYTEARRAY;
+            case FLOATARRAY:
+            case NOTNULL_FLOATARRAY:
+                return NOTNULL_FLOATARRAY;
             case TIMESTAMP:
             case NOTNULL_TIMESTAMP:
                 return NOTNULL_TIMESTAMP;
@@ -161,6 +169,9 @@ public class ColumnTypes {
             case BYTEARRAY:
             case NOTNULL_BYTEARRAY:
                 return "bytearray";
+            case FLOATARRAY:
+            case NOTNULL_FLOATARRAY:
+                return "floatarray";
             case TIMESTAMP:
             case NOTNULL_TIMESTAMP:
                 return "timestamp";

--- a/herddb-core/src/main/java/herddb/model/Tuple.java
+++ b/herddb-core/src/main/java/herddb/model/Tuple.java
@@ -185,6 +185,8 @@ public final class Tuple extends AbstractDataAccessor {
                         columnType = ColumnTypes.BOOLEAN;
                     } else if (value instanceof byte[]) {
                         columnType = ColumnTypes.BYTEARRAY;
+                    } else if (value instanceof float[]) {
+                        columnType = ColumnTypes.FLOATARRAY;
                     } else {
                         throw new IOException("unsupported class " + value.getClass());
                     }

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -458,9 +458,9 @@ public class CalcitePlanner extends AbstractSQLPlanner {
             props.put(CalciteConnectionProperty.DEFAULT_NULL_COLLATION.camelName(), NullCollation.LAST.toString());
             final CalciteConnectionConfigImpl calciteRuntimeContextConfig = new CalciteConnectionConfigImpl(props);
 
-            subSchema.add("COSINE_SIMILARITY", new CosineSimilarityFunction());
-            subSchema.add("DOT_PRODUCT", new DotProductSimilarityFunction());
-            subSchema.add("EUCLIDEAN_DISTANCE", new EuclideanSimilarityFunction());
+            subSchema.add("COSINE_SIMILARITY", CosineSimilarityFunction.INSTANCE);
+            subSchema.add("DOT_PRODUCT", DotProductSimilarityFunction.INSTANCE);
+            subSchema.add("EUCLIDEAN_DISTANCE", EuclideanSimilarityFunction.INSTANCE);
 
             final FrameworkConfig config = Frameworks.newConfigBuilder()
                     .parserConfig(SQL_PARSER_CONFIG)
@@ -1401,7 +1401,10 @@ public class CalcitePlanner extends AbstractSQLPlanner {
 
     }
 
-    public static class CosineSimilarityFunction implements Function, ScalarFunction {
+    private static class CosineSimilarityFunction implements Function, ScalarFunction {
+
+        static final CosineSimilarityFunction INSTANCE = new  CosineSimilarityFunction();
+
         @Override
         public List<FunctionParameter> getParameters() {
             return Arrays.asList(
@@ -1416,9 +1419,10 @@ public class CalcitePlanner extends AbstractSQLPlanner {
 
     }
 
+    private static class EuclideanSimilarityFunction implements Function, ScalarFunction {
 
+        static final EuclideanSimilarityFunction INSTANCE = new  EuclideanSimilarityFunction();
 
-    public static class EuclideanSimilarityFunction implements Function, ScalarFunction {
         @Override
         public List<FunctionParameter> getParameters() {
             return Arrays.asList(
@@ -1433,7 +1437,10 @@ public class CalcitePlanner extends AbstractSQLPlanner {
 
     }
 
-    public static class DotProductSimilarityFunction implements Function, ScalarFunction {
+    private static class DotProductSimilarityFunction implements Function, ScalarFunction {
+
+        static final DotProductSimilarityFunction INSTANCE = new  DotProductSimilarityFunction();
+
         @Override
         public List<FunctionParameter> getParameters() {
             return Arrays.asList(

--- a/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/CalcitePlanner.java
@@ -75,6 +75,7 @@ import herddb.sql.expressions.TypedJdbcParameterExpression;
 import herddb.utils.SQLUtils;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -140,8 +141,11 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.schema.Function;
+import org.apache.calcite.schema.FunctionParameter;
 import org.apache.calcite.schema.ModifiableTable;
 import org.apache.calcite.schema.ProjectableFilterableTable;
+import org.apache.calcite.schema.ScalarFunction;
 import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.Statistic;
@@ -453,6 +457,10 @@ public class CalcitePlanner extends AbstractSQLPlanner {
             props.put(CalciteConnectionProperty.LOCALE.camelName(), Locale.ROOT.toString());
             props.put(CalciteConnectionProperty.DEFAULT_NULL_COLLATION.camelName(), NullCollation.LAST.toString());
             final CalciteConnectionConfigImpl calciteRuntimeContextConfig = new CalciteConnectionConfigImpl(props);
+
+            subSchema.add("COSINE_SIMILARITY", new CosineSimilarityFunction());
+            subSchema.add("DOT_PRODUCT", new DotProductSimilarityFunction());
+            subSchema.add("EUCLIDEAN_DISTANCE", new EuclideanSimilarityFunction());
 
             final FrameworkConfig config = Frameworks.newConfigBuilder()
                     .parserConfig(SQL_PARSER_CONFIG)
@@ -1176,6 +1184,12 @@ public class CalcitePlanner extends AbstractSQLPlanner {
                 return ColumnTypes.LONG;
             case VARBINARY:
                 return ColumnTypes.BYTEARRAY;
+            case ARRAY:
+                if (type.getComponentType().getSqlTypeName() == SqlTypeName.FLOAT) {
+                    return ColumnTypes.FLOATARRAY;
+                } else {
+                    throw new StatementExecutionException("Only arrays of floats are supported");
+                }
             case NULL:
                 return ColumnTypes.NULL;
             case TIMESTAMP:
@@ -1183,6 +1197,7 @@ public class CalcitePlanner extends AbstractSQLPlanner {
                 return ColumnTypes.TIMESTAMP;
             case DECIMAL:
             case DOUBLE:
+            case FLOAT:
                 return ColumnTypes.DOUBLE;
             case ANY:
             case SYMBOL:
@@ -1370,6 +1385,9 @@ public class CalcitePlanner extends AbstractSQLPlanner {
                     return typeFactory.createSqlType(SqlTypeName.VARCHAR);
                 case ColumnTypes.BYTEARRAY:
                     return typeFactory.createSqlType(SqlTypeName.VARBINARY);
+                case ColumnTypes.FLOATARRAY:
+                    return typeFactory
+                            .createArrayType(typeFactory.createSqlType(SqlTypeName.FLOAT), -1);
                 case ColumnTypes.LONG:
                 case ColumnTypes.NOTNULL_LONG:
                     return typeFactory.createSqlType(SqlTypeName.BIGINT);
@@ -1383,4 +1401,83 @@ public class CalcitePlanner extends AbstractSQLPlanner {
 
     }
 
+    public static class CosineSimilarityFunction implements Function, ScalarFunction {
+        @Override
+        public List<FunctionParameter> getParameters() {
+            return Arrays.asList(
+                    new CalcitePlanner.SimpleArrayParameter(0, "op1", SqlTypeName.FLOAT),
+                    new CalcitePlanner.SimpleArrayParameter(1, "op2", SqlTypeName.FLOAT));
+        }
+
+        @Override
+        public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
+            return typeFactory.createSqlType(SqlTypeName.FLOAT);
+        }
+
+    }
+
+
+
+    public static class EuclideanSimilarityFunction implements Function, ScalarFunction {
+        @Override
+        public List<FunctionParameter> getParameters() {
+            return Arrays.asList(
+                    new CalcitePlanner.SimpleArrayParameter(0, "op1", SqlTypeName.FLOAT),
+                    new CalcitePlanner.SimpleArrayParameter(1, "op2", SqlTypeName.FLOAT));
+        }
+
+        @Override
+        public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
+            return typeFactory.createSqlType(SqlTypeName.FLOAT);
+        }
+
+    }
+
+    public static class DotProductSimilarityFunction implements Function, ScalarFunction {
+        @Override
+        public List<FunctionParameter> getParameters() {
+            return Arrays.asList(
+                    new CalcitePlanner.SimpleArrayParameter(0, "op1", SqlTypeName.FLOAT),
+                    new CalcitePlanner.SimpleArrayParameter(1, "op2", SqlTypeName.FLOAT));
+        }
+
+        @Override
+        public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
+            return typeFactory.createSqlType(SqlTypeName.FLOAT);
+        }
+
+    }
+
+    private static class SimpleArrayParameter implements FunctionParameter {
+        int ordinal;
+        String name;
+        SqlTypeName type;
+
+        public SimpleArrayParameter(int ordinal, String name, SqlTypeName type) {
+            this.ordinal = ordinal;
+            this.name = name;
+            this.type = type;
+        }
+
+        @Override
+        public int getOrdinal() {
+            return ordinal;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public RelDataType getType(RelDataTypeFactory typeFactory) {
+            return typeFactory.createTypeWithNullability(
+                    typeFactory.createArrayType(typeFactory.createSqlType(type), -1), true);
+        }
+
+        @Override
+        public boolean isOptional() {
+            return false;
+        }
+    }
 }

--- a/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
+++ b/herddb-core/src/main/java/herddb/sql/JSQLParserPlanner.java
@@ -780,6 +780,9 @@ public class JSQLParserPlanner extends AbstractSQLPlanner {
             case "image":
                 type = ColumnTypes.BYTEARRAY;
                 break;
+            case "floata":
+                type = ColumnTypes.FLOATARRAY;
+                break;
             case "timestamp":
             case "timestamptz":
             case "timestamp with time zone":

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLExpressionCompiler.java
@@ -153,6 +153,12 @@ public class SQLExpressionCompiler {
                     return new CompiledFunction(BuiltinFunctions.UPPER, Arrays.asList(operands));
                 case BuiltinFunctions.NAME_ABS:
                     return new CompiledFunction(BuiltinFunctions.ABS, Arrays.asList(operands));
+                case BuiltinFunctions.NAME_COSINE_SIMILARITY:
+                    return new CompiledFunction(BuiltinFunctions.COSINE_SIMILARITY, Arrays.asList(operands));
+                case BuiltinFunctions.NAME_DOT_PRODUCT:
+                    return new CompiledFunction(BuiltinFunctions.DOT_PRODUCT, Arrays.asList(operands));
+                case BuiltinFunctions.NAME_EUCLIDEAN_DISTANCE:
+                    return new CompiledFunction(BuiltinFunctions.EUCLIDEAN_DISTANCE, Arrays.asList(operands));
                 case BuiltinFunctions.NAME_ROUND:
                     return new CompiledFunction(BuiltinFunctions.ROUND, Arrays.asList(operands));
                 case BuiltinFunctions.NAME_EXTRACT:

--- a/herddb-core/src/main/java/herddb/sql/expressions/SQLParserExpressionCompiler.java
+++ b/herddb-core/src/main/java/herddb/sql/expressions/SQLParserExpressionCompiler.java
@@ -172,6 +172,8 @@ public class SQLParserExpressionCompiler {
                     return new CompiledFunction(BuiltinFunctions.UPPER, operands);
                 case BuiltinFunctions.NAME_ABS:
                     return new CompiledFunction(BuiltinFunctions.ABS, operands);
+                case BuiltinFunctions.NAME_COSINE_SIMILARITY:
+                    return new CompiledFunction(BuiltinFunctions.COSINE_SIMILARITY, operands);
                 case BuiltinFunctions.NAME_AVG:
                     return new CompiledFunction(BuiltinFunctions.AVG, operands);
                 case BuiltinFunctions.NAME_ROUND:

--- a/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
+++ b/herddb-core/src/main/java/herddb/sql/functions/BuiltinFunctions.java
@@ -52,6 +52,11 @@ public class BuiltinFunctions {
     public static final String LOWER = "lower";
     public static final String UPPER = "upper";
     public static final String ABS = "abs";
+
+    public static final String COSINE_SIMILARITY = "cosine_similarity";
+    public static final String DOT_PRODUCT = "dot_product";
+    public static final String EUCLIDEAN_DISTANCE = "euclidean_distance";
+
     public static final String ROUND = "round";
     public static final String EXTRACT = "extract";
     public static final String FLOOR = "floor";
@@ -73,6 +78,10 @@ public class BuiltinFunctions {
     public static final String NAME_LOWERCASE = "LOWER";
     public static final String NAME_UPPER = "UPPER";
     public static final String NAME_ABS = "ABS";
+    public static final String NAME_COSINE_SIMILARITY = "COSINE_SIMILARITY";
+    public static final String NAME_DOT_PRODUCT = "DOT_PRODUCT";
+    public static final String NAME_EUCLIDEAN_DISTANCE = "EUCLIDEAN_DISTANCE";
+
     public static final String NAME_ROUND = "ROUND";
     public static final String NAME_EXTRACT = "EXTRACT";
     public static final String NAME_FLOOR = "FLOOR";

--- a/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
@@ -23,7 +23,9 @@ package herddb.sql;
 import static herddb.core.TestUtils.execute;
 import static herddb.core.TestUtils.executeUpdate;
 import static herddb.core.TestUtils.scan;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import herddb.core.DBManager;
 import herddb.mem.MemoryCommitLogManager;
 import herddb.mem.MemoryDataStorageManager;
@@ -32,6 +34,7 @@ import herddb.model.DataScanner;
 import herddb.model.StatementEvaluationContext;
 import herddb.model.TransactionContext;
 import herddb.model.commands.CreateTableSpaceStatement;
+import herddb.sql.expressions.CompiledFunction;
 import herddb.utils.DataAccessor;
 import herddb.utils.RawString;
 import java.util.Arrays;
@@ -233,6 +236,32 @@ public class SimplerPlannerTest {
                 assertEquals(1L, results.get(1).get(1));
                 assertEquals(1235, results.get(1).get(0));
             }
+            try (DataScanner scan = scan(manager, "SELECT n1, count(*) as cc "
+                            + " FROM tblspace1.tsql"
+                            + " GROUP by n1"
+                            + " ORDER BY abs(n1)",
+                    Collections.emptyList())) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals(2, results.size());
+                assertEquals(2, results.get(0).getFieldNames().length);
+                assertEquals(1L, results.get(0).get(1));
+                assertEquals(1234, results.get(0).get(0));
+                assertEquals(1L, results.get(1).get(1));
+                assertEquals(1235, results.get(1).get(0));
+            }
+            try (DataScanner scan = scan(manager, "SELECT n1, count(*) as cc "
+                            + " FROM tblspace1.tsql"
+                            + " GROUP by n1"
+                            + " ORDER BY cosine_similarity(n1, n1)",
+                    Collections.emptyList())) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals(2, results.size());
+                assertEquals(2, results.get(0).getFieldNames().length);
+                assertEquals(1L, results.get(0).get(1));
+                assertEquals(1234, results.get(0).get(0));
+                assertEquals(1L, results.get(1).get(1));
+                assertEquals(1235, results.get(1).get(0));
+            }
             if (manager.getPlanner() instanceof CalcitePlanner) {
                 try (DataScanner scan = scan(manager, "SELECT sum(n1), count(*) as cc, k1 "
                                 + " FROM tblspace1.tsql"
@@ -342,6 +371,88 @@ public class SimplerPlannerTest {
             try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql where n1=1114", Collections.emptyList())) {
                 List<DataAccessor> results = scan.consume();
                 assertEquals(1, results.size());
+            }
+        }
+    }
+
+    @Test
+    public void basicVectorTest() throws Exception {
+        String nodeId = "localhost";
+        try (DBManager manager = new DBManager("localhost", new MemoryMetadataStorageManager(), new MemoryDataStorageManager(), new MemoryCommitLogManager(), null, null)) {
+            manager.start();
+            CreateTableSpaceStatement st1 = new CreateTableSpaceStatement("tblspace1", Collections.singleton(nodeId), nodeId, 1, 0, 0);
+            manager.executeStatement(st1, StatementEvaluationContext.DEFAULT_EVALUATION_CONTEXT(), TransactionContext.NO_TRANSACTION);
+            manager.waitForTablespace("tblspace1", 10000);
+
+            execute(manager, "CREATE TABLE tblspace1.tsql (k1 string primary key,n1 int,s1 string, v1 floata)", Collections.emptyList());
+
+            List<Float> vector1AsList = Arrays.asList(0.2f, 0.8f);
+            float[] vector3raw = new float[]{0f, 1f};
+            float[] vector2raw = new float[]{0.1f, 0.9f};
+            float[] vector1raw = new float[]{0.2f, 0.8f};
+
+            float v3v3 = CompiledFunction.cosineSimilarity(vector3raw, vector3raw);
+            float v3v2 = CompiledFunction.cosineSimilarity(vector3raw, vector2raw);
+            float v3v1 = CompiledFunction.cosineSimilarity(vector3raw, vector1raw);
+            System.out.println("v3v3:" + v3v3);
+            System.out.println("v3v2:" + v3v2);
+            System.out.println("v3v1:" + v3v1);
+            assertTrue(v3v2 < v3v3);
+            assertTrue(v3v1 < v3v3);
+            assertTrue(v3v1 < v3v2);
+
+            assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,v1) values(?,?,?)", Arrays.asList("mykey", Integer.valueOf(1234),
+                    vector1AsList)).getUpdateCount());
+            assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,v1) values(?,?,?)", Arrays.asList("mykey2", Integer.valueOf(1235),
+                    vector2raw)).getUpdateCount());
+            assertEquals(1, executeUpdate(manager, "INSERT INTO tblspace1.tsql(k1,n1,v1) values(?,?,?)", Arrays.asList("mykey3", Integer.valueOf(1236),
+                    vector3raw)).getUpdateCount());
+
+            try (DataScanner scan = scan(manager, "SELECT * FROM tblspace1.tsql where n1=1234", Collections.emptyList())) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals(1, results.size());
+                assertEquals(4, results.get(0).getFieldNames().length);
+                assertEquals(RawString.of("mykey"), results.get(0).get(0));
+                assertEquals(RawString.of("mykey"), results.get(0).get("k1"));
+                assertEquals(1234, results.get(0).get(1));
+                assertEquals(1234, results.get(0).get("n1"));
+                assertEquals(null, results.get(0).get(2));
+                assertEquals(null, results.get(0).get("s1"));
+                assertArrayEquals(vector1raw, (float[]) results.get(0).get(3), 0);
+                assertArrayEquals(vector1raw, (float[]) results.get(0).get("v1"), 0);
+            }
+
+            try (DataScanner scan = scan(manager, "SELECT n1, cosine_similarity(v1, cast(? as FLOAT ARRAY)) as distance, v1 "
+                            + " FROM tblspace1.tsql"
+                            + " ORDER BY cosine_similarity(v1, cast(? as FLOAT ARRAY)) DESC",
+                    Arrays.asList(vector3raw, vector3raw))) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals(3, results.size());
+                assertEquals(1236, results.get(0).get(0));
+                assertEquals(1235, results.get(1).get(0));
+                assertEquals(1234, results.get(2).get(0));
+            }
+
+            try (DataScanner scan = scan(manager, "SELECT n1, dot_product(v1, cast(? as FLOAT ARRAY)) as distance, v1 "
+                            + " FROM tblspace1.tsql"
+                            + " ORDER BY dot_product(v1, cast(? as FLOAT ARRAY)) DESC",
+                    Arrays.asList(vector3raw, vector3raw))) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals(3, results.size());
+                assertEquals(1236, results.get(0).get(0));
+                assertEquals(1235, results.get(1).get(0));
+                assertEquals(1234, results.get(2).get(0));
+            }
+
+            try (DataScanner scan = scan(manager, "SELECT n1, euclidean_distance(v1, cast(? as FLOAT ARRAY)) as distance, v1 "
+                            + " FROM tblspace1.tsql"
+                            + " ORDER BY euclidean_distance(v1, cast(? as FLOAT ARRAY))",
+                    Arrays.asList(vector3raw, vector3raw))) {
+                List<DataAccessor> results = scan.consume();
+                assertEquals(3, results.size());
+                assertEquals(1236, results.get(0).get(0));
+                assertEquals(1235, results.get(1).get(0));
+                assertEquals(1234, results.get(2).get(0));
             }
         }
     }

--- a/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
+++ b/herddb-core/src/test/java/herddb/sql/SimplerPlannerTest.java
@@ -249,19 +249,6 @@ public class SimplerPlannerTest {
                 assertEquals(1L, results.get(1).get(1));
                 assertEquals(1235, results.get(1).get(0));
             }
-            try (DataScanner scan = scan(manager, "SELECT n1, count(*) as cc "
-                            + " FROM tblspace1.tsql"
-                            + " GROUP by n1"
-                            + " ORDER BY cosine_similarity(n1, n1)",
-                    Collections.emptyList())) {
-                List<DataAccessor> results = scan.consume();
-                assertEquals(2, results.size());
-                assertEquals(2, results.get(0).getFieldNames().length);
-                assertEquals(1L, results.get(0).get(1));
-                assertEquals(1234, results.get(0).get(0));
-                assertEquals(1L, results.get(1).get(1));
-                assertEquals(1235, results.get(1).get(0));
-            }
             if (manager.getPlanner() instanceof CalcitePlanner) {
                 try (DataScanner scan = scan(manager, "SELECT sum(n1), count(*) as cc, k1 "
                                 + " FROM tblspace1.tsql"

--- a/herddb-jdbc/src/test/java/herddb/jdbc/VectorSearchWithJDBCTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/VectorSearchWithJDBCTest.java
@@ -42,10 +42,11 @@ import org.junit.rules.TemporaryFolder;
 public class VectorSearchWithJDBCTest {
 
     static final String CREATE_TABLE = "CREATE TABLE DOCUMENTS (\n"
-            + "  FILENAME string PRIMARY KEY,\n"
+            + "  FILENAME string,\n"
             + "  CHUNKID int,  \n"
             + "  TEXT string,  \n"
-            + "  EMBEDDINGSVECTOR floata\n"
+            + "  EMBEDDINGSVECTOR floata, \n"
+            + "  PRIMARY KEY(FILENAME, CHUNKID) \n"
             + ")";
 
     @Rule

--- a/herddb-jdbc/src/test/java/herddb/jdbc/VectorSearchWithJDBCTest.java
+++ b/herddb-jdbc/src/test/java/herddb/jdbc/VectorSearchWithJDBCTest.java
@@ -1,0 +1,105 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+
+package herddb.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import herddb.client.ClientConfiguration;
+import herddb.client.HDBClient;
+import herddb.server.Server;
+import herddb.server.StaticClientSideMetadataProvider;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author enrico.olivelli
+ */
+public class VectorSearchWithJDBCTest {
+
+    static final String CREATE_TABLE = "CREATE TABLE DOCUMENTS (\n"
+            + "  FILENAME string PRIMARY KEY,\n"
+            + "  CHUNKID int,  \n"
+            + "  TEXT string,  \n"
+            + "  EMBEDDINGSVECTOR floata\n"
+            + ")";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testSimpleVectorSearch() throws Exception {
+        try (Server server = new Server(TestUtils.newServerConfigurationWithAutoPort(folder.newFolder().toPath()))) {
+            server.start();
+            server.waitForStandaloneBoot();
+            try (HDBClient client = new HDBClient(new ClientConfiguration(folder.newFolder().toPath()))) {
+                client.setClientSideMetadataProvider(new StaticClientSideMetadataProvider(server));
+                try (BasicHerdDBDataSource dataSource = new BasicHerdDBDataSource(client);
+                        Connection con = dataSource.getConnection();
+                        Statement create = con.createStatement();
+                        PreparedStatement statement_insert = con.prepareStatement("INSERT INTO DOCUMENTS(filename,chunkid,text,embeddingsvector) values(?,?,?,?)");
+                        PreparedStatement vector_search = con.prepareStatement("SELECT text FROM DOCUMENTS ORDER BY cosine_similarity(embeddingsvector,cast(? as FLOAT ARRAY)) DESC LIMIT 10")) {
+                    create.execute(CREATE_TABLE);
+
+
+                    float[] embeddingsVector = new float[] {1, 2, 3, 4, 5};
+                    statement_insert.setString(1, "document.pdf");
+                    statement_insert.setInt(2, 1);
+                    statement_insert.setString(3, "Lorem ipsum");
+                    statement_insert.setObject(4, embeddingsVector);
+                    assertEquals(1, statement_insert.executeUpdate());
+
+                    vector_search.setObject(1, embeddingsVector);
+                    try (ResultSet rs = vector_search.executeQuery()) {
+                        assertTrue(rs.next());
+                        String text = rs.getString(1);
+                        assertEquals("Lorem ipsum", text);
+                    }
+
+                    List<Float>  embeddingVectorAsListOfFloat = Arrays.asList(1f, 2f, 3f, 4f, 5f);
+                    vector_search.setObject(1, embeddingVectorAsListOfFloat);
+                    try (ResultSet rs = vector_search.executeQuery()) {
+                        assertTrue(rs.next());
+                        String text = rs.getString(1);
+                        assertEquals("Lorem ipsum", text);
+                    }
+
+                    List<Double>  embeddingVectorAsListOfDouble = Arrays.asList(1d, 2d, 3d, 4d, 5d);
+                    vector_search.setObject(1, embeddingVectorAsListOfDouble);
+                    try (ResultSet rs = vector_search.executeQuery()) {
+                        assertTrue(rs.next());
+                        String text = rs.getString(1);
+                        assertEquals("Lorem ipsum", text);
+                    }
+
+                }
+            }
+        }
+
+    }
+
+}

--- a/herddb-utils/src/main/java/herddb/proto/PduCodec.java
+++ b/herddb-utils/src/main/java/herddb/proto/PduCodec.java
@@ -84,6 +84,8 @@ public abstract class PduCodec {
     public static final byte TYPE_SHORT = 8;
     public static final byte TYPE_BYTE = 9;
 
+    public static final byte TYPE_FLOATARRAY = 10;
+
     public abstract static class ExecuteStatementsResult {
 
         public static ByteBuf write(long replyId, List<Long> updateCounts, List<Map<String, Object>> otherdata, long tx) {
@@ -1879,6 +1881,12 @@ public abstract class PduCodec {
         } else if (v instanceof Byte) {
             byteBuf.writeByte(TYPE_BYTE);
             byteBuf.writeByte((Byte) v);
+        } else if (v instanceof float[]) {
+            byteBuf.writeByte(TYPE_FLOATARRAY);
+            ByteBufUtils.writeFloatArray(byteBuf, (float[]) v);
+        } else if (v instanceof List) {
+            byteBuf.writeByte(TYPE_FLOATARRAY);
+            ByteBufUtils.writeFloatArray(byteBuf, (List<Number>) v);
         } else {
             throw new IllegalArgumentException("bad data type " + v.getClass());
         }
@@ -1892,6 +1900,8 @@ public abstract class PduCodec {
         switch (type) {
             case TYPE_BYTEARRAY:
                 return ByteBufUtils.readArray(dii);
+            case TYPE_FLOATARRAY:
+                return ByteBufUtils.readFloatArray(dii);
             case TYPE_LONG:
                 return dii.readLong();
             case TYPE_INTEGER:

--- a/herddb-utils/src/main/java/herddb/utils/ByteArrayCursor.java
+++ b/herddb-utils/src/main/java/herddb/utils/ByteArrayCursor.java
@@ -238,6 +238,7 @@ public class ByteArrayCursor implements Closeable {
     }
 
     private static final byte[] EMPTY_ARRAY = new byte[0];
+    private static final float[] EMPTY_FLOAT_ARRAY = new float[0];
 
     public int readArrayLen() throws IOException {
         return readVInt();
@@ -273,7 +274,15 @@ public class ByteArrayCursor implements Closeable {
             throw new EOFException();
         }
         return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
+    }
 
+    public float readFloat() throws IOException {
+        int asInt = readInt();
+        return Float.intBitsToFloat(asInt);
+    }
+
+    public void skipFloat() throws IOException {
+        skipInt();
     }
 
     public long readLong() throws IOException {
@@ -314,6 +323,21 @@ public class ByteArrayCursor implements Closeable {
         return res;
     }
 
+    public float[] readFloatArray() throws IOException {
+        int len = readVInt();
+        if (len == 0) {
+            return EMPTY_FLOAT_ARRAY;
+        } else if (len == -1) {
+            /* NULL array */
+            return null;
+        }
+        float[] result = new float[len];
+        for (int i = 0; i < len; i++) {
+            result[i] = readFloat();
+        }
+        return result;
+    }
+
     public Bytes readBytesNoCopy() throws IOException {
         int len = readVInt();
         if (len == 0) {
@@ -352,6 +376,15 @@ public class ByteArrayCursor implements Closeable {
             return;
         }
         skip(len);
+    }
+
+    @SuppressFBWarnings(value = "SR_NOT_CHECKED")
+    public void skipFloatArray() throws IOException {
+        int len = readVInt();
+        if (len <= 0) {
+            return;
+        }
+        skip(len * 4);
     }
 
     @SuppressFBWarnings(value = "SR_NOT_CHECKED")

--- a/herddb-utils/src/main/java/herddb/utils/ByteBufUtils.java
+++ b/herddb-utils/src/main/java/herddb/utils/ByteBufUtils.java
@@ -22,6 +22,7 @@ package herddb.utils;
 
 import io.netty.buffer.ByteBuf;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 /**
  * Utilities for write variable length values on {@link ByteBuf}.
@@ -33,6 +34,20 @@ public class ByteBufUtils {
     public static void writeArray(ByteBuf buffer, byte[] array) {
         writeVInt(buffer, array.length);
         buffer.writeBytes(array);
+    }
+
+    public static void writeFloatArray(ByteBuf buffer, float[] array) {
+        writeVInt(buffer, array.length);
+        for (float f : array) {
+            buffer.writeFloat(f);
+        }
+    }
+
+    public static void writeFloatArray(ByteBuf buffer, List<Number> array) {
+        writeVInt(buffer, array.size());
+        for (Number f : array) {
+            buffer.writeFloat(f.floatValue());
+        }
     }
 
     public static void writeArray(ByteBuf buffer, Bytes array) {
@@ -57,6 +72,15 @@ public class ByteBufUtils {
         final int len = readVInt(buffer);
         final byte[] array = new byte[len];
         buffer.readBytes(array);
+        return array;
+    }
+
+    public static float[] readFloatArray(ByteBuf buffer) {
+        final int len = readVInt(buffer);
+        final float[] array = new float[len];
+        for (int i = 0; i < len; i++) {
+            array[i] = buffer.readFloat();
+        }
         return array;
     }
 

--- a/herddb-utils/src/main/java/herddb/utils/Bytes.java
+++ b/herddb-utils/src/main/java/herddb/utils/Bytes.java
@@ -22,6 +22,7 @@ package herddb.utils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.util.internal.PlatformDependent;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
@@ -140,6 +141,32 @@ public final class Bytes implements Comparable<Bytes>, SizeAwareObject {
             System.arraycopy(buffer, offset, copy, 0, length);
             return copy;
         }
+    }
+
+    public float[] to_float_array() {
+        return to_float_array(buffer, offset, length);
+    }
+
+    public static float[] to_float_array(byte[] buffer, int offset, int length) {
+        if (length % 4 != 0) {
+            throw new IllegalArgumentException("Invalid byte array length");
+        }
+        int floatCount = length / 4;
+        ByteBuffer wrappedBuffer = ByteBuffer.wrap(buffer, offset, length);
+        float[] result = new float[floatCount];
+        for (int i = 0; i < floatCount; i++) {
+            result[i] = wrappedBuffer.getFloat();
+        }
+        return result;
+    }
+
+    public static Bytes from_float_array(float[] floatArray) {
+        int length = floatArray.length;
+        ByteBuffer buffer = ByteBuffer.allocate(length * 4); // Each float is 4 bytes
+        for (float f : floatArray) {
+            buffer.putFloat(f);
+        }
+        return new Bytes(buffer.array());
     }
 
     public static Bytes from_int(int value) {

--- a/herddb-utils/src/main/java/herddb/utils/ExtendedDataOutputStream.java
+++ b/herddb-utils/src/main/java/herddb/utils/ExtendedDataOutputStream.java
@@ -113,6 +113,10 @@ public final class ExtendedDataOutputStream extends DataOutputStream {
         writeVInt(-1);
     }
 
+    public void writeNullFloatArray() throws IOException {
+        writeVInt(-1);
+    }
+
     public void writeArray(byte[] data) throws IOException {
         if (data == null) {
             writeNullArray();
@@ -121,6 +125,18 @@ public final class ExtendedDataOutputStream extends DataOutputStream {
             write(data);
         }
     }
+    public void writeFloatArray(float[] data) throws IOException {
+        if (data == null) {
+            writeNullFloatArray();
+        } else {
+            writeVInt(data.length);
+            for (float f : data) {
+                writeFloat(f);
+            }
+        }
+    }
+
+
 
     public void writeArray(byte[] data, int offset, int len) throws IOException {
         writeVInt(len);

--- a/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
+++ b/herddb-utils/src/main/java/herddb/utils/SQLRecordPredicateFunctions.java
@@ -135,8 +135,25 @@ public interface SQLRecordPredicateFunctions {
         if (a instanceof byte[] && b instanceof byte[]) {
             return CompareResult.fromInt(Bytes.compare((byte[]) a, (byte[]) b));
         }
+        if (a instanceof float[] && b instanceof float[]) {
+            return CompareResult.fromInt(compareFloatArrays((float[]) a, (float[]) b));
+        }
         throw new IllegalArgumentException(
                 "uncomparable objects " + a.getClass() + " ('" + a + "') vs " + b.getClass() + " ('" + b + "')");
+    }
+
+    static int compareFloatArrays(float[] arr1, float[] arr2) {
+        int minLength = Math.min(arr1.length, arr2.length);
+
+        for (int i = 0; i < minLength; i++) {
+            int comparison = Float.compare(arr1[i], arr2[i]);
+            if (comparison != 0) {
+                return comparison; // Return the result if elements are not equal
+            }
+        }
+
+        // If the common elements are equal, check the lengths of the arrays
+        return Integer.compare(arr1.length, arr2.length);
     }
 
     /**


### PR DESCRIPTION
Motivation:

In Generative AI Application having the ability to deal with vectors (of float) is fundamental in order to implement the RAG patten.

While HerdDB is not meant to be a Vector database, it is still true the one of the HerdDB goals is to be a small footprint embeddable database, very useful for testing and for small applications.

Contents of the patch:
- This patch introduces end to end support for the "Float array" data type, both in the core (server side) and in the JDBC Driver 
- We are adding 3 basic scalar functions to compare vectors of floats: cosine_similarity, dot_product and euclidean_distance

In order to support the RAG pattern you only need 2 features:
- inserting records with a vector field
- retrieve the records ordering using some "distance" function


This patch doesn't add any special index, it is really out of the scope of HerdDB, but with this key features it is pretty easy to build a small vector database to index thousands of documents and support chat bots.



Sample table:

```sql
CREATE TABLE DOCUMENTS (
            FILENAME string
            CHUNKID int, "
            TEXT string, "
             EMBEDDINGSVECTOR floata,
             PRIMARY KEY(filename, chinkid)
)
```

Sample Vector Search query

```sql
SELECT text
FROM DOCUMENTS
ORDER BY cosine_similarity(embeddingsvector,cast(? as FLOAT ARRAY)) DESC
LIMIT 10
```