### PR TITLE
BRIN fix load/unload with locks, fixes #820

### DIFF
--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -334,7 +334,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                     /*
                      * If this block has been detached it means that current block has been merged by another
                      * thread before beeing able to lock the block.
-                     * The should be now in the preceeding node and this shouldn't be used anymore.
+                     * It should be now in the preceeding node and this shouldn't be used anymore.
                      * Normally we scan the index using the next block reference and we cannot backtrack to previous
                      * nodes so we need to start another search on the index itself to look for the current data node
                      */
@@ -397,7 +397,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                     /*
                      * If this block has been detached it means that current block has been merged by another
                      * thread before beeing able to lock the block.
-                     * The should be now in the preceeding node and this shouldn't be used anymore.
+                     * It should be now in the preceeding node and this shouldn't be used anymore.
                      * Normally we scan the index using the next block reference and we cannot backtrack to previous
                      * nodes so we need to start another search on the index itself to look for the current data node
                      */
@@ -805,7 +805,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
         @Override
         public String toString() {
-            return System.identityHashCode(this) + "Block{" + "key=" + key + ", minKey=" + key.minKey
+            return "Block{" + "key=" + key + ", minKey=" + key.minKey
                    + ", size=" + size + ", next=" + (next == null ? null : next.key) + ", pageId=" + pageId
                    + ", loaded=" + loaded + ", dirty=" + dirty + ", detached=" + detached + "}";
         }
@@ -829,11 +829,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             return first.checkpoint();
         }
 
-
-        /*
-         * Data is provided in reverse order (smaller block is last) so we must iterate
-         * in reverse order (to preserve "next" relationship)
-         */
         final ListIterator<Block<K, V>> iterator = merging.listIterator();
 
         Page.Metadata unload = null;
