### PR TITLE
Fix ignored index memory configuration

### DIFF
--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -282,7 +282,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                 ServerConfiguration.PROPERTY_MAX_INDEX_MEMORY_PERCENTAGE_DEFAULT);
 
         if (maxIndexUsedMemoryPercentage <= 0.0D) {
-            maxIndexUsedMemoryPercentage = ServerConfiguration.PROPERTY_MAX_DATA_MEMORY_PERCENTAGE_DEFAULT;
+            maxIndexUsedMemoryPercentage = ServerConfiguration.PROPERTY_MAX_INDEX_MEMORY_PERCENTAGE_DEFAULT;
         }
 
         this.maxPKUsedMemoryPercentage = configuration.getDouble(

--- a/herddb-core/src/main/java/herddb/core/DBManager.java
+++ b/herddb-core/src/main/java/herddb/core/DBManager.java
@@ -471,7 +471,7 @@ public class DBManager implements AutoCloseable, MetadataChangeListener {
                     / ((double) (maxDataUsedMemory + maxIndexUsedMemory + maxPKUsedMemory)) * maxMemoryReference);
 
             maxDataUsedMemory = data;
-            maxIndexUsedMemory = data;
+            maxIndexUsedMemory = index;
             maxPKUsedMemory = pk;
         }
 

--- a/herddb-core/src/main/java/herddb/core/TableManager.java
+++ b/herddb-core/src/main/java/herddb/core/TableManager.java
@@ -902,7 +902,7 @@ public final class TableManager implements AbstractTableManager, Page.Owner {
             /*
              * NewPages removal technically could be done before current write lock but
              * doing it in lock permit to check safely if a page has been removed. Without
-             * lock we can't known if no page has been removed because already removed by a
+             * lock we can't know if no page has been removed because already removed by a
              * concurrent thread or because it wasn't present in the first place.
              */
             /* Set the new page as a fully active page */

--- a/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
+++ b/herddb-core/src/test/java/herddb/cluster/follower/ChangeRoleTest.java
@@ -51,14 +51,15 @@ public class ChangeRoleTest extends MultiServerBase {
 
     @Test
     public void testChangeRoleAndReleaseMemory() throws Exception {
-        ServerConfiguration serverconfig_1 = newServerConfigurationWithAutoPort(folder.newFolder().toPath());
-        serverconfig_1.set(ServerConfiguration.PROPERTY_NODEID, "server1");
-        serverconfig_1.set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER);
-        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress());
-        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath());
-        serverconfig_1.set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout());
-        serverconfig_1.set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false);
-        serverconfig_1.set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0); // disabled
+        ServerConfiguration serverconfig_1 = newServerConfigurationWithAutoPort(folder.newFolder().toPath())
+                .set(ServerConfiguration.PROPERTY_NODEID, "server1")
+                .set(ServerConfiguration.PROPERTY_MODE, ServerConfiguration.PROPERTY_MODE_CLUSTER)
+                .set(ServerConfiguration.PROPERTY_ZOOKEEPER_ADDRESS, testEnv.getAddress())
+                .set(ServerConfiguration.PROPERTY_ZOOKEEPER_PATH, testEnv.getPath())
+                .set(ServerConfiguration.PROPERTY_ZOOKEEPER_SESSIONTIMEOUT, testEnv.getTimeout())
+                .set(ServerConfiguration.PROPERTY_ENFORCE_LEADERSHIP, false)
+                .set(ServerConfiguration.PROPERTY_BOOKKEEPER_MAX_IDLE_TIME, 0) // disabled
+                .set(ServerConfiguration.PROPERTY_MAX_INDEX_MEMORY_PERCENTAGE, 0.2);
 
         ServerConfiguration serverconfig_2 = serverconfig_1
                 .copy()

--- a/herddb-core/src/test/java/herddb/core/BigTableScanTest.java
+++ b/herddb-core/src/test/java/herddb/core/BigTableScanTest.java
@@ -21,6 +21,7 @@
 package herddb.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import herddb.codec.RecordSerializer;
 import herddb.core.stats.TableManagerStats;
 import herddb.mem.MemoryCommitLogManager;
@@ -80,7 +81,8 @@ public class BigTableScanTest {
 
             TableManagerStats stats = manager.getTableSpaceManager(table.tablespace).getTableManager(table.name).getStats();
             assertEquals(testSize, stats.getTablesize());
-            assertEquals(2, stats.getLoadedpages());
+            // More than a page loaded
+            assertTrue(stats.getLoadedpages() >= 2);
 
             manager.checkpoint();
 


### PR DESCRIPTION
Fixes index memory configuration introduced in #755 up untill now instead of use configured index memory the server used a copy of data memory configuration (doubling used memory!)