@@ -871,7 +866,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                          * but we need to restore original list data from first value (due to overwrite)
                          */
                         if (potentialOverwrite != null) {
-                            /* Restore overwiritten data */
+                            /* Restore overwritten data */
                             first.values.merge(other.key.minKey, potentialOverwrite,
                                     (l1, l2) -> {
                                         l1.addAll(l2);

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -20,6 +20,7 @@
 
 package herddb.index.brin;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import herddb.core.Page;
 import herddb.core.Page.Metadata;
 import herddb.core.PageReplacementPolicy;
@@ -963,6 +964,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
         mergeReferences.clear();
     }
 
+    @SuppressFBWarnings("UL_UNRELEASED_LOCK", "false positive, locks are released in this method or in mergeAndUnlock")
     public BlockRangeIndexMetadata<K> checkpoint() throws IOException {
         final boolean fineEnabled = LOG.isLoggable(Level.FINE);
 
@@ -1000,6 +1002,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                          * MergeReferences could be empty if current block is the first too small and previous
                          * blocks were too big to be merged to.
                          */
+                        // Locks release
                         mergeAndUnlock(mergeTarget, mergeReferences, blocksMetadata);
 
                         // Set next merge target
@@ -1024,6 +1027,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                 if (mergeTarget != null) {
 
                     // Handles current merge stream process
+                    // Locks release
                     mergeAndUnlock(mergeTarget, mergeReferences, blocksMetadata);
 
                     // Set next merge target (current block is too big to be merged)
@@ -1038,6 +1042,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
                 try {
                     blocksMetadata.add(block.checkpoint());
                 } finally {
+                    // Lock release
                     block.lock.unlock();
                 }
             }
@@ -1045,6 +1050,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
         // We need to handle any remaining merges if exists
         if (mergeTarget != null) {
+            // Locks release
             mergeAndUnlock(mergeTarget, mergeReferences, blocksMetadata);
         }
 

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -964,7 +964,8 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
         mergeReferences.clear();
     }
 
-    @SuppressFBWarnings("UL_UNRELEASED_LOCK", "false positive, locks are released in this method or in mergeAndUnlock")
+    @SuppressFBWarnings(value = "UL_UNRELEASED_LOCK",
+            justification = "false positive, locks are released in this method or in mergeAndUnlock")
     public BlockRangeIndexMetadata<K> checkpoint() throws IOException {
         final boolean fineEnabled = LOG.isLoggable(Level.FINE);
 

--- a/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
+++ b/herddb-core/src/main/java/herddb/index/brin/BlockRangeIndex.java
@@ -834,7 +834,7 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
          * Data is provided in reverse order (smaller block is last) so we must iterate
          * in reverse order (to preserve "next" relationship)
          */
-        final ListIterator<Block<K, V>> iterator = merging.listIterator(merging.size());
+        final ListIterator<Block<K, V>> iterator = merging.listIterator();
 
         Page.Metadata unload = null;
         List<Page.Metadata> unloads = new ArrayList<>();
@@ -846,9 +846,9 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             /* We need block data to attempt merge */
             unload = first.ensureBlockLoadedWithoutUnload();
 
-            while (iterator.hasPrevious()) {
+            while (iterator.hasNext()) {
 
-                Block<K, V> other = iterator.previous();
+                Block<K, V> other = iterator.next();
 
                 other.lock.lock();
                 try {
@@ -971,7 +971,6 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
 
         List<BlockRangeIndexMetadata.BlockMetadata<K>> blocksMetadata = new ArrayList<>();
 
-        /* Reverse ordering! */
         Iterator<Block<K, V>> iterator = blocks.values().iterator();
 
         long mergeSize = 0;
@@ -1055,6 +1054,8 @@ public final class BlockRangeIndex<K extends Comparable<K> & SizeAwareObject, V 
             mergeAndUnlock(mergeTarget, mergeReferences, blocksMetadata);
         }
 
+        // Historically blocks are stored in reverse order to be able to recover the index in a simpler way
+        Collections.reverse(blocksMetadata);
         return new BlockRangeIndexMetadata<>(blocksMetadata);
 
     }

--- a/herddb-core/src/main/java/herddb/index/brin/MemoryIndexDataStorage.java
+++ b/herddb-core/src/main/java/herddb/index/brin/MemoryIndexDataStorage.java
@@ -21,11 +21,13 @@
 package herddb.index.brin;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
 
 /**
  * Simple in-memory index data storage manager
@@ -34,6 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class MemoryIndexDataStorage<K, V> implements IndexDataStorage<K, V> {
 
+    private static final Logger LOG = Logger.getLogger(MemoryIndexDataStorage.class.getName());
     AtomicLong newPageId = new AtomicLong();
 
     private final ConcurrentHashMap<Long, List<Map.Entry<K, V>>> pages = new ConcurrentHashMap<>();
@@ -44,13 +47,14 @@ public class MemoryIndexDataStorage<K, V> implements IndexDataStorage<K, V> {
         if (page == null) {
             throw new IOException("Unknown pageId " + pageId);
         }
-        return page;
+        return new ArrayList<>(page);
     }
 
     @Override
     public long createDataPage(List<Map.Entry<K, V>> values) throws IOException {
         long newid = newPageId.incrementAndGet();
-        pages.put(newid, values);
+        List<Map.Entry<K, V>> copy = new ArrayList<>(values);
+        pages.put(newid, copy);
         return newid;
     }
 

--- a/herddb-core/src/main/java/herddb/index/brin/MemoryIndexDataStorage.java
+++ b/herddb-core/src/main/java/herddb/index/brin/MemoryIndexDataStorage.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Logger;
 
 /**
  * Simple in-memory index data storage manager
@@ -35,8 +34,6 @@ import java.util.logging.Logger;
  * @author enrico.olivelli
  */
 public class MemoryIndexDataStorage<K, V> implements IndexDataStorage<K, V> {
-
-    private static final Logger LOG = Logger.getLogger(MemoryIndexDataStorage.class.getName());
     AtomicLong newPageId = new AtomicLong();
 
     private final ConcurrentHashMap<Long, List<Map.Entry<K, V>>> pages = new ConcurrentHashMap<>();

--- a/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexConcurrentTest.java
+++ b/herddb-core/src/test/java/herddb/index/brin/BlockRangeIndexConcurrentTest.java
@@ -20,14 +20,18 @@
 
 package herddb.index.brin;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import herddb.core.ClockProPolicy;
+import herddb.core.PageReplacementPolicy;
 import herddb.core.RandomPageReplacementPolicy;
 import herddb.index.brin.BlockRangeIndex.Block;
 import herddb.utils.SizeAwareObject;
 import herddb.utils.Sized;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -35,6 +39,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 /**
@@ -228,30 +234,195 @@ public class BlockRangeIndexConcurrentTest {
             throw e;
         }
 
+    }
+
+    @Test
+    public void testConcurrentReadsWritesDeletesWithSplitsOnTwoIndexes() throws Exception {
+
+        int testSize = 10000;
+        int parallelism = 10;
+
+        PageReplacementPolicy policy = new ClockProPolicy(3);
+        BlockRangeIndex<Sized<Integer>, Sized<String>> checkpointIndex =
+                new BlockRangeIndex<>(1024, policy);
+        BlockRangeIndex<Sized<Integer>, Sized<String>> otherIndex =
+                new BlockRangeIndex<>(1024, policy);
+        checkpointIndex.boot(BlockRangeIndexMetadata.empty());
+        otherIndex.boot(BlockRangeIndexMetadata.empty());
+
+        int cpreload = 0;
+        int opreload = 0;
+        while (checkpointIndex.getNumBlocks() < 2) {
+            checkpointIndex.put(Sized.valueOf(1), sizedWithPadding("c", 5, cpreload++));
+        }
+        final int fincpreload = cpreload;
+        while (otherIndex.getNumBlocks() < 2) {
+            otherIndex.put(Sized.valueOf(1), sizedWithPadding("a", 5, opreload++));
+        }
+
+        try {
+
+            ExecutorService threadpool = Executors.newFixedThreadPool(parallelism);
+            Future<Void> checkpointingJob;
+            List<Future<?>> jobs = new ArrayList<>(testSize);
+
+            AtomicBoolean stopCheckpointingThread = new AtomicBoolean(false);
+
+            try {
+                checkpointingJob = threadpool.submit((Callable<Void>) () -> {
+                    int i = fincpreload;
+                    while (stopCheckpointingThread.get()) {
+                        ++i;
+                        if (i % 10 == 0) {
+                            checkpointIndex.checkpoint();
+                        }
+
+                        Sized<Integer> key = Sized.valueOf(1);
+                        Sized<String> value = sizedWithPadding("c", 5, i);
+                        checkpointIndex.put(key, value);
+                        List<Sized<String>> search = checkpointIndex.search(key);
+                        if (search.isEmpty()) {
+                            throw new IllegalStateException("Empty Search! Checkpointing index i " + 1);
+                        }
+                        checkpointIndex.delete(key, value);
+                    }
+
+                    return null;
+                });
+
+                for (int test = opreload; test < testSize + opreload; test++) {
+                    int i = test;
+                    jobs.add(threadpool.submit((Callable<Void>) () -> {
+                        Sized<Integer> key = Sized.valueOf(1);
+                        Sized<String> value = sizedWithPadding("a", 5, i);
+                        List<Sized<String>> search = otherIndex.search(key);
+                        if (search.isEmpty()) {
+                            throw new IllegalStateException("Empty Search! i " + 1);
+                        }
+                        otherIndex.delete(key, value);
+                        List<Sized<String>> research = otherIndex.search(key);
+                        if (!research.isEmpty()) {
+                            if (research.contains(value)) {
+                                throw new IllegalStateException("Value not deleted! i " + 1 + " k " + key + " v " + value);
+                            }
+                        }
+
+                        if (i % 10 == 0) {
+                            otherIndex.checkpoint();
+                        }
+                        return null;
+                    }));
+                }
+            } finally {
+                threadpool.shutdown();
+            }
+
+
+            System.out.println("Waiting running jobs");
+            int n = 0;
+            for (Future<?> job : jobs) {
+                /* Job exception rethrow */
+                try {
+                    job.get(25, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    if (e instanceof TimeoutException) {
+                        System.out.println("Probable deadlock condition detected");
+                    }
+                    System.out.println("Running job " + n + " returned in error, terminating all jobs");
+                    for (Future<?> termination : jobs) {
+                        termination.cancel(true);
+                    }
+                    stopCheckpointingThread.set(true);
+                    checkpointingJob.cancel(true);
+                    throw e;
+                }
+            }
+
+            stopCheckpointingThread.set(true);
+            /* Job exception rethrow */
+            try {
+                checkpointingJob.get(10, TimeUnit.SECONDS);
+                System.out.println("Checkpointing job terminated");
+            } catch (ExecutionException e) {
+                throw (Exception) e.getCause();
+            }
+
+            deepDumpIndex(otherIndex);
+            System.out.println("Checkpointing indexes");
+            checkpointIndex.checkpoint();
+            otherIndex.checkpoint();
+
+            List<Sized<String>> otherContent = otherIndex.search(Sized.valueOf(1));
+            assertEquals(otherContent.size(), opreload);
+
+            System.out.println("Dumping indexes");
+            System.out.println("Dumping checkpointIndex");
+            deepDumpIndex(checkpointIndex);
+            System.out.println("Dumping otherIndex");
+            deepDumpIndex(otherIndex);
+
+            System.out.println("Verifying indexes");
+            System.out.println("Verifying checkpointIndex");
+            verifyIndex(checkpointIndex);
+            System.out.println("Verifying otherIndex");
+            verifyIndex(otherIndex);
+
+        } catch (Exception | AssertionError e) {
+            deepDumpIndex(checkpointIndex);
+            deepDumpIndex(otherIndex);
+            throw e;
+        }
 
     }
 
+    private Sized<String> sizedWithPadding(String prefix, int places, int value) {
+        StringBuilder builder = new StringBuilder(prefix);
+        String string = Integer.toString(value);
+        int valuelen = string.length();
+        int paddings = places - valuelen;
+        for (int i = 0; i < paddings; ++i) {
+            builder.append('0');
+        }
+        builder.append(string);
+        return Sized.valueOf(builder.toString());
+    }
 
     private <X extends Comparable<X> & SizeAwareObject> void dumpIndex(BlockRangeIndex<X, ?> index) {
-        for (Block<X, ?> b : index.getBlocks().values()) {
-            System.out.println("BLOCK " + b);
+        System.out.println("---DUMP INDEX-----------------------------");
+        for (Block<X, ?> block : index.getBlocks().values()) {
+            dumpBlock(block, false);
         }
+        System.out.println("------------------------------------------");
     }
 
     private <X extends Comparable<X> & SizeAwareObject> void deepDumpIndex(BlockRangeIndex<X, ?> index) {
-        for (Block<X, ?> block : index.getBlocks().values()) {
+        try {
+            System.out.println("---DEEP DUMP INDEX------------------------");
+            for (Block<X, ?> block : index.getBlocks().values()) {
+                System.out.println("---------------------");
+                dumpBlock(block, true);
+            }
             System.out.println("------------------------------------------");
-            System.out.println("BLOCK " + block);
-            System.out.println("------------------------------------------");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
-            /* Forcefully load the block to check internal data */
-            block.ensureBlockLoaded();
+    private <X extends Comparable<X> & SizeAwareObject> void dumpBlock(Block<X, ?> block, boolean deep) {
+        System.out.println("BLOCK " + block);
+        if (deep) {
+            /*
+             * Forcefully load the block to check internal data.
+             * Do not attempt to unload to avoid locking in deadlock situations
+             */
+            block.ensureBlockLoadedWithoutUnload();
 
             block.values.forEach((k, v) -> System.out.println(k + ": " + v));
         }
     }
 
     private void verifyIndex(BlockRangeIndex<Sized<Integer>, Sized<String>> index) {
+        System.out.println("check index");
         Integer lastmax = null;
         for (Block<Sized<Integer>, Sized<String>> b : index.getBlocks().values()) {
             if (b.key == BlockRangeIndex.BlockStartKey.HEAD_KEY) {
@@ -261,15 +432,13 @@ public class BlockRangeIndexConcurrentTest {
             }
 
             /* Forcefully load the block to check internal data */
-            b.ensureBlockLoaded();
-
-            if (b.values.isEmpty() && index.getBlocks().size() != 1 && b.key != BlockRangeIndex.BlockStartKey.HEAD_KEY) {
-                fail("non head of degenerate tree empty block");
-            }
+            b.ensureBlockLoadedWithoutUnload();
 
             if (b.values.isEmpty()) {
                 if (index.getBlocks().size() != 1 && b.key != BlockRangeIndex.BlockStartKey.HEAD_KEY) {
-                    fail("non head of degenerate tree empty block");
+                    System.out.println("non head of degenerate tree empty block: " + b);
+                    dumpBlock(b, true);
+                    fail("non head of degenerate tree empty block " + b);
                 }
             } else {
                 if (lastmax == null) {


### PR DESCRIPTION
This PR fixes #820 
Changes load/unload BRIN pages deferring unload until the unlock of currently handled BRIN block, doing so we don't keep current block locked until other block has been fully unload (that needs a lock too).
Changed block loading during blocks merge too: now we don't load in the page memory blocks that aren't needed anymore because the will deleted at merge end.
The neat result is that there is one more page in thread memory that will discarded/cleaned at the end.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Rember to add the correct license header to new files.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
